### PR TITLE
feat: implement UC-7 find senior design teams

### DIFF
--- a/src/backend/pom.xml
+++ b/src/backend/pom.xml
@@ -120,6 +120,11 @@
         <!-- Test -->
         <dependency>
             <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-webmvc-test</artifactId>
             <scope>test</scope>
         </dependency>
@@ -131,6 +136,11 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-security-oauth2-resource-server-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-test</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/backend/src/main/java/team/projectpulse/config/SecurityConfig.java
+++ b/src/backend/src/main/java/team/projectpulse/config/SecurityConfig.java
@@ -8,6 +8,7 @@ import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.AuthenticationProvider;
 import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -25,6 +26,7 @@ import java.util.List;
 
 @Configuration
 @EnableWebSecurity
+@EnableMethodSecurity
 public class SecurityConfig {
 
     private final UserDetailsService userDetailsService;

--- a/src/backend/src/main/java/team/projectpulse/team/controller/TeamController.java
+++ b/src/backend/src/main/java/team/projectpulse/team/controller/TeamController.java
@@ -1,0 +1,34 @@
+package team.projectpulse.team.controller;
+
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import team.projectpulse.system.Result;
+import team.projectpulse.team.dto.TeamSummary;
+import team.projectpulse.team.service.TeamService;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("${api.endpoint.base-url}/teams")
+public class TeamController {
+
+    private final TeamService teamService;
+
+    public TeamController(TeamService teamService) {
+        this.teamService = teamService;
+    }
+
+    @GetMapping
+    @PreAuthorize("hasAnyRole('ADMIN', 'INSTRUCTOR')")
+    public Result<List<TeamSummary>> findTeams(
+        @RequestParam(required = false) Long sectionId,
+        @RequestParam(required = false) String sectionName,
+        @RequestParam(required = false) String teamName,
+        @RequestParam(required = false) String instructor
+    ) {
+        return Result.success(teamService.findTeams(sectionId, sectionName, teamName, instructor));
+    }
+}

--- a/src/backend/src/main/java/team/projectpulse/team/domain/Team.java
+++ b/src/backend/src/main/java/team/projectpulse/team/domain/Team.java
@@ -1,0 +1,68 @@
+package team.projectpulse.team.domain;
+
+import jakarta.persistence.*;
+import team.projectpulse.section.domain.Section;
+import team.projectpulse.user.domain.User;
+
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+@Entity
+@Table(name = "teams")
+public class Team {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "team_id")
+    private Long teamId;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "section_id", nullable = false)
+    private Section section;
+
+    @Column(name = "team_name", nullable = false, unique = true)
+    private String teamName;
+
+    @Column(name = "team_description")
+    private String teamDescription;
+
+    @Column(name = "team_website_url")
+    private String teamWebsiteUrl;
+
+    @ManyToMany
+    @JoinTable(
+        name = "team_students",
+        joinColumns = @JoinColumn(name = "team_id"),
+        inverseJoinColumns = @JoinColumn(name = "user_id")
+    )
+    private Set<User> students = new LinkedHashSet<>();
+
+    @ManyToMany
+    @JoinTable(
+        name = "team_instructors",
+        joinColumns = @JoinColumn(name = "team_id"),
+        inverseJoinColumns = @JoinColumn(name = "user_id")
+    )
+    private Set<User> instructors = new LinkedHashSet<>();
+
+    public Long getTeamId()                         { return teamId; }
+    public void setTeamId(Long v)                   { this.teamId = v; }
+
+    public Section getSection()                     { return section; }
+    public void setSection(Section v)               { this.section = v; }
+
+    public String getTeamName()                     { return teamName; }
+    public void setTeamName(String v)               { this.teamName = v; }
+
+    public String getTeamDescription()              { return teamDescription; }
+    public void setTeamDescription(String v)        { this.teamDescription = v; }
+
+    public String getTeamWebsiteUrl()               { return teamWebsiteUrl; }
+    public void setTeamWebsiteUrl(String v)         { this.teamWebsiteUrl = v; }
+
+    public Set<User> getStudents()                  { return students; }
+    public void setStudents(Set<User> v)            { this.students = v; }
+
+    public Set<User> getInstructors()               { return instructors; }
+    public void setInstructors(Set<User> v)         { this.instructors = v; }
+}

--- a/src/backend/src/main/java/team/projectpulse/team/dto/TeamSummary.java
+++ b/src/backend/src/main/java/team/projectpulse/team/dto/TeamSummary.java
@@ -1,0 +1,14 @@
+package team.projectpulse.team.dto;
+
+import java.util.List;
+
+public record TeamSummary(
+    Long teamId,
+    Long sectionId,
+    String sectionName,
+    String teamName,
+    String teamDescription,
+    String teamWebsiteUrl,
+    List<String> teamMemberNames,
+    List<String> instructorNames
+) {}

--- a/src/backend/src/main/java/team/projectpulse/team/repository/TeamRepository.java
+++ b/src/backend/src/main/java/team/projectpulse/team/repository/TeamRepository.java
@@ -1,0 +1,34 @@
+package team.projectpulse.team.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import team.projectpulse.team.domain.Team;
+
+import java.util.List;
+
+public interface TeamRepository extends JpaRepository<Team, Long> {
+
+    @Query("""
+        select distinct t from Team t
+        join fetch t.section s
+        left join fetch t.students st
+        left join fetch t.instructors i
+        where (:sectionId is null or s.sectionId = :sectionId)
+          and (:sectionName is null or lower(s.sectionName) like lower(concat('%', :sectionName, '%')))
+          and (:teamName is null or lower(t.teamName) like lower(concat('%', :teamName, '%')))
+          and (
+              :instructor is null
+              or lower(concat(coalesce(i.firstName, ''), ' ', coalesce(i.lastName, ''))) like lower(concat('%', :instructor, '%'))
+              or lower(coalesce(i.firstName, '')) like lower(concat('%', :instructor, '%'))
+              or lower(coalesce(i.lastName, '')) like lower(concat('%', :instructor, '%'))
+          )
+        order by s.sectionName desc, t.teamName asc
+        """)
+    List<Team> search(
+        @Param("sectionId") Long sectionId,
+        @Param("sectionName") String sectionName,
+        @Param("teamName") String teamName,
+        @Param("instructor") String instructor
+    );
+}

--- a/src/backend/src/main/java/team/projectpulse/team/service/TeamService.java
+++ b/src/backend/src/main/java/team/projectpulse/team/service/TeamService.java
@@ -1,0 +1,67 @@
+package team.projectpulse.team.service;
+
+import org.springframework.stereotype.Service;
+import team.projectpulse.team.domain.Team;
+import team.projectpulse.team.dto.TeamSummary;
+import team.projectpulse.team.repository.TeamRepository;
+import team.projectpulse.user.domain.User;
+
+import java.util.List;
+
+@Service
+public class TeamService {
+
+    private final TeamRepository teamRepository;
+
+    public TeamService(TeamRepository teamRepository) {
+        this.teamRepository = teamRepository;
+    }
+
+    public List<TeamSummary> findTeams(Long sectionId, String sectionName, String teamName, String instructor) {
+        List<Team> teams = teamRepository.search(
+            sectionId,
+            normalize(sectionName),
+            normalize(teamName),
+            normalize(instructor)
+        );
+
+        return teams.stream()
+            .map(this::toSummary)
+            .toList();
+    }
+
+    private TeamSummary toSummary(Team team) {
+        List<String> teamMemberNames = team.getStudents().stream()
+            .map(this::toDisplayName)
+            .sorted(String.CASE_INSENSITIVE_ORDER)
+            .toList();
+
+        List<String> instructorNames = team.getInstructors().stream()
+            .map(this::toDisplayName)
+            .sorted(String.CASE_INSENSITIVE_ORDER)
+            .toList();
+
+        return new TeamSummary(
+            team.getTeamId(),
+            team.getSection().getSectionId(),
+            team.getSection().getSectionName(),
+            team.getTeamName(),
+            team.getTeamDescription(),
+            team.getTeamWebsiteUrl(),
+            teamMemberNames,
+            instructorNames
+        );
+    }
+
+    private String toDisplayName(User user) {
+        return (user.getFirstName() + " " + user.getLastName()).trim();
+    }
+
+    private String normalize(String value) {
+        if (value == null) {
+            return null;
+        }
+        String trimmed = value.trim();
+        return trimmed.isEmpty() ? null : trimmed;
+    }
+}

--- a/src/backend/src/main/resources/db/migration/V4__teams.sql
+++ b/src/backend/src/main/resources/db/migration/V4__teams.sql
@@ -1,0 +1,79 @@
+-- V4: Teams, members, and instructors
+
+CREATE TABLE IF NOT EXISTS teams (
+    team_id            BIGINT AUTO_INCREMENT PRIMARY KEY,
+    section_id         BIGINT       NOT NULL,
+    team_name          VARCHAR(255) NOT NULL,
+    team_description   TEXT,
+    team_website_url   VARCHAR(500),
+    created_at         TIMESTAMP    DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT uk_teams_team_name UNIQUE (team_name),
+    CONSTRAINT fk_teams_section
+        FOREIGN KEY (section_id) REFERENCES sections(section_id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS team_students (
+    team_id  BIGINT NOT NULL,
+    user_id  BIGINT NOT NULL,
+    PRIMARY KEY (team_id, user_id),
+    CONSTRAINT fk_team_students_team
+        FOREIGN KEY (team_id) REFERENCES teams(team_id) ON DELETE CASCADE,
+    CONSTRAINT fk_team_students_user
+        FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS team_instructors (
+    team_id  BIGINT NOT NULL,
+    user_id  BIGINT NOT NULL,
+    PRIMARY KEY (team_id, user_id),
+    CONSTRAINT fk_team_instructors_team
+        FOREIGN KEY (team_id) REFERENCES teams(team_id) ON DELETE CASCADE,
+    CONSTRAINT fk_team_instructors_user
+        FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+);
+
+-- Seed users for local/dev team discovery and login.
+INSERT INTO users (id, first_name, last_name, email, password, roles, enabled)
+VALUES
+    (1001, 'Ivy',   'Stone',  'ivy.stone@tcu.edu',   '$2y$10$xsTQw5eM..haCE5neBk7AOEYqyvE65uyBlLZo.svoOKNKmrwfPLcG', 'instructor', TRUE),
+    (1002, 'Noah',  'Bennett','noah.bennett@tcu.edu','$2y$10$xsTQw5eM..haCE5neBk7AOEYqyvE65uyBlLZo.svoOKNKmrwfPLcG', 'instructor', TRUE),
+    (1003, 'Ava',   'Johnson','ava.johnson@tcu.edu', '$2y$10$xsTQw5eM..haCE5neBk7AOEYqyvE65uyBlLZo.svoOKNKmrwfPLcG', 'student', TRUE),
+    (1004, 'Liam',  'Parker', 'liam.parker@tcu.edu', '$2y$10$xsTQw5eM..haCE5neBk7AOEYqyvE65uyBlLZo.svoOKNKmrwfPLcG', 'student', TRUE),
+    (1005, 'Mia',   'Chen',   'mia.chen@tcu.edu',    '$2y$10$xsTQw5eM..haCE5neBk7AOEYqyvE65uyBlLZo.svoOKNKmrwfPLcG', 'student', TRUE),
+    (1006, 'Ethan', 'Wright', 'ethan.wright@tcu.edu','$2y$10$xsTQw5eM..haCE5neBk7AOEYqyvE65uyBlLZo.svoOKNKmrwfPLcG', 'student', TRUE)
+ON DUPLICATE KEY UPDATE
+    first_name = VALUES(first_name),
+    last_name = VALUES(last_name),
+    password = VALUES(password),
+    roles = VALUES(roles),
+    enabled = VALUES(enabled);
+
+INSERT INTO teams (team_id, section_id, team_name, team_description, team_website_url)
+VALUES
+    (2001, 1, 'Pulse Analytics', 'Analytics dashboard for tracking senior design team progress.', 'https://pulse-analytics.example.com'),
+    (2002, 1, 'Peer Review Tool', 'Platform for collecting and summarizing peer evaluation feedback.', 'https://peer-review-tool.example.com'),
+    (2003, 2, 'Requirements Hub', 'Centralized requirements workspace for senior design clients and teams.', 'https://requirements-hub.example.com')
+ON DUPLICATE KEY UPDATE
+    section_id = VALUES(section_id),
+    team_description = VALUES(team_description),
+    team_website_url = VALUES(team_website_url);
+
+INSERT INTO team_students (team_id, user_id)
+VALUES
+    (2001, 1003),
+    (2001, 1004),
+    (2002, 1005),
+    (2002, 1006),
+    (2003, 1003),
+    (2003, 1005)
+ON DUPLICATE KEY UPDATE
+    team_id = VALUES(team_id);
+
+INSERT INTO team_instructors (team_id, user_id)
+VALUES
+    (2001, 1001),
+    (2002, 1001),
+    (2002, 1002),
+    (2003, 1002)
+ON DUPLICATE KEY UPDATE
+    team_id = VALUES(team_id);

--- a/src/backend/src/test/java/team/projectpulse/team/controller/TeamControllerIntegrationTest.java
+++ b/src/backend/src/test/java/team/projectpulse/team/controller/TeamControllerIntegrationTest.java
@@ -1,0 +1,75 @@
+package team.projectpulse.team.controller;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import team.projectpulse.team.dto.TeamSummary;
+import team.projectpulse.team.service.TeamService;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class TeamControllerIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private TeamService teamService;
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void should_ReturnTeamsWrappedInResult_When_AdminRequestsTeams() throws Exception {
+        when(teamService.findTeams(null, null, "Pulse", null))
+            .thenReturn(List.of(new TeamSummary(1L, 1L, "Spring 2026 - Section A", "Pulse Analytics", "desc", "https://pulse.example.com", List.of("Ava Johnson"), List.of("Ivy Stone"))));
+
+        mockMvc.perform(get("/api/v1/teams").param("teamName", "Pulse"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.flag").value(true))
+            .andExpect(jsonPath("$.code").value(200))
+            .andExpect(jsonPath("$.data[0].teamName").value("Pulse Analytics"));
+
+        verify(teamService).findTeams(null, null, "Pulse", null);
+    }
+
+    @Test
+    @WithMockUser(roles = "INSTRUCTOR")
+    void should_AllowInstructor_When_RequestingTeams() throws Exception {
+        when(teamService.findTeams(null, "Spring", null, "Ivy")).thenReturn(List.of());
+
+        mockMvc.perform(get("/api/v1/teams")
+                .param("sectionName", "Spring")
+                .param("instructor", "Ivy"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.data").isArray());
+
+        verify(teamService).findTeams(null, "Spring", null, "Ivy");
+    }
+
+    @Test
+    @WithMockUser(roles = "STUDENT")
+    void should_ReturnForbidden_When_StudentRequestsTeams() throws Exception {
+        mockMvc.perform(get("/api/v1/teams"))
+            .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void should_ReturnUnauthorized_When_RequestIsUnauthenticated() throws Exception {
+        mockMvc.perform(get("/api/v1/teams"))
+            .andExpect(status().isUnauthorized());
+    }
+}

--- a/src/backend/src/test/java/team/projectpulse/team/repository/TeamRepositoryIntegrationTest.java
+++ b/src/backend/src/test/java/team/projectpulse/team/repository/TeamRepositoryIntegrationTest.java
@@ -1,0 +1,112 @@
+package team.projectpulse.team.repository;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import jakarta.persistence.EntityManager;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import org.springframework.test.context.ActiveProfiles;
+import team.projectpulse.section.domain.Section;
+import team.projectpulse.team.domain.Team;
+import team.projectpulse.user.domain.User;
+
+import java.time.LocalDate;
+import java.util.LinkedHashSet;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@DataJpaTest
+@ActiveProfiles("test")
+class TeamRepositoryIntegrationTest {
+
+    @Autowired
+    private EntityManager entityManager;
+
+    @Autowired
+    private TeamRepository teamRepository;
+
+    @Test
+    void should_ReturnTeamsSortedBySectionDescThenTeamAsc_When_NoFilters() {
+        SeededData data = seedTeams();
+
+        List<Team> teams = teamRepository.search(null, null, null, null);
+
+        assertEquals(List.of(data.teamAlpha, data.teamBravo, data.teamGamma),
+            teams.stream().map(Team::getTeamName).toList());
+    }
+
+    @Test
+    void should_FilterBySectionNameTeamNameAndInstructor_When_FiltersProvided() {
+        seedTeams();
+
+        List<Team> teams = teamRepository.search(null, "Spring 2026 - Section A", "pulse", "ivy");
+
+        assertEquals(List.of("Pulse Analytics"), teams.stream().map(Team::getTeamName).toList());
+    }
+
+    @Test
+    void should_ReturnEmptyList_When_NoTeamsMatchFilters() {
+        seedTeams();
+
+        List<Team> teams = teamRepository.search(null, null, "missing", null);
+
+        assertEquals(List.of(), teams);
+    }
+
+    private SeededData seedTeams() {
+        Section sectionA = new Section();
+        sectionA.setSectionName("Spring 2026 - Section A");
+        sectionA.setStartDate(LocalDate.of(2026, 1, 13));
+        sectionA.setEndDate(LocalDate.of(2026, 5, 10));
+        sectionA.setActive(true);
+        entityManager.persist(sectionA);
+
+        Section sectionB = new Section();
+        sectionB.setSectionName("Fall 2025 - Section B");
+        sectionB.setStartDate(LocalDate.of(2025, 8, 25));
+        sectionB.setEndDate(LocalDate.of(2025, 12, 15));
+        sectionB.setActive(true);
+        entityManager.persist(sectionB);
+
+        User ivy = persistUser("Ivy", "Stone", "ivy.repo@tcu.edu", "instructor");
+        User noah = persistUser("Noah", "Bennett", "noah.repo@tcu.edu", "instructor");
+        User ava = persistUser("Ava", "Johnson", "ava.repo@tcu.edu", "student");
+        User liam = persistUser("Liam", "Parker", "liam.repo@tcu.edu", "student");
+        User mia = persistUser("Mia", "Chen", "mia.repo@tcu.edu", "student");
+
+        Team pulse = persistTeam(sectionA, "Pulse Analytics", ivy, List.of(ava, liam));
+        Team review = persistTeam(sectionA, "Review Board", noah, List.of(mia));
+        Team gamma = persistTeam(sectionB, "Gamma Studio", noah, List.of(ava, mia));
+
+        entityManager.flush();
+        entityManager.clear();
+
+        return new SeededData("Review Board", "Pulse Analytics", "Gamma Studio");
+    }
+
+    private User persistUser(String firstName, String lastName, String email, String roles) {
+        User user = new User();
+        user.setFirstName(firstName);
+        user.setLastName(lastName);
+        user.setEmail(email);
+        user.setPassword("encoded");
+        user.setRoles(roles);
+        user.setEnabled(true);
+        entityManager.persist(user);
+        return user;
+    }
+
+    private Team persistTeam(Section section, String teamName, User instructor, List<User> students) {
+        Team team = new Team();
+        team.setSection(section);
+        team.setTeamName(teamName);
+        team.setTeamDescription(teamName + " description");
+        team.setTeamWebsiteUrl("https://" + teamName.toLowerCase().replace(" ", "-") + ".example.com");
+        team.setInstructors(new LinkedHashSet<>(List.of(instructor)));
+        team.setStudents(new LinkedHashSet<>(students));
+        entityManager.persist(team);
+        return team;
+    }
+
+    private record SeededData(String teamBravo, String teamAlpha, String teamGamma) {}
+}

--- a/src/backend/src/test/java/team/projectpulse/team/service/TeamServiceTest.java
+++ b/src/backend/src/test/java/team/projectpulse/team/service/TeamServiceTest.java
@@ -1,0 +1,102 @@
+package team.projectpulse.team.service;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import team.projectpulse.section.domain.Section;
+import team.projectpulse.team.domain.Team;
+import team.projectpulse.team.dto.TeamSummary;
+import team.projectpulse.team.repository.TeamRepository;
+import team.projectpulse.user.domain.User;
+
+import java.util.LinkedHashSet;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class TeamServiceTest {
+
+    @Mock
+    private TeamRepository teamRepository;
+
+    @InjectMocks
+    private TeamService teamService;
+
+    @Test
+    void should_NormalizeBlankFiltersAndMapSortedSummary_When_SearchingTeams() {
+        Team team = buildTeam();
+        when(teamRepository.search(5L, null, "Pulse", null)).thenReturn(List.of(team));
+
+        List<TeamSummary> results = teamService.findTeams(5L, "   ", " Pulse ", "");
+
+        assertEquals(1, results.size());
+        TeamSummary summary = results.getFirst();
+        assertEquals(10L, summary.teamId());
+        assertEquals(2L, summary.sectionId());
+        assertEquals("Spring 2026 - Section A", summary.sectionName());
+        assertEquals("Pulse Analytics", summary.teamName());
+        assertEquals(List.of("Amy Adams", "Zoe Zeta"), summary.teamMemberNames());
+        assertEquals(List.of("Ivy Stone", "Noah Bennett"), summary.instructorNames());
+        verify(teamRepository).search(5L, null, "Pulse", null);
+    }
+
+    @Test
+    void should_ReturnEmptyList_When_RepositoryFindsNoTeams() {
+        when(teamRepository.search(null, null, null, null)).thenReturn(List.of());
+
+        List<TeamSummary> results = teamService.findTeams(null, null, null, null);
+
+        assertEquals(List.of(), results);
+    }
+
+    @Test
+    void should_KeepNullableFields_When_MappingSummary() {
+        Team team = buildTeam();
+        team.setTeamDescription(null);
+        team.setTeamWebsiteUrl(null);
+        when(teamRepository.search(null, null, null, null)).thenReturn(List.of(team));
+
+        TeamSummary summary = teamService.findTeams(null, null, null, null).getFirst();
+
+        assertNull(summary.teamDescription());
+        assertNull(summary.teamWebsiteUrl());
+    }
+
+    private Team buildTeam() {
+        Section section = new Section();
+        section.setSectionId(2L);
+        section.setSectionName("Spring 2026 - Section A");
+
+        User student1 = new User();
+        student1.setFirstName("Zoe");
+        student1.setLastName("Zeta");
+
+        User student2 = new User();
+        student2.setFirstName("Amy");
+        student2.setLastName("Adams");
+
+        User instructor1 = new User();
+        instructor1.setFirstName("Noah");
+        instructor1.setLastName("Bennett");
+
+        User instructor2 = new User();
+        instructor2.setFirstName("Ivy");
+        instructor2.setLastName("Stone");
+
+        Team team = new Team();
+        team.setTeamId(10L);
+        team.setSection(section);
+        team.setTeamName("Pulse Analytics");
+        team.setTeamDescription("Analytics dashboard");
+        team.setTeamWebsiteUrl("https://pulse.example.com");
+        team.setStudents(new LinkedHashSet<>(List.of(student1, student2)));
+        team.setInstructors(new LinkedHashSet<>(List.of(instructor1, instructor2)));
+        return team;
+    }
+}

--- a/src/backend/src/test/resources/application-test.yml
+++ b/src/backend/src/test/resources/application-test.yml
@@ -13,6 +13,7 @@ api:
   endpoint:
     base-url: /api/v1
 
-jwt:
-  secret-key: test-secret-key-for-testing-only-32chars!!
-  expiration: 3600000
+security:
+  jwt:
+    secret-key: test-secret-key-for-testing-only-32chars!!
+    token-expiry-in-hours: 1

--- a/src/frontend/src/features/team/pages/Teams.vue
+++ b/src/frontend/src/features/team/pages/Teams.vue
@@ -1,0 +1,164 @@
+<template>
+  <v-container>
+    <v-row class="mb-4" align="center">
+      <v-col><h2 class="text-h5 font-weight-bold">Senior Design Teams</h2></v-col>
+    </v-row>
+
+    <v-row class="mb-4">
+      <v-col cols="12" md="4">
+        <v-text-field
+          v-model="filters.sectionName"
+          label="Search by section"
+          prepend-inner-icon="mdi-school"
+          clearable
+          hide-details
+          @keyup.enter="search"
+        />
+      </v-col>
+      <v-col cols="12" md="4">
+        <v-text-field
+          v-model="filters.teamName"
+          label="Search by team name"
+          prepend-inner-icon="mdi-account-group"
+          clearable
+          hide-details
+          @keyup.enter="search"
+        />
+      </v-col>
+      <v-col cols="12" md="4">
+        <v-text-field
+          v-model="filters.instructor"
+          label="Search by instructor"
+          prepend-inner-icon="mdi-account-tie"
+          clearable
+          hide-details
+          @keyup.enter="search"
+        />
+      </v-col>
+      <v-col cols="auto">
+        <v-btn color="primary" @click="search">Search</v-btn>
+      </v-col>
+      <v-col cols="auto">
+        <v-btn variant="text" @click="clearFilters">Clear</v-btn>
+      </v-col>
+    </v-row>
+
+    <v-row v-if="loading">
+      <v-col class="text-center">
+        <v-progress-circular indeterminate />
+      </v-col>
+    </v-row>
+
+    <v-row v-else-if="teams.length === 0">
+      <v-col>
+        <v-alert type="info" variant="tonal">
+          No matching senior design teams found.
+        </v-alert>
+      </v-col>
+    </v-row>
+
+    <v-row v-else>
+      <v-col cols="12">
+        <v-table>
+          <thead>
+            <tr>
+              <th>Section</th>
+              <th>Team Name</th>
+              <th>Description</th>
+              <th>Website</th>
+              <th>Team Members</th>
+              <th>Instructors</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr v-for="team in teams" :key="team.teamId">
+              <td>{{ team.sectionName }}</td>
+              <td>{{ team.teamName }}</td>
+              <td>{{ team.teamDescription || '—' }}</td>
+              <td>
+                <a
+                  v-if="team.teamWebsiteUrl"
+                  :href="team.teamWebsiteUrl"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  Open
+                </a>
+                <span v-else class="text-medium-emphasis">—</span>
+              </td>
+              <td>
+                <div v-if="team.teamMemberNames.length" class="chip-group">
+                  <v-chip
+                    v-for="member in team.teamMemberNames"
+                    :key="member"
+                    size="small"
+                    variant="tonal"
+                    class="mr-1 mb-1"
+                  >{{ member }}</v-chip>
+                </div>
+                <span v-else class="text-medium-emphasis">—</span>
+              </td>
+              <td>
+                <div v-if="team.instructorNames.length" class="chip-group">
+                  <v-chip
+                    v-for="instructor in team.instructorNames"
+                    :key="instructor"
+                    size="small"
+                    variant="tonal"
+                    color="primary"
+                    class="mr-1 mb-1"
+                  >{{ instructor }}</v-chip>
+                </div>
+                <span v-else class="text-medium-emphasis">—</span>
+              </td>
+            </tr>
+          </tbody>
+        </v-table>
+      </v-col>
+    </v-row>
+  </v-container>
+</template>
+
+<script setup lang="ts">
+import { onMounted, ref } from 'vue'
+import { findTeams } from '../services/teamService'
+import type { FindTeamsParams, TeamSummary } from '../services/teamTypes'
+
+const teams = ref<TeamSummary[]>([])
+const loading = ref(false)
+const filters = ref<FindTeamsParams>({
+  sectionName: '',
+  teamName: '',
+  instructor: ''
+})
+
+onMounted(() => search())
+
+async function search() {
+  loading.value = true
+  try {
+    const res = await findTeams({
+      sectionName: filters.value.sectionName?.trim() || undefined,
+      teamName: filters.value.teamName?.trim() || undefined,
+      instructor: filters.value.instructor?.trim() || undefined
+    }) as any
+
+    teams.value = res.flag ? (res.data ?? []) : []
+  } catch {
+    teams.value = []
+  } finally {
+    loading.value = false
+  }
+}
+
+function clearFilters() {
+  filters.value = { sectionName: '', teamName: '', instructor: '' }
+  search()
+}
+</script>
+
+<style scoped lang="scss">
+.chip-group {
+  min-width: 180px;
+}
+</style>

--- a/src/frontend/src/features/team/services/teamService.ts
+++ b/src/frontend/src/features/team/services/teamService.ts
@@ -1,0 +1,8 @@
+import request from '@/shared/utils/request'
+import type { ApiResponse } from '@/shared/types/api'
+import type { FindTeamsParams, TeamSummary } from './teamTypes'
+
+const BASE = '/teams'
+
+export const findTeams = (params?: FindTeamsParams) =>
+  request.get<ApiResponse<TeamSummary[]>>(BASE, { params: params ?? {} })

--- a/src/frontend/src/features/team/services/teamTypes.ts
+++ b/src/frontend/src/features/team/services/teamTypes.ts
@@ -1,0 +1,17 @@
+export interface TeamSummary {
+  teamId: number
+  sectionId: number
+  sectionName: string
+  teamName: string
+  teamDescription: string | null
+  teamWebsiteUrl: string | null
+  teamMemberNames: string[]
+  instructorNames: string[]
+}
+
+export interface FindTeamsParams {
+  sectionId?: number
+  sectionName?: string
+  teamName?: string
+  instructor?: string
+}

--- a/src/frontend/src/router/guards.ts
+++ b/src/frontend/src/router/guards.ts
@@ -37,8 +37,8 @@ function isLoggedIn(): boolean {
 
 function checkPermissions(to: RouteLocationNormalized): boolean {
   const userPermissions = useUserInfoStore().roleList
-  if (!to.meta.requiresPermissions) return true
-  const required = to.meta.requiresPermissions as string[]
+  if (!to.meta.roles) return true
+  const required = to.meta.roles as string[]
   return required.some((p) => userPermissions.includes(p.toLowerCase()))
 }
 

--- a/src/frontend/src/router/routes.ts
+++ b/src/frontend/src/router/routes.ts
@@ -49,6 +49,14 @@ export const routes = [
         meta: { title: 'Sections', icon: 'mdi-school', isMenuItem: true, requiresAuth: true, roles: ['admin'] }
       },
 
+      // ── Teams ────────────────────────────────────────────────────────────
+      {
+        path: '/teams',
+        component: () => import('@/features/team/pages/Teams.vue'),
+        name: 'teams',
+        meta: { title: 'Teams', icon: 'mdi-account-group', isMenuItem: true, requiresAuth: true, roles: ['admin', 'instructor'] }
+      },
+
       // ── Rubrics ──────────────────────────────────────────────────────────
       {
         path: '/rubrics',

--- a/src/frontend/src/shared/components/MenuItems.vue
+++ b/src/frontend/src/shared/components/MenuItems.vue
@@ -2,7 +2,7 @@
   <template v-for="menuItem in menuRoute.children" :key="menuItem.path">
     <!-- Leaf menu item -->
     <v-list-item
-      v-if="!menuItem.children && hasPermission(menuItem.meta.requiresPermissions) && menuItem.meta.isMenuItem"
+      v-if="!menuItem.children && hasPermission(menuItem.meta.roles) && menuItem.meta.isMenuItem"
       :to="menuItem.path"
       :prepend-icon="menuItem.meta.icon"
       :title="menuItem.meta.title"
@@ -12,7 +12,7 @@
 
     <!-- Sub-menu with children -->
     <v-list-group
-      v-if="menuItem.children && hasPermission(menuItem.meta.requiresPermissions) && menuItem.meta.isMenuItem"
+      v-if="menuItem.children && hasPermission(menuItem.meta.roles) && menuItem.meta.isMenuItem"
       :value="menuItem.path"
     >
       <template #activator="{ props }">
@@ -37,8 +37,8 @@ defineProps(['menuRoute'])
 const userInfoStore = useUserInfoStore()
 const userPermissions = computed(() => userInfoStore.roleList)
 
-function hasPermission(requiredPermissions: string[] | undefined) {
-  if (requiredPermissions === undefined) return true
-  return requiredPermissions.some((p) => userPermissions.value.includes(p.toLowerCase()))
+function hasPermission(roles: string[] | undefined) {
+  if (roles === undefined) return true
+  return roles.some((p) => userPermissions.value.includes(p.toLowerCase()))
 }
 </script>


### PR DESCRIPTION
Implements UC-7 end to end
Adds team schema, seeded dev data, /api/v1/teams, frontend Teams page
Normalizes frontend role-based route/menu checks
Adds backend service/repository/controller tests
