### PR TITLE
feat(uc-25): implement student account setup via invite link

### DIFF
--- a/docs/development-plan.md
+++ b/docs/development-plan.md
@@ -34,7 +34,7 @@ Modules: `auth`, `section`, `rubric`
 | UC-4 | Create a senior design section | Done |
 | UC-5 | Edit a senior design section | Done |
 | UC-6 | Set up active weeks for a section | Done |
-| UC-25 | Student sets up a student account | Not started |
+| UC-25 | Student sets up a student account | Done |
 | UC-31 | Generate peer eval report for entire section | Not started |
 | UC-32 | Generate WAR report for a team | Not started |
 | UC-33 | Generate peer eval report for a student | Not started |

--- a/src/backend/src/main/java/team/projectpulse/auth/controller/AuthController.java
+++ b/src/backend/src/main/java/team/projectpulse/auth/controller/AuthController.java
@@ -5,6 +5,8 @@ import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
+import team.projectpulse.auth.dto.InviteTokenInfo;
+import team.projectpulse.auth.dto.StudentRegisterRequest;
 import team.projectpulse.auth.service.AuthService;
 import team.projectpulse.config.JwtUtils;
 import team.projectpulse.system.Result;
@@ -58,6 +60,17 @@ public class AuthController {
     @PostMapping("/register")
     public Result<Void> register(@RequestBody RegisterRequest request) {
         authService.registerStudent(request);
+        return Result.success("Account created. Please log in.", null);
+    }
+
+    @GetMapping("/join")
+    public Result<InviteTokenInfo> validateJoinToken(@RequestParam String token) {
+        return Result.success(authService.validateStudentInviteToken(token));
+    }
+
+    @PostMapping("/join")
+    public Result<Void> joinWithToken(@RequestBody StudentRegisterRequest request) {
+        authService.registerStudentWithToken(request);
         return Result.success("Account created. Please log in.", null);
     }
 }

--- a/src/backend/src/main/java/team/projectpulse/auth/controller/AuthExceptionHandler.java
+++ b/src/backend/src/main/java/team/projectpulse/auth/controller/AuthExceptionHandler.java
@@ -5,6 +5,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import team.projectpulse.system.Result;
+import team.projectpulse.user.domain.InvalidInviteTokenException;
 import team.projectpulse.user.domain.UserAlreadyExistsException;
 
 @RestControllerAdvice
@@ -14,5 +15,11 @@ public class AuthExceptionHandler {
     @ResponseStatus(HttpStatus.CONFLICT)
     Result<Void> handleAlreadyExists(UserAlreadyExistsException ex) {
         return Result.conflict(ex.getMessage());
+    }
+
+    @ExceptionHandler(InvalidInviteTokenException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    Result<Void> handleInvalidToken(InvalidInviteTokenException ex) {
+        return Result.error(400, ex.getMessage());
     }
 }

--- a/src/backend/src/main/java/team/projectpulse/auth/dto/InviteTokenInfo.java
+++ b/src/backend/src/main/java/team/projectpulse/auth/dto/InviteTokenInfo.java
@@ -1,0 +1,3 @@
+package team.projectpulse.auth.dto;
+
+public record InviteTokenInfo(String email, String sectionName) {}

--- a/src/backend/src/main/java/team/projectpulse/auth/dto/StudentRegisterRequest.java
+++ b/src/backend/src/main/java/team/projectpulse/auth/dto/StudentRegisterRequest.java
@@ -1,0 +1,8 @@
+package team.projectpulse.auth.dto;
+
+public record StudentRegisterRequest(
+        String token,
+        String firstName,
+        String lastName,
+        String password
+) {}

--- a/src/backend/src/main/java/team/projectpulse/auth/service/AuthService.java
+++ b/src/backend/src/main/java/team/projectpulse/auth/service/AuthService.java
@@ -2,20 +2,37 @@ package team.projectpulse.auth.service;
 
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import team.projectpulse.auth.dto.InviteTokenInfo;
+import team.projectpulse.auth.dto.StudentRegisterRequest;
+import team.projectpulse.section.domain.Section;
+import team.projectpulse.section.repository.SectionRepository;
+import team.projectpulse.user.domain.InvalidInviteTokenException;
+import team.projectpulse.user.domain.StudentInviteToken;
 import team.projectpulse.user.domain.User;
 import team.projectpulse.user.domain.UserAlreadyExistsException;
 import team.projectpulse.user.dto.RegisterRequest;
+import team.projectpulse.user.repository.StudentInviteTokenRepository;
 import team.projectpulse.user.repository.UserRepository;
+
+import java.time.LocalDateTime;
 
 @Service
 public class AuthService {
 
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
+    private final StudentInviteTokenRepository tokenRepository;
+    private final SectionRepository sectionRepository;
 
-    public AuthService(UserRepository userRepository, PasswordEncoder passwordEncoder) {
+    public AuthService(UserRepository userRepository,
+                       PasswordEncoder passwordEncoder,
+                       StudentInviteTokenRepository tokenRepository,
+                       SectionRepository sectionRepository) {
         this.userRepository = userRepository;
         this.passwordEncoder = passwordEncoder;
+        this.tokenRepository = tokenRepository;
+        this.sectionRepository = sectionRepository;
     }
 
     public User registerStudent(RegisterRequest req) {
@@ -35,5 +52,51 @@ public class AuthService {
         user.setRoles(role);
         user.setEnabled(true);
         return userRepository.save(user);
+    }
+
+    public InviteTokenInfo validateStudentInviteToken(String token) {
+        StudentInviteToken invite = tokenRepository.findByToken(token)
+                .orElseThrow(InvalidInviteTokenException::new);
+
+        if (invite.isUsed() || invite.getExpiresAt().isBefore(LocalDateTime.now())) {
+            throw new InvalidInviteTokenException();
+        }
+
+        if (userRepository.existsByEmailIgnoreCase(invite.getEmail())) {
+            throw new UserAlreadyExistsException(invite.getEmail());
+        }
+
+        String sectionName = sectionRepository.findById(invite.getSectionId())
+                .map(Section::getSectionName)
+                .orElse(null);
+
+        return new InviteTokenInfo(invite.getEmail(), sectionName);
+    }
+
+    @Transactional
+    public void registerStudentWithToken(StudentRegisterRequest req) {
+        StudentInviteToken invite = tokenRepository.findByToken(req.token())
+                .orElseThrow(InvalidInviteTokenException::new);
+
+        if (invite.isUsed() || invite.getExpiresAt().isBefore(LocalDateTime.now())) {
+            throw new InvalidInviteTokenException();
+        }
+
+        String email = invite.getEmail().trim().toLowerCase();
+        if (userRepository.existsByEmailIgnoreCase(email)) {
+            throw new UserAlreadyExistsException(email);
+        }
+
+        User user = new User();
+        user.setFirstName(req.firstName().trim());
+        user.setLastName(req.lastName().trim());
+        user.setEmail(email);
+        user.setPassword(passwordEncoder.encode(req.password()));
+        user.setRoles("student");
+        user.setEnabled(true);
+        userRepository.save(user);
+
+        invite.setUsed(true);
+        tokenRepository.save(invite);
     }
 }

--- a/src/backend/src/main/java/team/projectpulse/config/SecurityConfig.java
+++ b/src/backend/src/main/java/team/projectpulse/config/SecurityConfig.java
@@ -50,6 +50,8 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(HttpMethod.POST, "/api/v1/auth/login").permitAll()
                         .requestMatchers(HttpMethod.POST, "/api/v1/auth/register").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/v1/auth/join").permitAll()
+                        .requestMatchers(HttpMethod.POST, "/api/v1/auth/join").permitAll()
                         .requestMatchers(HttpMethod.POST, "/api/v1/auth/forget-password/**").permitAll()
                         .requestMatchers(HttpMethod.PATCH, "/api/v1/auth/reset-password").permitAll()
                         .requestMatchers("/actuator/**").permitAll()

--- a/src/backend/src/main/java/team/projectpulse/user/domain/InvalidInviteTokenException.java
+++ b/src/backend/src/main/java/team/projectpulse/user/domain/InvalidInviteTokenException.java
@@ -1,0 +1,7 @@
+package team.projectpulse.user.domain;
+
+public class InvalidInviteTokenException extends RuntimeException {
+    public InvalidInviteTokenException() {
+        super("This invite link is invalid or has expired.");
+    }
+}

--- a/src/backend/src/main/java/team/projectpulse/user/domain/StudentInviteToken.java
+++ b/src/backend/src/main/java/team/projectpulse/user/domain/StudentInviteToken.java
@@ -1,0 +1,46 @@
+package team.projectpulse.user.domain;
+
+import jakarta.persistence.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "student_invite_tokens")
+public class StudentInviteToken {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String token;
+
+    @Column(nullable = false)
+    private String email;
+
+    @Column(name = "section_id", nullable = false)
+    private Long sectionId;
+
+    @Column(name = "expires_at", nullable = false)
+    private LocalDateTime expiresAt;
+
+    @Column(nullable = false)
+    private boolean used = false;
+
+    public Long getId()                        { return id; }
+    public void setId(Long id)                 { this.id = id; }
+
+    public String getToken()                   { return token; }
+    public void setToken(String token)         { this.token = token; }
+
+    public String getEmail()                   { return email; }
+    public void setEmail(String email)         { this.email = email; }
+
+    public Long getSectionId()                 { return sectionId; }
+    public void setSectionId(Long sectionId)   { this.sectionId = sectionId; }
+
+    public LocalDateTime getExpiresAt()        { return expiresAt; }
+    public void setExpiresAt(LocalDateTime v)  { this.expiresAt = v; }
+
+    public boolean isUsed()                    { return used; }
+    public void setUsed(boolean used)          { this.used = used; }
+}

--- a/src/backend/src/main/java/team/projectpulse/user/repository/StudentInviteTokenRepository.java
+++ b/src/backend/src/main/java/team/projectpulse/user/repository/StudentInviteTokenRepository.java
@@ -1,0 +1,11 @@
+package team.projectpulse.user.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import team.projectpulse.user.domain.StudentInviteToken;
+
+import java.util.Optional;
+
+public interface StudentInviteTokenRepository extends JpaRepository<StudentInviteToken, Long> {
+    Optional<StudentInviteToken> findByToken(String token);
+    Optional<StudentInviteToken> findByEmailIgnoreCaseAndSectionId(String email, Long sectionId);
+}

--- a/src/backend/src/main/resources/db/migration/V5__student_invite_tokens.sql
+++ b/src/backend/src/main/resources/db/migration/V5__student_invite_tokens.sql
@@ -1,0 +1,12 @@
+-- V5: Student invite tokens
+
+CREATE TABLE IF NOT EXISTS student_invite_tokens (
+    id          BIGINT AUTO_INCREMENT PRIMARY KEY,
+    token       VARCHAR(255) NOT NULL UNIQUE,
+    email       VARCHAR(255) NOT NULL,
+    section_id  BIGINT       NOT NULL,
+    expires_at  TIMESTAMP    NOT NULL,
+    used        BOOLEAN      NOT NULL DEFAULT FALSE,
+    created_at  TIMESTAMP    DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (section_id) REFERENCES sections(section_id) ON DELETE CASCADE
+);

--- a/src/frontend/src/features/auth/pages/JoinSection.vue
+++ b/src/frontend/src/features/auth/pages/JoinSection.vue
@@ -1,0 +1,225 @@
+<template>
+  <div class="join-page">
+    <v-card class="join-card" rounded="lg">
+
+      <!-- Already registered -->
+      <template v-if="tokenState === 'already-registered'">
+        <v-card-text class="pa-8 text-center">
+          <v-icon size="64" color="info" class="mb-4">mdi-account-check</v-icon>
+          <h2 class="mb-2">Already Registered</h2>
+          <p class="text-medium-emphasis mb-2">You already have an account. Redirecting you to login...</p>
+          <v-progress-linear indeterminate color="primary" class="mb-4" />
+          <v-btn color="primary" @click="router.replace({ name: 'login' })">Go to Login</v-btn>
+        </v-card-text>
+      </template>
+
+      <!-- Invalid / expired token -->
+      <template v-else-if="tokenState === 'invalid'">
+        <v-card-text class="pa-8 text-center">
+          <v-icon size="64" color="error" class="mb-4">mdi-link-off</v-icon>
+          <h2 class="mb-2">Invalid Invite Link</h2>
+          <p class="text-medium-emphasis mb-6">This invite link is invalid or has expired. Please ask your admin for a new link.</p>
+          <v-btn color="primary" @click="router.push({ name: 'login' })">Go to Login</v-btn>
+        </v-card-text>
+      </template>
+
+      <!-- Loading -->
+      <template v-else-if="tokenState === 'loading'">
+        <v-card-text class="pa-8 text-center">
+          <v-progress-circular indeterminate color="primary" class="mb-4" />
+          <p class="text-medium-emphasis">Validating your invite link...</p>
+        </v-card-text>
+      </template>
+
+      <!-- Registration form -->
+      <template v-else>
+        <v-card-title class="pt-6 px-6">
+          <h2>Set Up Your Account</h2>
+          <p class="subtitle">You've been invited to join <strong>{{ sectionName }}</strong>.</p>
+        </v-card-title>
+
+        <v-card-text class="px-6">
+
+          <!-- Step 1: Enter details -->
+          <v-form v-if="step === 1" ref="formRef" @submit.prevent>
+            <v-text-field
+              v-model="form.firstName"
+              label="First Name"
+              variant="outlined"
+              density="comfortable"
+              class="mb-3"
+              :rules="[(v) => !!v || 'First name is required.']"
+            />
+            <v-text-field
+              v-model="form.lastName"
+              label="Last Name"
+              variant="outlined"
+              density="comfortable"
+              class="mb-3"
+              :rules="[(v) => !!v || 'Last name is required.']"
+            />
+            <v-text-field
+              v-model="email"
+              label="Email"
+              variant="outlined"
+              density="comfortable"
+              class="mb-3"
+              readonly
+              disabled
+            />
+            <v-text-field
+              v-model="form.password"
+              label="Password"
+              :type="showPwd ? 'text' : 'password'"
+              :append-inner-icon="showPwd ? 'mdi-eye-off' : 'mdi-eye'"
+              @click:append-inner="showPwd = !showPwd"
+              variant="outlined"
+              density="comfortable"
+              class="mb-3"
+              :rules="[(v) => !!v && v.length >= 6 || 'Password must be at least 6 characters.']"
+            />
+            <v-text-field
+              v-model="form.confirmPassword"
+              label="Confirm Password"
+              :type="showConfirm ? 'text' : 'password'"
+              :append-inner-icon="showConfirm ? 'mdi-eye-off' : 'mdi-eye'"
+              @click:append-inner="showConfirm = !showConfirm"
+              variant="outlined"
+              density="comfortable"
+              class="mb-4"
+              :rules="[
+                (v) => !!v || 'Please confirm your password.',
+                (v) => v === form.password || 'Passwords do not match.'
+              ]"
+            />
+            <v-btn block color="primary" size="large" @click="goToPreview">Preview</v-btn>
+          </v-form>
+
+          <!-- Step 2: Preview & confirm -->
+          <template v-else>
+            <v-alert type="info" variant="tonal" class="mb-4">
+              Please review your details before confirming.
+            </v-alert>
+            <v-list density="compact" class="mb-4">
+              <v-list-item title="First Name" :subtitle="form.firstName" />
+              <v-list-item title="Last Name" :subtitle="form.lastName" />
+              <v-list-item title="Email" :subtitle="email" />
+              <v-list-item title="Section" :subtitle="sectionName ?? '—'" />
+            </v-list>
+            <v-row>
+              <v-col>
+                <v-btn block variant="outlined" @click="step = 1">Modify</v-btn>
+              </v-col>
+              <v-col>
+                <v-btn block color="primary" :loading="submitting" @click="confirmRegister">
+                  Confirm
+                </v-btn>
+              </v-col>
+            </v-row>
+          </template>
+
+        </v-card-text>
+      </template>
+
+    </v-card>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, onMounted } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import { validateJoinToken, registerWithToken } from '@/features/auth/services/authService'
+import { useNotifyStore } from '@/stores/notify'
+
+const route = useRoute()
+const router = useRouter()
+const notify = useNotifyStore()
+
+type TokenState = 'loading' | 'valid' | 'invalid' | 'already-registered'
+
+const tokenState = ref<TokenState>('loading')
+const token = ref('')
+const email = ref('')
+const sectionName = ref<string | null>(null)
+const step = ref(1)
+const submitting = ref(false)
+const showPwd = ref(false)
+const showConfirm = ref(false)
+const formRef = ref()
+
+const form = ref({ firstName: '', lastName: '', password: '', confirmPassword: '' })
+
+onMounted(async () => {
+  token.value = (route.query.token as string) ?? ''
+  if (!token.value) {
+    tokenState.value = 'invalid'
+    return
+  }
+  try {
+    const res = await validateJoinToken(token.value) as any
+    if (res.flag) {
+      email.value = res.data.email
+      sectionName.value = res.data.sectionName
+      tokenState.value = 'valid'
+    } else {
+      tokenState.value = 'invalid'
+    }
+  } catch (err: any) {
+    if (err?.response?.status === 409) {
+      tokenState.value = 'already-registered'
+      setTimeout(() => router.replace({ name: 'login' }), 3000)
+    } else {
+      tokenState.value = 'invalid'
+    }
+  }
+})
+
+async function goToPreview() {
+  const { valid } = await formRef.value.validate()
+  if (valid) step.value = 2
+}
+
+async function confirmRegister() {
+  submitting.value = true
+  try {
+    const res = await registerWithToken({
+      token: token.value,
+      firstName: form.value.firstName,
+      lastName: form.value.lastName,
+      password: form.value.password,
+    }) as any
+    if (res.flag) {
+      notify.success('Account created! Please log in.')
+      router.push({ name: 'login' })
+    } else {
+      notify.error(res.message)
+      step.value = 1
+    }
+  } catch (err: any) {
+    const msg = err?.response?.data?.message || 'An error occurred. Please try again.'
+    notify.error(msg)
+    step.value = 1
+  } finally {
+    submitting.value = false
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+.join-page {
+  min-height: 100vh;
+  background: #f0f2f5;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 40px 20px;
+
+  .join-card {
+    width: 100%;
+    max-width: 520px;
+
+    h2 { margin: 0 0 4px; font-size: 22px; font-weight: 700; color: #1a2744; }
+    .subtitle { margin: 0; color: #909399; font-size: 14px; }
+  }
+}
+</style>

--- a/src/frontend/src/features/auth/services/authService.ts
+++ b/src/frontend/src/features/auth/services/authService.ts
@@ -33,3 +33,9 @@ export const resetUserPassword = (email: string, token: string, newPassword: str
 
 export const changePassword = (payload: ChangePasswordRequest) =>
   request.patch<any, ChangePasswordResponse>(`${API.USERS}/change-password`, payload)
+
+export const validateJoinToken = (token: string) =>
+  request.get<any>(`${API.AUTH}/join`, { params: { token } })
+
+export const registerWithToken = (payload: { token: string; firstName: string; lastName: string; password: string }) =>
+  request.post<any>(`${API.AUTH}/join`, payload)

--- a/src/frontend/src/router/routes.ts
+++ b/src/frontend/src/router/routes.ts
@@ -27,6 +27,13 @@ export const routes = [
     meta: { requiresAuth: false, visitorOnly: true }
   },
 
+  {
+    path: '/join',
+    component: () => import('@/features/auth/pages/JoinSection.vue'),
+    name: 'join-section',
+    meta: { requiresAuth: false }
+  },
+
   // ─── Main App (authenticated) ────────────────────────────────────────────
   {
     path: '/',


### PR DESCRIPTION
- Add V5 Flyway migration for student_invite_tokens table
- Add StudentInviteToken entity and repository in user module
- Add validateStudentInviteToken and registerStudentWithToken to AuthService
- Add GET/POST /auth/join endpoints in AuthController
- Handle InvalidInviteTokenException (400) and already-registered (409)
- Permit /auth/join endpoints in SecurityConfig
- Add /join route and JoinSection.vue with 2-step registration form
- Show already-registered state with auto-redirect after 3s on 409