### PR TITLE
feat: implement UC-9 create senior design team

### DIFF
--- a/src/backend/src/main/java/team/projectpulse/team/controller/TeamController.java
+++ b/src/backend/src/main/java/team/projectpulse/team/controller/TeamController.java
@@ -3,10 +3,13 @@ package team.projectpulse.team.controller;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import team.projectpulse.system.Result;
+import team.projectpulse.team.dto.CreateTeamRequest;
 import team.projectpulse.team.dto.TeamDetail;
 import team.projectpulse.team.dto.TeamSummary;
 import team.projectpulse.team.service.TeamService;
@@ -38,5 +41,11 @@ public class TeamController {
     @PreAuthorize("hasAnyRole('ADMIN', 'INSTRUCTOR')")
     public Result<TeamDetail> getTeam(@PathVariable Long id) {
         return Result.success(teamService.findTeamDetail(id));
+    }
+
+    @PostMapping
+    @PreAuthorize("hasRole('ADMIN')")
+    public Result<TeamDetail> createTeam(@RequestBody CreateTeamRequest request) {
+        return Result.success("Team created successfully.", teamService.createTeam(request));
     }
 }

--- a/src/backend/src/main/java/team/projectpulse/team/controller/TeamExceptionHandler.java
+++ b/src/backend/src/main/java/team/projectpulse/team/controller/TeamExceptionHandler.java
@@ -5,6 +5,9 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import team.projectpulse.system.Result;
+import team.projectpulse.system.StatusCode;
+import team.projectpulse.team.domain.InvalidTeamException;
+import team.projectpulse.team.domain.TeamAlreadyExistsException;
 import team.projectpulse.team.domain.TeamNotFoundException;
 
 @RestControllerAdvice
@@ -14,5 +17,17 @@ public class TeamExceptionHandler {
     @ResponseStatus(HttpStatus.NOT_FOUND)
     public Result<Void> handleNotFound(TeamNotFoundException ex) {
         return Result.notFound(ex.getMessage());
+    }
+
+    @ExceptionHandler(TeamAlreadyExistsException.class)
+    @ResponseStatus(HttpStatus.CONFLICT)
+    public Result<Void> handleConflict(TeamAlreadyExistsException ex) {
+        return Result.conflict(ex.getMessage());
+    }
+
+    @ExceptionHandler(InvalidTeamException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public Result<Void> handleInvalidTeam(InvalidTeamException ex) {
+        return Result.error(StatusCode.INVALID_ARGUMENT, ex.getMessage());
     }
 }

--- a/src/backend/src/main/java/team/projectpulse/team/domain/InvalidTeamException.java
+++ b/src/backend/src/main/java/team/projectpulse/team/domain/InvalidTeamException.java
@@ -1,0 +1,7 @@
+package team.projectpulse.team.domain;
+
+public class InvalidTeamException extends RuntimeException {
+    public InvalidTeamException(String message) {
+        super(message);
+    }
+}

--- a/src/backend/src/main/java/team/projectpulse/team/domain/TeamAlreadyExistsException.java
+++ b/src/backend/src/main/java/team/projectpulse/team/domain/TeamAlreadyExistsException.java
@@ -1,0 +1,7 @@
+package team.projectpulse.team.domain;
+
+public class TeamAlreadyExistsException extends RuntimeException {
+    public TeamAlreadyExistsException(String teamName) {
+        super("Team already exists with name: " + teamName);
+    }
+}

--- a/src/backend/src/main/java/team/projectpulse/team/dto/CreateTeamRequest.java
+++ b/src/backend/src/main/java/team/projectpulse/team/dto/CreateTeamRequest.java
@@ -1,0 +1,9 @@
+package team.projectpulse.team.dto;
+
+public record CreateTeamRequest(
+    Long sectionId,
+    String teamName,
+    String teamDescription,
+    String teamWebsiteUrl
+) {
+}

--- a/src/backend/src/main/java/team/projectpulse/team/repository/TeamRepository.java
+++ b/src/backend/src/main/java/team/projectpulse/team/repository/TeamRepository.java
@@ -10,6 +10,8 @@ import java.util.Optional;
 
 public interface TeamRepository extends JpaRepository<Team, Long> {
 
+    boolean existsByTeamNameIgnoreCase(String teamName);
+
     @Query("""
         select distinct t from Team t
         join fetch t.section s

--- a/src/backend/src/main/java/team/projectpulse/team/service/TeamService.java
+++ b/src/backend/src/main/java/team/projectpulse/team/service/TeamService.java
@@ -1,13 +1,20 @@
 package team.projectpulse.team.service;
 
 import org.springframework.stereotype.Service;
+import team.projectpulse.section.domain.Section;
+import team.projectpulse.section.repository.SectionRepository;
 import team.projectpulse.team.domain.Team;
+import team.projectpulse.team.domain.InvalidTeamException;
+import team.projectpulse.team.domain.TeamAlreadyExistsException;
 import team.projectpulse.team.domain.TeamNotFoundException;
+import team.projectpulse.team.dto.CreateTeamRequest;
 import team.projectpulse.team.dto.TeamDetail;
 import team.projectpulse.team.dto.TeamSummary;
 import team.projectpulse.team.repository.TeamRepository;
 import team.projectpulse.user.domain.User;
 
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.List;
 import java.util.stream.StreamSupport;
 
@@ -15,9 +22,11 @@ import java.util.stream.StreamSupport;
 public class TeamService {
 
     private final TeamRepository teamRepository;
+    private final SectionRepository sectionRepository;
 
-    public TeamService(TeamRepository teamRepository) {
+    public TeamService(TeamRepository teamRepository, SectionRepository sectionRepository) {
         this.teamRepository = teamRepository;
+        this.sectionRepository = sectionRepository;
     }
 
     public List<TeamSummary> findTeams(Long sectionId, String sectionName, String teamName, String instructor) {
@@ -38,6 +47,37 @@ public class TeamService {
             .orElseThrow(() -> new TeamNotFoundException(id));
 
         return toDetail(team);
+    }
+
+    public TeamDetail createTeam(CreateTeamRequest request) {
+        if (request == null) {
+            throw new InvalidTeamException("Team request is required.");
+        }
+
+        if (request.sectionId() == null) {
+            throw new InvalidTeamException("Section is required.");
+        }
+
+        String normalizedName = requireTeamName(request.teamName());
+        String normalizedDescription = normalizeNullable(request.teamDescription());
+        String normalizedWebsite = normalizeNullable(request.teamWebsiteUrl());
+
+        validateWebsite(normalizedWebsite);
+
+        Section section = sectionRepository.findById(request.sectionId())
+            .orElseThrow(() -> new team.projectpulse.section.domain.SectionNotFoundException(request.sectionId()));
+
+        if (teamRepository.existsByTeamNameIgnoreCase(normalizedName)) {
+            throw new TeamAlreadyExistsException(normalizedName);
+        }
+
+        Team team = new Team();
+        team.setSection(section);
+        team.setTeamName(normalizedName);
+        team.setTeamDescription(normalizedDescription);
+        team.setTeamWebsiteUrl(normalizedWebsite);
+
+        return toDetail(teamRepository.save(team));
     }
 
     private TeamSummary toSummary(Team team) {
@@ -83,5 +123,41 @@ public class TeamService {
         }
         String trimmed = value.trim();
         return trimmed.isEmpty() ? null : trimmed;
+    }
+
+    private String normalizeNullable(String value) {
+        return normalize(value);
+    }
+
+    private String requireTeamName(String teamName) {
+        String normalizedName = normalize(teamName);
+        if (normalizedName == null) {
+            throw new InvalidTeamException("Team name is required.");
+        }
+        if (normalizedName.length() > 255) {
+            throw new InvalidTeamException("Team name must be 255 characters or fewer.");
+        }
+        return normalizedName;
+    }
+
+    private void validateWebsite(String websiteUrl) {
+        if (websiteUrl == null) {
+            return;
+        }
+        if (websiteUrl.length() > 500) {
+            throw new InvalidTeamException("Team website URL must be 500 characters or fewer.");
+        }
+        try {
+            URI uri = new URI(websiteUrl);
+            String scheme = uri.getScheme();
+            if (scheme == null || (!scheme.equalsIgnoreCase("http") && !scheme.equalsIgnoreCase("https"))) {
+                throw new InvalidTeamException("Team website URL must start with http:// or https://.");
+            }
+            if (uri.getHost() == null || uri.getHost().isBlank()) {
+                throw new InvalidTeamException("Team website URL must be a valid absolute URL.");
+            }
+        } catch (URISyntaxException ex) {
+            throw new InvalidTeamException("Team website URL must be a valid absolute URL.");
+        }
     }
 }

--- a/src/backend/src/test/java/team/projectpulse/team/controller/TeamControllerIntegrationTest.java
+++ b/src/backend/src/test/java/team/projectpulse/team/controller/TeamControllerIntegrationTest.java
@@ -4,10 +4,14 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
+import team.projectpulse.section.domain.SectionNotFoundException;
+import team.projectpulse.team.domain.InvalidTeamException;
+import team.projectpulse.team.domain.TeamAlreadyExistsException;
 import team.projectpulse.team.domain.TeamNotFoundException;
 import team.projectpulse.team.dto.TeamDetail;
 import team.projectpulse.team.dto.TeamSummary;
@@ -19,6 +23,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -147,5 +152,110 @@ class TeamControllerIntegrationTest {
             .andExpect(jsonPath("$.message").value("No team found with id: 999"));
 
         verify(teamService).findTeamDetail(999L);
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void should_CreateTeamWrappedInResult_When_AdminRequestsCreate() throws Exception {
+        when(teamService.createTeam(org.mockito.ArgumentMatchers.any()))
+            .thenReturn(new TeamDetail(
+                10L,
+                2L,
+                "Spring 2026 - Section A",
+                "Requirements Hub",
+                "desc",
+                "https://requirements-hub.example.com",
+                List.of(),
+                List.of()
+            ));
+
+        mockMvc.perform(post("/api/v1/teams")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                    {
+                      "sectionId": 2,
+                      "teamName": "Requirements Hub",
+                      "teamDescription": "desc",
+                      "teamWebsiteUrl": "https://requirements-hub.example.com"
+                    }
+                    """))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.flag").value(true))
+            .andExpect(jsonPath("$.message").value("Team created successfully."))
+            .andExpect(jsonPath("$.data.teamId").value(10))
+            .andExpect(jsonPath("$.data.teamName").value("Requirements Hub"))
+            .andExpect(jsonPath("$.data.teamMemberNames").isArray())
+            .andExpect(jsonPath("$.data.instructorNames").isArray());
+    }
+
+    @Test
+    @WithMockUser(roles = "INSTRUCTOR")
+    void should_ReturnForbidden_When_InstructorRequestsCreate() throws Exception {
+        mockMvc.perform(post("/api/v1/teams")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"sectionId\":2,\"teamName\":\"Requirements Hub\"}"))
+            .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @WithMockUser(roles = "STUDENT")
+    void should_ReturnForbidden_When_StudentRequestsCreate() throws Exception {
+        mockMvc.perform(post("/api/v1/teams")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"sectionId\":2,\"teamName\":\"Requirements Hub\"}"))
+            .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void should_ReturnUnauthorized_When_UnauthenticatedRequestCreatesTeam() throws Exception {
+        mockMvc.perform(post("/api/v1/teams")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"sectionId\":2,\"teamName\":\"Requirements Hub\"}"))
+            .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void should_ReturnConflict_When_TeamNameAlreadyExists() throws Exception {
+        when(teamService.createTeam(org.mockito.ArgumentMatchers.any()))
+            .thenThrow(new TeamAlreadyExistsException("Requirements Hub"));
+
+        mockMvc.perform(post("/api/v1/teams")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"sectionId\":2,\"teamName\":\"Requirements Hub\"}"))
+            .andExpect(status().isConflict())
+            .andExpect(jsonPath("$.flag").value(false))
+            .andExpect(jsonPath("$.code").value(409))
+            .andExpect(jsonPath("$.message").value("Team already exists with name: Requirements Hub"));
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void should_ReturnBadRequest_When_CreateRequestIsInvalid() throws Exception {
+        when(teamService.createTeam(org.mockito.ArgumentMatchers.any()))
+            .thenThrow(new InvalidTeamException("Team name is required."));
+
+        mockMvc.perform(post("/api/v1/teams")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"sectionId\":2,\"teamName\":\"   \"}"))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.flag").value(false))
+            .andExpect(jsonPath("$.code").value(400))
+            .andExpect(jsonPath("$.message").value("Team name is required."));
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void should_ReturnNotFound_When_SectionIdDoesNotExist() throws Exception {
+        when(teamService.createTeam(org.mockito.ArgumentMatchers.any()))
+            .thenThrow(new SectionNotFoundException(999L));
+
+        mockMvc.perform(post("/api/v1/teams")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"sectionId\":999,\"teamName\":\"Requirements Hub\"}"))
+            .andExpect(status().isNotFound())
+            .andExpect(jsonPath("$.flag").value(false))
+            .andExpect(jsonPath("$.code").value(404))
+            .andExpect(jsonPath("$.message").value("No section found with id: 999"));
     }
 }

--- a/src/backend/src/test/java/team/projectpulse/team/repository/TeamRepositoryIntegrationTest.java
+++ b/src/backend/src/test/java/team/projectpulse/team/repository/TeamRepositoryIntegrationTest.java
@@ -78,6 +78,24 @@ class TeamRepositoryIntegrationTest {
         assertTrue(team.isEmpty());
     }
 
+    @Test
+    void should_ReturnTrue_When_TeamNameExistsIgnoringCase() {
+        seedTeams();
+
+        boolean exists = teamRepository.existsByTeamNameIgnoreCase("pulse analytics");
+
+        assertTrue(exists);
+    }
+
+    @Test
+    void should_ReturnFalse_When_TeamNameDoesNotExist() {
+        seedTeams();
+
+        boolean exists = teamRepository.existsByTeamNameIgnoreCase("Missing Team");
+
+        assertEquals(false, exists);
+    }
+
     private SeededData seedTeams() {
         Section sectionA = new Section();
         sectionA.setSectionName("Spring 2026 - Section A");

--- a/src/backend/src/test/java/team/projectpulse/team/service/TeamServiceTest.java
+++ b/src/backend/src/test/java/team/projectpulse/team/service/TeamServiceTest.java
@@ -6,8 +6,13 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import team.projectpulse.section.domain.Section;
+import team.projectpulse.section.domain.SectionNotFoundException;
+import team.projectpulse.section.repository.SectionRepository;
+import team.projectpulse.team.domain.InvalidTeamException;
 import team.projectpulse.team.domain.Team;
+import team.projectpulse.team.domain.TeamAlreadyExistsException;
 import team.projectpulse.team.domain.TeamNotFoundException;
+import team.projectpulse.team.dto.CreateTeamRequest;
 import team.projectpulse.team.dto.TeamDetail;
 import team.projectpulse.team.dto.TeamSummary;
 import team.projectpulse.team.repository.TeamRepository;
@@ -28,6 +33,9 @@ class TeamServiceTest {
 
     @Mock
     private TeamRepository teamRepository;
+
+    @Mock
+    private SectionRepository sectionRepository;
 
     @InjectMocks
     private TeamService teamService;
@@ -110,10 +118,126 @@ class TeamServiceTest {
         assertEquals("No team found with id: 999", ex.getMessage());
     }
 
+    @Test
+    void should_CreateTeam_When_RequestIsValid() {
+        Section section = buildSection();
+        Team savedTeam = new Team();
+        savedTeam.setTeamId(77L);
+        savedTeam.setSection(section);
+        savedTeam.setTeamName("Requirements Hub");
+        savedTeam.setTeamDescription("Centralized workspace");
+        savedTeam.setTeamWebsiteUrl("https://requirements-hub.example.com");
+
+        when(sectionRepository.findById(2L)).thenReturn(Optional.of(section));
+        when(teamRepository.existsByTeamNameIgnoreCase("Requirements Hub")).thenReturn(false);
+        when(teamRepository.save(org.mockito.ArgumentMatchers.any(Team.class))).thenReturn(savedTeam);
+
+        TeamDetail detail = teamService.createTeam(new CreateTeamRequest(
+            2L,
+            " Requirements Hub ",
+            " Centralized workspace ",
+            " https://requirements-hub.example.com "
+        ));
+
+        assertEquals(77L, detail.teamId());
+        assertEquals(2L, detail.sectionId());
+        assertEquals("Spring 2026 - Section A", detail.sectionName());
+        assertEquals("Requirements Hub", detail.teamName());
+        assertEquals("Centralized workspace", detail.teamDescription());
+        assertEquals("https://requirements-hub.example.com", detail.teamWebsiteUrl());
+        assertEquals(List.of(), detail.teamMemberNames());
+        assertEquals(List.of(), detail.instructorNames());
+        verify(sectionRepository).findById(2L);
+        verify(teamRepository).existsByTeamNameIgnoreCase("Requirements Hub");
+        verify(teamRepository).save(org.mockito.ArgumentMatchers.any(Team.class));
+    }
+
+    @Test
+    void should_TrimAndNormalizeOptionalFields_When_CreatingTeam() {
+        Section section = buildSection();
+        Team savedTeam = new Team();
+        savedTeam.setTeamId(88L);
+        savedTeam.setSection(section);
+        savedTeam.setTeamName("Review Board");
+        savedTeam.setTeamDescription(null);
+        savedTeam.setTeamWebsiteUrl(null);
+
+        when(sectionRepository.findById(2L)).thenReturn(Optional.of(section));
+        when(teamRepository.existsByTeamNameIgnoreCase("Review Board")).thenReturn(false);
+        when(teamRepository.save(org.mockito.ArgumentMatchers.any(Team.class))).thenReturn(savedTeam);
+
+        TeamDetail detail = teamService.createTeam(new CreateTeamRequest(2L, " Review Board ", "   ", "   "));
+
+        assertNull(detail.teamDescription());
+        assertNull(detail.teamWebsiteUrl());
+    }
+
+    @Test
+    void should_ThrowNotFoundException_When_SectionDoesNotExist() {
+        when(sectionRepository.findById(22L)).thenReturn(Optional.empty());
+
+        SectionNotFoundException ex = assertThrows(
+            SectionNotFoundException.class,
+            () -> teamService.createTeam(new CreateTeamRequest(22L, "Requirements Hub", null, null))
+        );
+
+        assertEquals("No section found with id: 22", ex.getMessage());
+    }
+
+    @Test
+    void should_ThrowConflict_When_TeamNameAlreadyExistsIgnoringCase() {
+        Section section = buildSection();
+        when(sectionRepository.findById(2L)).thenReturn(Optional.of(section));
+        when(teamRepository.existsByTeamNameIgnoreCase("pulse analytics")).thenReturn(true);
+
+        TeamAlreadyExistsException ex = assertThrows(
+            TeamAlreadyExistsException.class,
+            () -> teamService.createTeam(new CreateTeamRequest(2L, " pulse analytics ", null, null))
+        );
+
+        assertEquals("Team already exists with name: pulse analytics", ex.getMessage());
+    }
+
+    @Test
+    void should_ThrowInvalidArgument_When_TeamNameIsBlank() {
+        InvalidTeamException ex = assertThrows(
+            InvalidTeamException.class,
+            () -> teamService.createTeam(new CreateTeamRequest(2L, "   ", null, null))
+        );
+
+        assertEquals("Team name is required.", ex.getMessage());
+    }
+
+    @Test
+    void should_ThrowInvalidArgument_When_WebsiteUrlIsInvalid() {
+        InvalidTeamException ex = assertThrows(
+            InvalidTeamException.class,
+            () -> teamService.createTeam(new CreateTeamRequest(2L, "Requirements Hub", null, "not-a-url"))
+        );
+
+        assertEquals("Team website URL must start with http:// or https://.", ex.getMessage());
+    }
+
+    @Test
+    void should_ReturnCreatedTeamDetailWithEmptyMembersAndInstructors_When_TeamIsCreated() {
+        Section section = buildSection();
+        Team savedTeam = new Team();
+        savedTeam.setTeamId(99L);
+        savedTeam.setSection(section);
+        savedTeam.setTeamName("New Team");
+
+        when(sectionRepository.findById(2L)).thenReturn(Optional.of(section));
+        when(teamRepository.existsByTeamNameIgnoreCase("New Team")).thenReturn(false);
+        when(teamRepository.save(org.mockito.ArgumentMatchers.any(Team.class))).thenReturn(savedTeam);
+
+        TeamDetail detail = teamService.createTeam(new CreateTeamRequest(2L, "New Team", null, null));
+
+        assertEquals(List.of(), detail.teamMemberNames());
+        assertEquals(List.of(), detail.instructorNames());
+    }
+
     private Team buildTeam() {
-        Section section = new Section();
-        section.setSectionId(2L);
-        section.setSectionName("Spring 2026 - Section A");
+        Section section = buildSection();
 
         User student1 = new User();
         student1.setFirstName("Zoe");
@@ -140,5 +264,12 @@ class TeamServiceTest {
         team.setStudents(new LinkedHashSet<>(List.of(student1, student2)));
         team.setInstructors(new LinkedHashSet<>(List.of(instructor1, instructor2)));
         return team;
+    }
+
+    private Section buildSection() {
+        Section section = new Section();
+        section.setSectionId(2L);
+        section.setSectionName("Spring 2026 - Section A");
+        return section;
     }
 }

--- a/src/frontend/src/features/team/pages/Teams.vue
+++ b/src/frontend/src/features/team/pages/Teams.vue
@@ -2,6 +2,9 @@
   <v-container>
     <v-row class="mb-4" align="center">
       <v-col><h2 class="text-h5 font-weight-bold">Senior Design Teams</h2></v-col>
+      <v-col v-if="isAdmin" cols="auto">
+        <v-btn color="primary" prepend-icon="mdi-plus" @click="openCreateDialog">Create Team</v-btn>
+      </v-col>
     </v-row>
 
     <v-row class="mb-4">
@@ -54,6 +57,9 @@
         <v-alert type="info" variant="tonal">
           No matching senior design teams found.
         </v-alert>
+        <v-btn v-if="isAdmin" color="primary" class="mt-4" prepend-icon="mdi-plus" @click="openCreateDialog">
+          Create Team
+        </v-btn>
       </v-col>
     </v-row>
 
@@ -127,22 +133,143 @@
         </v-table>
       </v-col>
     </v-row>
+
+    <v-dialog v-model="dialog" max-width="700" persistent>
+      <v-card>
+        <v-card-title class="pa-4">
+          {{ step === 1 ? 'Create Team' : 'Confirm Team' }}
+        </v-card-title>
+        <v-divider />
+
+        <v-card-text v-if="step === 1" class="pa-4">
+          <v-select
+            v-model="form.sectionId"
+            :items="sections"
+            item-title="sectionName"
+            item-value="sectionId"
+            label="Section"
+            :loading="sectionsLoading"
+            :error-messages="errors.sectionId"
+            class="mb-4"
+          />
+
+          <v-text-field
+            v-model="form.teamName"
+            label="Team Name"
+            placeholder="e.g. Peer Evaluation Tool team"
+            :error-messages="errors.teamName"
+            class="mb-4"
+          />
+
+          <v-textarea
+            v-model="form.teamDescription"
+            label="Team Description"
+            rows="3"
+            class="mb-4"
+          />
+
+          <v-text-field
+            v-model="form.teamWebsiteUrl"
+            label="Team Website URL"
+            placeholder="https://example.com"
+            :error-messages="errors.teamWebsiteUrl"
+          />
+        </v-card-text>
+
+        <v-card-text v-else class="pa-4">
+          <v-alert type="info" variant="tonal" class="mb-4">
+            Please review the team details before confirming.
+          </v-alert>
+          <v-table density="compact">
+            <tbody>
+              <tr>
+                <th class="text-left">Section</th>
+                <td>{{ selectedSectionName }}</td>
+              </tr>
+              <tr>
+                <th class="text-left">Team Name</th>
+                <td>{{ previewPayload.teamName }}</td>
+              </tr>
+              <tr>
+                <th class="text-left">Description</th>
+                <td>{{ previewPayload.teamDescription ?? '—' }}</td>
+              </tr>
+              <tr>
+                <th class="text-left">Website</th>
+                <td>{{ previewPayload.teamWebsiteUrl ?? '—' }}</td>
+              </tr>
+            </tbody>
+          </v-table>
+        </v-card-text>
+
+        <v-divider />
+        <v-card-actions class="pa-4">
+          <v-btn variant="text" @click="cancelCreate">Cancel</v-btn>
+          <v-spacer />
+          <v-btn v-if="step === 2" variant="outlined" @click="step = 1">Modify</v-btn>
+          <v-btn
+            color="primary"
+            :loading="saving"
+            @click="step === 1 ? goToPreview() : confirmCreate()"
+          >
+            {{ step === 1 ? 'Preview' : 'Confirm' }}
+          </v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
+
+    <v-snackbar v-model="snackbar.show" :color="snackbar.color" timeout="3000">
+      {{ snackbar.message }}
+    </v-snackbar>
   </v-container>
 </template>
 
 <script setup lang="ts">
-import { onMounted, ref } from 'vue'
+import { computed, onMounted, ref } from 'vue'
 import { useRouter } from 'vue-router'
-import { findTeams } from '../services/teamService'
-import type { FindTeamsParams, TeamSummary } from '../services/teamTypes'
+import { findSections } from '@/features/section/services/sectionService'
+import { useUserInfoStore } from '@/stores/userInfo'
+import { createTeam, findTeams } from '../services/teamService'
+import type { SectionSummary } from '@/features/section/services/sectionTypes'
+import type { CreateTeamRequest, FindTeamsParams, TeamSummary } from '../services/teamTypes'
 
 const router = useRouter()
+const userInfoStore = useUserInfoStore()
 const teams = ref<TeamSummary[]>([])
 const loading = ref(false)
 const filters = ref<FindTeamsParams>({
   sectionName: '',
   teamName: '',
   instructor: ''
+})
+const dialog = ref(false)
+const step = ref(1)
+const saving = ref(false)
+const sectionsLoading = ref(false)
+const sections = ref<SectionSummary[]>([])
+
+const emptyForm = () => ({
+  sectionId: null as number | null,
+  teamName: '',
+  teamDescription: '',
+  teamWebsiteUrl: ''
+})
+
+const form = ref(emptyForm())
+const errors = ref<{ sectionId?: string; teamName?: string; teamWebsiteUrl?: string }>({})
+const snackbar = ref({ show: false, message: '', color: 'success' })
+
+const isAdmin = computed(() => userInfoStore.isAdmin)
+
+const previewPayload = computed<CreateTeamRequest>(() => ({
+  sectionId: form.value.sectionId ?? 0,
+  teamName: form.value.teamName.trim(),
+  teamDescription: normalizeOptional(form.value.teamDescription),
+  teamWebsiteUrl: normalizeOptional(form.value.teamWebsiteUrl)
+}))
+
+const selectedSectionName = computed(() => {
+  return sections.value.find((section) => section.sectionId === form.value.sectionId)?.sectionName ?? '—'
 })
 
 onMounted(() => search())
@@ -171,6 +298,96 @@ function clearFilters() {
 
 function viewTeam(teamId: number) {
   router.push({ name: 'team-detail', params: { id: teamId } })
+}
+
+async function openCreateDialog() {
+  form.value = emptyForm()
+  errors.value = {}
+  step.value = 1
+  dialog.value = true
+  await loadSections()
+}
+
+function cancelCreate() {
+  dialog.value = false
+}
+
+async function loadSections() {
+  sectionsLoading.value = true
+  try {
+    const res = await findSections() as any
+    sections.value = res.flag ? (res.data ?? []) : []
+  } catch {
+    sections.value = []
+    snackbar.value = { show: true, message: 'Failed to load sections.', color: 'error' }
+  } finally {
+    sectionsLoading.value = false
+  }
+}
+
+function validate(): boolean {
+  errors.value = {}
+  let valid = true
+
+  if (!form.value.sectionId) {
+    errors.value.sectionId = 'Section is required.'
+    valid = false
+  }
+
+  if (!form.value.teamName.trim()) {
+    errors.value.teamName = 'Team name is required.'
+    valid = false
+  }
+
+  const website = normalizeOptional(form.value.teamWebsiteUrl)
+  if (website && !isValidAbsoluteHttpUrl(website)) {
+    errors.value.teamWebsiteUrl = 'Team website URL must be a valid http:// or https:// URL.'
+    valid = false
+  }
+
+  return valid
+}
+
+function goToPreview() {
+  if (validate()) {
+    step.value = 2
+  }
+}
+
+async function confirmCreate() {
+  saving.value = true
+  try {
+    const res = await createTeam(previewPayload.value) as any
+    if (res.flag && res.data) {
+      snackbar.value = { show: true, message: 'Team created successfully.', color: 'success' }
+      dialog.value = false
+      router.push({ name: 'team-detail', params: { id: res.data.teamId } })
+      return
+    }
+
+    step.value = 1
+    snackbar.value = { show: true, message: res.message || 'Failed to create team.', color: 'error' }
+  } catch (error: any) {
+    step.value = 1
+    const message = error?.response?.data?.message || 'An error occurred. Please try again.'
+    snackbar.value = { show: true, message, color: 'error' }
+  } finally {
+    saving.value = false
+  }
+}
+
+function normalizeOptional(value: string | null | undefined) {
+  const trimmed = value?.trim() ?? ''
+  return trimmed ? trimmed : null
+}
+
+function isValidAbsoluteHttpUrl(value: string) {
+  try {
+    const url = new URL(value)
+    return url.protocol === 'http:' || url.protocol === 'https:'
+  } catch {
+    return false
+  }
 }
 </script>
 

--- a/src/frontend/src/features/team/services/teamService.ts
+++ b/src/frontend/src/features/team/services/teamService.ts
@@ -1,6 +1,6 @@
 import request from '@/shared/utils/request'
 import type { ApiResponse } from '@/shared/types/api'
-import type { FindTeamsParams, TeamDetail, TeamSummary } from './teamTypes'
+import type { CreateTeamRequest, FindTeamsParams, TeamDetail, TeamSummary } from './teamTypes'
 
 const BASE = '/teams'
 
@@ -9,3 +9,6 @@ export const findTeams = (params?: FindTeamsParams) =>
 
 export const getTeam = (id: number) =>
   request.get<ApiResponse<TeamDetail>>(`${BASE}/${id}`)
+
+export const createTeam = (payload: CreateTeamRequest) =>
+  request.post<ApiResponse<TeamDetail>>(BASE, payload)

--- a/src/frontend/src/features/team/services/teamTypes.ts
+++ b/src/frontend/src/features/team/services/teamTypes.ts
@@ -20,6 +20,13 @@ export interface TeamDetail {
   instructorNames: string[]
 }
 
+export interface CreateTeamRequest {
+  sectionId: number
+  teamName: string
+  teamDescription: string | null
+  teamWebsiteUrl: string | null
+}
+
 export interface FindTeamsParams {
   sectionId?: number
   sectionName?: string


### PR DESCRIPTION
Implement UC-9 admin team creation flow
Add create team API, validation, and duplicate detection
Add admin-only create dialog on Teams page with preview/confirm step
Redirect to team detail after successful creation
Add backend coverage for create scenarios