### PR TITLE
feat: implement UC-8 view senior design team

### DIFF
--- a/src/backend/src/main/java/team/projectpulse/config/SecurityConfig.java
+++ b/src/backend/src/main/java/team/projectpulse/config/SecurityConfig.java
@@ -66,7 +66,7 @@ public class SecurityConfig {
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration config = new CorsConfiguration();
-        config.setAllowedOrigins(List.of("http://localhost:5173"));
+        config.setAllowedOrigins(List.of("http://localhost:5173", "http://127.0.0.1:5173"));
         config.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
         config.setAllowedHeaders(List.of("*"));
         config.setAllowCredentials(true);

--- a/src/backend/src/main/java/team/projectpulse/team/controller/TeamController.java
+++ b/src/backend/src/main/java/team/projectpulse/team/controller/TeamController.java
@@ -2,10 +2,12 @@ package team.projectpulse.team.controller;
 
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import team.projectpulse.system.Result;
+import team.projectpulse.team.dto.TeamDetail;
 import team.projectpulse.team.dto.TeamSummary;
 import team.projectpulse.team.service.TeamService;
 
@@ -30,5 +32,11 @@ public class TeamController {
         @RequestParam(required = false) String instructor
     ) {
         return Result.success(teamService.findTeams(sectionId, sectionName, teamName, instructor));
+    }
+
+    @GetMapping("/{id}")
+    @PreAuthorize("hasAnyRole('ADMIN', 'INSTRUCTOR')")
+    public Result<TeamDetail> getTeam(@PathVariable Long id) {
+        return Result.success(teamService.findTeamDetail(id));
     }
 }

--- a/src/backend/src/main/java/team/projectpulse/team/controller/TeamExceptionHandler.java
+++ b/src/backend/src/main/java/team/projectpulse/team/controller/TeamExceptionHandler.java
@@ -1,0 +1,18 @@
+package team.projectpulse.team.controller;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import team.projectpulse.system.Result;
+import team.projectpulse.team.domain.TeamNotFoundException;
+
+@RestControllerAdvice
+public class TeamExceptionHandler {
+
+    @ExceptionHandler(TeamNotFoundException.class)
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    public Result<Void> handleNotFound(TeamNotFoundException ex) {
+        return Result.notFound(ex.getMessage());
+    }
+}

--- a/src/backend/src/main/java/team/projectpulse/team/domain/TeamNotFoundException.java
+++ b/src/backend/src/main/java/team/projectpulse/team/domain/TeamNotFoundException.java
@@ -1,0 +1,7 @@
+package team.projectpulse.team.domain;
+
+public class TeamNotFoundException extends RuntimeException {
+    public TeamNotFoundException(Long id) {
+        super("No team found with id: " + id);
+    }
+}

--- a/src/backend/src/main/java/team/projectpulse/team/dto/TeamDetail.java
+++ b/src/backend/src/main/java/team/projectpulse/team/dto/TeamDetail.java
@@ -1,0 +1,15 @@
+package team.projectpulse.team.dto;
+
+import java.util.List;
+
+public record TeamDetail(
+    Long teamId,
+    Long sectionId,
+    String sectionName,
+    String teamName,
+    String teamDescription,
+    String teamWebsiteUrl,
+    List<String> teamMemberNames,
+    List<String> instructorNames
+) {
+}

--- a/src/backend/src/main/java/team/projectpulse/team/repository/TeamRepository.java
+++ b/src/backend/src/main/java/team/projectpulse/team/repository/TeamRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.repository.query.Param;
 import team.projectpulse.team.domain.Team;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface TeamRepository extends JpaRepository<Team, Long> {
 
@@ -31,4 +32,13 @@ public interface TeamRepository extends JpaRepository<Team, Long> {
         @Param("teamName") String teamName,
         @Param("instructor") String instructor
     );
+
+    @Query("""
+        select distinct t from Team t
+        join fetch t.section s
+        left join fetch t.students st
+        left join fetch t.instructors i
+        where t.teamId = :teamId
+        """)
+    Optional<Team> findDetailById(@Param("teamId") Long teamId);
 }

--- a/src/backend/src/main/java/team/projectpulse/team/service/TeamService.java
+++ b/src/backend/src/main/java/team/projectpulse/team/service/TeamService.java
@@ -2,11 +2,14 @@ package team.projectpulse.team.service;
 
 import org.springframework.stereotype.Service;
 import team.projectpulse.team.domain.Team;
+import team.projectpulse.team.domain.TeamNotFoundException;
+import team.projectpulse.team.dto.TeamDetail;
 import team.projectpulse.team.dto.TeamSummary;
 import team.projectpulse.team.repository.TeamRepository;
 import team.projectpulse.user.domain.User;
 
 import java.util.List;
+import java.util.stream.StreamSupport;
 
 @Service
 public class TeamService {
@@ -30,17 +33,14 @@ public class TeamService {
             .toList();
     }
 
+    public TeamDetail findTeamDetail(Long id) {
+        Team team = teamRepository.findDetailById(id)
+            .orElseThrow(() -> new TeamNotFoundException(id));
+
+        return toDetail(team);
+    }
+
     private TeamSummary toSummary(Team team) {
-        List<String> teamMemberNames = team.getStudents().stream()
-            .map(this::toDisplayName)
-            .sorted(String.CASE_INSENSITIVE_ORDER)
-            .toList();
-
-        List<String> instructorNames = team.getInstructors().stream()
-            .map(this::toDisplayName)
-            .sorted(String.CASE_INSENSITIVE_ORDER)
-            .toList();
-
         return new TeamSummary(
             team.getTeamId(),
             team.getSection().getSectionId(),
@@ -48,13 +48,33 @@ public class TeamService {
             team.getTeamName(),
             team.getTeamDescription(),
             team.getTeamWebsiteUrl(),
-            teamMemberNames,
-            instructorNames
+            toSortedNames(team.getStudents()),
+            toSortedNames(team.getInstructors())
+        );
+    }
+
+    private TeamDetail toDetail(Team team) {
+        return new TeamDetail(
+            team.getTeamId(),
+            team.getSection().getSectionId(),
+            team.getSection().getSectionName(),
+            team.getTeamName(),
+            team.getTeamDescription(),
+            team.getTeamWebsiteUrl(),
+            toSortedNames(team.getStudents()),
+            toSortedNames(team.getInstructors())
         );
     }
 
     private String toDisplayName(User user) {
         return (user.getFirstName() + " " + user.getLastName()).trim();
+    }
+
+    private List<String> toSortedNames(Iterable<User> users) {
+        return StreamSupport.stream(users.spliterator(), false)
+            .map(this::toDisplayName)
+            .sorted(String.CASE_INSENSITIVE_ORDER)
+            .toList();
     }
 
     private String normalize(String value) {

--- a/src/backend/src/test/java/team/projectpulse/team/controller/TeamControllerIntegrationTest.java
+++ b/src/backend/src/test/java/team/projectpulse/team/controller/TeamControllerIntegrationTest.java
@@ -8,6 +8,8 @@ import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
+import team.projectpulse.team.domain.TeamNotFoundException;
+import team.projectpulse.team.dto.TeamDetail;
 import team.projectpulse.team.dto.TeamSummary;
 import team.projectpulse.team.service.TeamService;
 
@@ -71,5 +73,79 @@ class TeamControllerIntegrationTest {
     void should_ReturnUnauthorized_When_RequestIsUnauthenticated() throws Exception {
         mockMvc.perform(get("/api/v1/teams"))
             .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void should_ReturnTeamDetailWrappedInResult_When_AdminRequestsTeam() throws Exception {
+        when(teamService.findTeamDetail(1L))
+            .thenReturn(new TeamDetail(
+                1L,
+                1L,
+                "Spring 2026 - Section A",
+                "Pulse Analytics",
+                "desc",
+                "https://pulse.example.com",
+                List.of("Ava Johnson"),
+                List.of("Ivy Stone")
+            ));
+
+        mockMvc.perform(get("/api/v1/teams/1"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.flag").value(true))
+            .andExpect(jsonPath("$.code").value(200))
+            .andExpect(jsonPath("$.data.teamName").value("Pulse Analytics"))
+            .andExpect(jsonPath("$.data.sectionName").value("Spring 2026 - Section A"));
+
+        verify(teamService).findTeamDetail(1L);
+    }
+
+    @Test
+    @WithMockUser(roles = "INSTRUCTOR")
+    void should_AllowInstructor_When_RequestingTeamDetail() throws Exception {
+        when(teamService.findTeamDetail(2L))
+            .thenReturn(new TeamDetail(
+                2L,
+                1L,
+                "Spring 2026 - Section A",
+                "Review Board",
+                null,
+                null,
+                List.of(),
+                List.of()
+            ));
+
+        mockMvc.perform(get("/api/v1/teams/2"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.data.teamId").value(2));
+
+        verify(teamService).findTeamDetail(2L);
+    }
+
+    @Test
+    @WithMockUser(roles = "STUDENT")
+    void should_ReturnForbidden_When_StudentRequestsTeamDetail() throws Exception {
+        mockMvc.perform(get("/api/v1/teams/1"))
+            .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void should_ReturnUnauthorized_When_RequestIsUnauthenticated_ForTeamDetail() throws Exception {
+        mockMvc.perform(get("/api/v1/teams/1"))
+            .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void should_ReturnNotFound_When_TeamDoesNotExist() throws Exception {
+        when(teamService.findTeamDetail(eq(999L))).thenThrow(new TeamNotFoundException(999L));
+
+        mockMvc.perform(get("/api/v1/teams/999"))
+            .andExpect(status().isNotFound())
+            .andExpect(jsonPath("$.flag").value(false))
+            .andExpect(jsonPath("$.code").value(404))
+            .andExpect(jsonPath("$.message").value("No team found with id: 999"));
+
+        verify(teamService).findTeamDetail(999L);
     }
 }

--- a/src/backend/src/test/java/team/projectpulse/team/repository/TeamRepositoryIntegrationTest.java
+++ b/src/backend/src/test/java/team/projectpulse/team/repository/TeamRepositoryIntegrationTest.java
@@ -12,8 +12,10 @@ import team.projectpulse.user.domain.User;
 import java.time.LocalDate;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @DataJpaTest
 @ActiveProfiles("test")
@@ -53,6 +55,29 @@ class TeamRepositoryIntegrationTest {
         assertEquals(List.of(), teams);
     }
 
+    @Test
+    void should_FetchSectionStudentsAndInstructors_When_FindingTeamDetailById() {
+        SeededData data = seedTeams();
+
+        Optional<Team> teamOptional = teamRepository.findDetailById(data.teamAlphaId());
+
+        assertTrue(teamOptional.isPresent());
+        Team team = teamOptional.get();
+        assertEquals("Pulse Analytics", team.getTeamName());
+        assertEquals("Spring 2026 - Section A", team.getSection().getSectionName());
+        assertEquals(List.of("Ava", "Liam"), team.getStudents().stream().map(User::getFirstName).sorted().toList());
+        assertEquals(List.of("Ivy"), team.getInstructors().stream().map(User::getFirstName).sorted().toList());
+    }
+
+    @Test
+    void should_ReturnEmpty_When_TeamIdDoesNotExist() {
+        seedTeams();
+
+        Optional<Team> team = teamRepository.findDetailById(99999L);
+
+        assertTrue(team.isEmpty());
+    }
+
     private SeededData seedTeams() {
         Section sectionA = new Section();
         sectionA.setSectionName("Spring 2026 - Section A");
@@ -81,7 +106,7 @@ class TeamRepositoryIntegrationTest {
         entityManager.flush();
         entityManager.clear();
 
-        return new SeededData("Review Board", "Pulse Analytics", "Gamma Studio");
+        return new SeededData("Review Board", "Pulse Analytics", "Gamma Studio", pulse.getTeamId());
     }
 
     private User persistUser(String firstName, String lastName, String email, String roles) {
@@ -108,5 +133,5 @@ class TeamRepositoryIntegrationTest {
         return team;
     }
 
-    private record SeededData(String teamBravo, String teamAlpha, String teamGamma) {}
+    private record SeededData(String teamBravo, String teamAlpha, String teamGamma, Long teamAlphaId) {}
 }

--- a/src/backend/src/test/java/team/projectpulse/team/service/TeamServiceTest.java
+++ b/src/backend/src/test/java/team/projectpulse/team/service/TeamServiceTest.java
@@ -7,15 +7,19 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import team.projectpulse.section.domain.Section;
 import team.projectpulse.team.domain.Team;
+import team.projectpulse.team.domain.TeamNotFoundException;
+import team.projectpulse.team.dto.TeamDetail;
 import team.projectpulse.team.dto.TeamSummary;
 import team.projectpulse.team.repository.TeamRepository;
 import team.projectpulse.user.domain.User;
 
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -66,6 +70,44 @@ class TeamServiceTest {
 
         assertNull(summary.teamDescription());
         assertNull(summary.teamWebsiteUrl());
+    }
+
+    @Test
+    void should_ReturnTeamDetail_When_TeamExists() {
+        Team team = buildTeam();
+        when(teamRepository.findDetailById(10L)).thenReturn(Optional.of(team));
+
+        TeamDetail detail = teamService.findTeamDetail(10L);
+
+        assertEquals(10L, detail.teamId());
+        assertEquals(2L, detail.sectionId());
+        assertEquals("Spring 2026 - Section A", detail.sectionName());
+        assertEquals("Pulse Analytics", detail.teamName());
+        assertEquals("Analytics dashboard", detail.teamDescription());
+        assertEquals("https://pulse.example.com", detail.teamWebsiteUrl());
+        assertEquals(List.of("Amy Adams", "Zoe Zeta"), detail.teamMemberNames());
+        assertEquals(List.of("Ivy Stone", "Noah Bennett"), detail.instructorNames());
+        verify(teamRepository).findDetailById(10L);
+    }
+
+    @Test
+    void should_SortTeamMembersAndInstructorsAlphabetically_When_BuildingDetail() {
+        Team team = buildTeam();
+        when(teamRepository.findDetailById(10L)).thenReturn(Optional.of(team));
+
+        TeamDetail detail = teamService.findTeamDetail(10L);
+
+        assertEquals(List.of("Amy Adams", "Zoe Zeta"), detail.teamMemberNames());
+        assertEquals(List.of("Ivy Stone", "Noah Bennett"), detail.instructorNames());
+    }
+
+    @Test
+    void should_ThrowNotFoundException_When_TeamDetailIdDoesNotExist() {
+        when(teamRepository.findDetailById(999L)).thenReturn(Optional.empty());
+
+        TeamNotFoundException ex = assertThrows(TeamNotFoundException.class, () -> teamService.findTeamDetail(999L));
+
+        assertEquals("No team found with id: 999", ex.getMessage());
     }
 
     private Team buildTeam() {

--- a/src/frontend/src/features/team/pages/TeamDetail.vue
+++ b/src/frontend/src/features/team/pages/TeamDetail.vue
@@ -1,0 +1,123 @@
+<template>
+  <v-container>
+    <v-btn variant="text" prepend-icon="mdi-arrow-left" class="mb-4" @click="router.push({ name: 'teams' })">
+      Back to Teams
+    </v-btn>
+
+    <v-row v-if="loading">
+      <v-col class="text-center"><v-progress-circular indeterminate /></v-col>
+    </v-row>
+
+    <template v-else-if="team">
+      <v-row class="mb-2" align="center">
+        <v-col>
+          <h2 class="text-h5 font-weight-bold">{{ team.teamName }}</h2>
+        </v-col>
+        <v-col cols="auto">
+          <v-chip color="primary" variant="tonal">
+            {{ team.sectionName }}
+          </v-chip>
+        </v-col>
+      </v-row>
+
+      <v-card variant="outlined" class="mb-4">
+        <v-card-title class="text-subtitle-1 font-weight-bold pa-4 pb-2">Team Info</v-card-title>
+        <v-card-text>
+          <v-row>
+            <v-col cols="12" md="6">
+              <div class="text-caption text-medium-emphasis">Description</div>
+              <div>{{ team.teamDescription ?? '—' }}</div>
+            </v-col>
+            <v-col cols="12" md="6">
+              <div class="text-caption text-medium-emphasis">Website</div>
+              <a
+                v-if="team.teamWebsiteUrl"
+                :href="team.teamWebsiteUrl"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                {{ team.teamWebsiteUrl }}
+              </a>
+              <div v-else>—</div>
+            </v-col>
+          </v-row>
+        </v-card-text>
+      </v-card>
+
+      <v-row>
+        <v-col cols="12" md="6">
+          <v-card variant="outlined" class="fill-height">
+            <v-card-title class="text-subtitle-1 font-weight-bold pa-4 pb-2">Team Members</v-card-title>
+            <v-card-text>
+              <v-alert v-if="team.teamMemberNames.length === 0" type="info" variant="tonal" density="compact">
+                No team members assigned.
+              </v-alert>
+              <div v-else>
+                <v-chip
+                  v-for="member in team.teamMemberNames"
+                  :key="member"
+                  size="small"
+                  class="mr-1 mb-1"
+                >
+                  {{ member }}
+                </v-chip>
+              </div>
+            </v-card-text>
+          </v-card>
+        </v-col>
+        <v-col cols="12" md="6">
+          <v-card variant="outlined" class="fill-height">
+            <v-card-title class="text-subtitle-1 font-weight-bold pa-4 pb-2">Instructors</v-card-title>
+            <v-card-text>
+              <v-alert v-if="team.instructorNames.length === 0" type="info" variant="tonal" density="compact">
+                No instructors assigned.
+              </v-alert>
+              <div v-else>
+                <v-chip
+                  v-for="instructor in team.instructorNames"
+                  :key="instructor"
+                  size="small"
+                  color="primary"
+                  variant="tonal"
+                  class="mr-1 mb-1"
+                >
+                  {{ instructor }}
+                </v-chip>
+              </div>
+            </v-card-text>
+          </v-card>
+        </v-col>
+      </v-row>
+    </template>
+  </v-container>
+</template>
+
+<script setup lang="ts">
+import { onMounted, ref } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import { getTeam } from '../services/teamService'
+import type { TeamDetail } from '../services/teamTypes'
+
+const route = useRoute()
+const router = useRouter()
+
+const team = ref<TeamDetail | null>(null)
+const loading = ref(false)
+
+onMounted(async () => {
+  loading.value = true
+  try {
+    const teamId = Number(route.params.id)
+    const res = await getTeam(teamId) as any
+    if (res.flag && res.data) {
+      team.value = res.data
+    } else {
+      router.replace({ name: 'not-found' })
+    }
+  } catch {
+    router.replace({ name: 'not-found' })
+  } finally {
+    loading.value = false
+  }
+})
+</script>

--- a/src/frontend/src/features/team/pages/Teams.vue
+++ b/src/frontend/src/features/team/pages/Teams.vue
@@ -68,6 +68,7 @@
               <th>Website</th>
               <th>Team Members</th>
               <th>Instructors</th>
+              <th>Actions</th>
             </tr>
           </thead>
           <tbody>
@@ -111,6 +112,16 @@
                 </div>
                 <span v-else class="text-medium-emphasis">—</span>
               </td>
+              <td>
+                <v-btn
+                  size="small"
+                  variant="text"
+                  color="primary"
+                  @click="viewTeam(team.teamId)"
+                >
+                  View
+                </v-btn>
+              </td>
             </tr>
           </tbody>
         </v-table>
@@ -121,9 +132,11 @@
 
 <script setup lang="ts">
 import { onMounted, ref } from 'vue'
+import { useRouter } from 'vue-router'
 import { findTeams } from '../services/teamService'
 import type { FindTeamsParams, TeamSummary } from '../services/teamTypes'
 
+const router = useRouter()
 const teams = ref<TeamSummary[]>([])
 const loading = ref(false)
 const filters = ref<FindTeamsParams>({
@@ -154,6 +167,10 @@ async function search() {
 function clearFilters() {
   filters.value = { sectionName: '', teamName: '', instructor: '' }
   search()
+}
+
+function viewTeam(teamId: number) {
+  router.push({ name: 'team-detail', params: { id: teamId } })
 }
 </script>
 

--- a/src/frontend/src/features/team/services/teamService.ts
+++ b/src/frontend/src/features/team/services/teamService.ts
@@ -1,8 +1,11 @@
 import request from '@/shared/utils/request'
 import type { ApiResponse } from '@/shared/types/api'
-import type { FindTeamsParams, TeamSummary } from './teamTypes'
+import type { FindTeamsParams, TeamDetail, TeamSummary } from './teamTypes'
 
 const BASE = '/teams'
 
 export const findTeams = (params?: FindTeamsParams) =>
   request.get<ApiResponse<TeamSummary[]>>(BASE, { params: params ?? {} })
+
+export const getTeam = (id: number) =>
+  request.get<ApiResponse<TeamDetail>>(`${BASE}/${id}`)

--- a/src/frontend/src/features/team/services/teamTypes.ts
+++ b/src/frontend/src/features/team/services/teamTypes.ts
@@ -9,6 +9,17 @@ export interface TeamSummary {
   instructorNames: string[]
 }
 
+export interface TeamDetail {
+  teamId: number
+  sectionId: number
+  sectionName: string
+  teamName: string
+  teamDescription: string | null
+  teamWebsiteUrl: string | null
+  teamMemberNames: string[]
+  instructorNames: string[]
+}
+
 export interface FindTeamsParams {
   sectionId?: number
   sectionName?: string

--- a/src/frontend/src/router/routes.ts
+++ b/src/frontend/src/router/routes.ts
@@ -62,6 +62,12 @@ export const routes = [
         name: 'teams',
         meta: { title: 'Teams', icon: 'mdi-account-group', isMenuItem: true, requiresAuth: true, roles: ['admin', 'instructor'] }
       },
+      {
+        path: '/teams/:id',
+        component: () => import('@/features/team/pages/TeamDetail.vue'),
+        name: 'team-detail',
+        meta: { requiresAuth: true, roles: ['admin', 'instructor'] }
+      },
 
       // ── Rubrics ──────────────────────────────────────────────────────────
       {


### PR DESCRIPTION
Implement UC-8 team detail endpoint and UI
Add team detail DTO, not-found handling, and backend coverage
Add /teams/:id route and detail page
Add Teams list View action
Update CORS config to allow both localhost:5173 and 127.0.0.1:5173