### PR TITLE
feat(uc-10): implement edit senior design team flow

### DIFF
--- a/src/backend/src/main/java/team/projectpulse/team/controller/TeamController.java
+++ b/src/backend/src/main/java/team/projectpulse/team/controller/TeamController.java
@@ -4,6 +4,7 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -12,6 +13,7 @@ import team.projectpulse.system.Result;
 import team.projectpulse.team.dto.CreateTeamRequest;
 import team.projectpulse.team.dto.TeamDetail;
 import team.projectpulse.team.dto.TeamSummary;
+import team.projectpulse.team.dto.UpdateTeamRequest;
 import team.projectpulse.team.service.TeamService;
 
 import java.util.List;
@@ -47,5 +49,11 @@ public class TeamController {
     @PreAuthorize("hasRole('ADMIN')")
     public Result<TeamDetail> createTeam(@RequestBody CreateTeamRequest request) {
         return Result.success("Team created successfully.", teamService.createTeam(request));
+    }
+
+    @PutMapping("/{id}")
+    @PreAuthorize("hasRole('ADMIN')")
+    public Result<TeamDetail> updateTeam(@PathVariable Long id, @RequestBody UpdateTeamRequest request) {
+        return Result.success("Team updated successfully.", teamService.updateTeam(id, request));
     }
 }

--- a/src/backend/src/main/java/team/projectpulse/team/dto/UpdateTeamRequest.java
+++ b/src/backend/src/main/java/team/projectpulse/team/dto/UpdateTeamRequest.java
@@ -1,0 +1,8 @@
+package team.projectpulse.team.dto;
+
+public record UpdateTeamRequest(
+    String teamName,
+    String teamDescription,
+    String teamWebsiteUrl
+) {
+}

--- a/src/backend/src/main/java/team/projectpulse/team/repository/TeamRepository.java
+++ b/src/backend/src/main/java/team/projectpulse/team/repository/TeamRepository.java
@@ -12,6 +12,8 @@ public interface TeamRepository extends JpaRepository<Team, Long> {
 
     boolean existsByTeamNameIgnoreCase(String teamName);
 
+    boolean existsByTeamNameIgnoreCaseAndTeamIdNot(String teamName, Long teamId);
+
     @Query("""
         select distinct t from Team t
         join fetch t.section s

--- a/src/backend/src/main/java/team/projectpulse/team/service/TeamService.java
+++ b/src/backend/src/main/java/team/projectpulse/team/service/TeamService.java
@@ -10,6 +10,7 @@ import team.projectpulse.team.domain.TeamNotFoundException;
 import team.projectpulse.team.dto.CreateTeamRequest;
 import team.projectpulse.team.dto.TeamDetail;
 import team.projectpulse.team.dto.TeamSummary;
+import team.projectpulse.team.dto.UpdateTeamRequest;
 import team.projectpulse.team.repository.TeamRepository;
 import team.projectpulse.user.domain.User;
 
@@ -73,6 +74,31 @@ public class TeamService {
 
         Team team = new Team();
         team.setSection(section);
+        team.setTeamName(normalizedName);
+        team.setTeamDescription(normalizedDescription);
+        team.setTeamWebsiteUrl(normalizedWebsite);
+
+        return toDetail(teamRepository.save(team));
+    }
+
+    public TeamDetail updateTeam(Long id, UpdateTeamRequest request) {
+        if (request == null) {
+            throw new InvalidTeamException("Team request is required.");
+        }
+
+        Team team = teamRepository.findDetailById(id)
+            .orElseThrow(() -> new TeamNotFoundException(id));
+
+        String normalizedName = requireTeamName(request.teamName());
+        String normalizedDescription = normalizeNullable(request.teamDescription());
+        String normalizedWebsite = normalizeNullable(request.teamWebsiteUrl());
+
+        validateWebsite(normalizedWebsite);
+
+        if (teamRepository.existsByTeamNameIgnoreCaseAndTeamIdNot(normalizedName, id)) {
+            throw new TeamAlreadyExistsException(normalizedName);
+        }
+
         team.setTeamName(normalizedName);
         team.setTeamDescription(normalizedDescription);
         team.setTeamWebsiteUrl(normalizedWebsite);

--- a/src/backend/src/test/java/team/projectpulse/team/controller/TeamControllerIntegrationTest.java
+++ b/src/backend/src/test/java/team/projectpulse/team/controller/TeamControllerIntegrationTest.java
@@ -24,6 +24,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -257,5 +258,109 @@ class TeamControllerIntegrationTest {
             .andExpect(jsonPath("$.flag").value(false))
             .andExpect(jsonPath("$.code").value(404))
             .andExpect(jsonPath("$.message").value("No section found with id: 999"));
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void should_UpdateTeamWrappedInResult_When_AdminRequestsUpdate() throws Exception {
+        when(teamService.updateTeam(eq(10L), org.mockito.ArgumentMatchers.any()))
+            .thenReturn(new TeamDetail(
+                10L,
+                2L,
+                "Spring 2026 - Section A",
+                "Requirements Hub",
+                "Centralized workspace",
+                "https://requirements-hub.example.com",
+                List.of(),
+                List.of("Ivy Stone")
+            ));
+
+        mockMvc.perform(put("/api/v1/teams/10")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                    {
+                      "teamName": "Requirements Hub",
+                      "teamDescription": "Centralized workspace",
+                      "teamWebsiteUrl": "https://requirements-hub.example.com"
+                    }
+                    """))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.flag").value(true))
+            .andExpect(jsonPath("$.message").value("Team updated successfully."))
+            .andExpect(jsonPath("$.data.teamId").value(10))
+            .andExpect(jsonPath("$.data.teamName").value("Requirements Hub"));
+
+        verify(teamService).updateTeam(eq(10L), org.mockito.ArgumentMatchers.any());
+    }
+
+    @Test
+    @WithMockUser(roles = "INSTRUCTOR")
+    void should_ReturnForbidden_When_InstructorRequestsUpdate() throws Exception {
+        mockMvc.perform(put("/api/v1/teams/10")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"teamName\":\"Requirements Hub\"}"))
+            .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @WithMockUser(roles = "STUDENT")
+    void should_ReturnForbidden_When_StudentRequestsUpdate() throws Exception {
+        mockMvc.perform(put("/api/v1/teams/10")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"teamName\":\"Requirements Hub\"}"))
+            .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void should_ReturnUnauthorized_When_UnauthenticatedRequestUpdatesTeam() throws Exception {
+        mockMvc.perform(put("/api/v1/teams/10")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"teamName\":\"Requirements Hub\"}"))
+            .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void should_ReturnNotFound_When_UpdatedTeamDoesNotExist() throws Exception {
+        when(teamService.updateTeam(eq(999L), org.mockito.ArgumentMatchers.any()))
+            .thenThrow(new TeamNotFoundException(999L));
+
+        mockMvc.perform(put("/api/v1/teams/999")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"teamName\":\"Requirements Hub\"}"))
+            .andExpect(status().isNotFound())
+            .andExpect(jsonPath("$.flag").value(false))
+            .andExpect(jsonPath("$.code").value(404))
+            .andExpect(jsonPath("$.message").value("No team found with id: 999"));
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void should_ReturnConflict_When_UpdatedTeamNameAlreadyExists() throws Exception {
+        when(teamService.updateTeam(eq(10L), org.mockito.ArgumentMatchers.any()))
+            .thenThrow(new TeamAlreadyExistsException("Requirements Hub"));
+
+        mockMvc.perform(put("/api/v1/teams/10")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"teamName\":\"Requirements Hub\"}"))
+            .andExpect(status().isConflict())
+            .andExpect(jsonPath("$.flag").value(false))
+            .andExpect(jsonPath("$.code").value(409))
+            .andExpect(jsonPath("$.message").value("Team already exists with name: Requirements Hub"));
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void should_ReturnBadRequest_When_UpdateRequestIsInvalid() throws Exception {
+        when(teamService.updateTeam(eq(10L), org.mockito.ArgumentMatchers.any()))
+            .thenThrow(new InvalidTeamException("Team name is required."));
+
+        mockMvc.perform(put("/api/v1/teams/10")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"teamName\":\"   \"}"))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.flag").value(false))
+            .andExpect(jsonPath("$.code").value(400))
+            .andExpect(jsonPath("$.message").value("Team name is required."));
     }
 }

--- a/src/backend/src/test/java/team/projectpulse/team/repository/TeamRepositoryIntegrationTest.java
+++ b/src/backend/src/test/java/team/projectpulse/team/repository/TeamRepositoryIntegrationTest.java
@@ -59,7 +59,7 @@ class TeamRepositoryIntegrationTest {
     void should_FetchSectionStudentsAndInstructors_When_FindingTeamDetailById() {
         SeededData data = seedTeams();
 
-        Optional<Team> teamOptional = teamRepository.findDetailById(data.teamAlphaId());
+        Optional<Team> teamOptional = teamRepository.findDetailById(data.pulseAnalyticsId());
 
         assertTrue(teamOptional.isPresent());
         Team team = teamOptional.get();
@@ -96,6 +96,33 @@ class TeamRepositoryIntegrationTest {
         assertEquals(false, exists);
     }
 
+    @Test
+    void should_ReturnTrue_When_AnotherTeamHasSameNameIgnoringCase() {
+        SeededData data = seedTeams();
+
+        boolean exists = teamRepository.existsByTeamNameIgnoreCaseAndTeamIdNot("pulse analytics", data.reviewBoardId());
+
+        assertTrue(exists);
+    }
+
+    @Test
+    void should_ReturnFalse_When_OnlySameTeamHasThatName() {
+        SeededData data = seedTeams();
+
+        boolean exists = teamRepository.existsByTeamNameIgnoreCaseAndTeamIdNot("pulse analytics", data.pulseAnalyticsId());
+
+        assertEquals(false, exists);
+    }
+
+    @Test
+    void should_ReturnFalse_When_NameDoesNotExistForDifferentTeam() {
+        SeededData data = seedTeams();
+
+        boolean exists = teamRepository.existsByTeamNameIgnoreCaseAndTeamIdNot("Missing Team", data.pulseAnalyticsId());
+
+        assertEquals(false, exists);
+    }
+
     private SeededData seedTeams() {
         Section sectionA = new Section();
         sectionA.setSectionName("Spring 2026 - Section A");
@@ -124,7 +151,7 @@ class TeamRepositoryIntegrationTest {
         entityManager.flush();
         entityManager.clear();
 
-        return new SeededData("Review Board", "Pulse Analytics", "Gamma Studio", pulse.getTeamId());
+        return new SeededData("Review Board", "Pulse Analytics", "Gamma Studio", pulse.getTeamId(), review.getTeamId());
     }
 
     private User persistUser(String firstName, String lastName, String email, String roles) {
@@ -151,5 +178,5 @@ class TeamRepositoryIntegrationTest {
         return team;
     }
 
-    private record SeededData(String teamBravo, String teamAlpha, String teamGamma, Long teamAlphaId) {}
+    private record SeededData(String teamBravo, String teamAlpha, String teamGamma, Long pulseAnalyticsId, Long reviewBoardId) {}
 }

--- a/src/backend/src/test/java/team/projectpulse/team/service/TeamServiceTest.java
+++ b/src/backend/src/test/java/team/projectpulse/team/service/TeamServiceTest.java
@@ -15,6 +15,7 @@ import team.projectpulse.team.domain.TeamNotFoundException;
 import team.projectpulse.team.dto.CreateTeamRequest;
 import team.projectpulse.team.dto.TeamDetail;
 import team.projectpulse.team.dto.TeamSummary;
+import team.projectpulse.team.dto.UpdateTeamRequest;
 import team.projectpulse.team.repository.TeamRepository;
 import team.projectpulse.user.domain.User;
 
@@ -234,6 +235,111 @@ class TeamServiceTest {
 
         assertEquals(List.of(), detail.teamMemberNames());
         assertEquals(List.of(), detail.instructorNames());
+    }
+
+    @Test
+    void should_UpdateTeam_When_RequestIsValid() {
+        Team existingTeam = buildTeam();
+        when(teamRepository.findDetailById(10L)).thenReturn(Optional.of(existingTeam));
+        when(teamRepository.existsByTeamNameIgnoreCaseAndTeamIdNot("Requirements Hub", 10L)).thenReturn(false);
+        when(teamRepository.save(existingTeam)).thenReturn(existingTeam);
+
+        TeamDetail detail = teamService.updateTeam(10L, new UpdateTeamRequest(
+            " Requirements Hub ",
+            " Centralized workspace ",
+            " https://requirements-hub.example.com "
+        ));
+
+        assertEquals("Requirements Hub", detail.teamName());
+        assertEquals("Centralized workspace", detail.teamDescription());
+        assertEquals("https://requirements-hub.example.com", detail.teamWebsiteUrl());
+        assertEquals(List.of("Amy Adams", "Zoe Zeta"), detail.teamMemberNames());
+        assertEquals(List.of("Ivy Stone", "Noah Bennett"), detail.instructorNames());
+        verify(teamRepository).findDetailById(10L);
+        verify(teamRepository).existsByTeamNameIgnoreCaseAndTeamIdNot("Requirements Hub", 10L);
+        verify(teamRepository).save(existingTeam);
+    }
+
+    @Test
+    void should_TrimAndNormalizeOptionalFields_When_UpdatingTeam() {
+        Team existingTeam = buildTeam();
+        when(teamRepository.findDetailById(10L)).thenReturn(Optional.of(existingTeam));
+        when(teamRepository.existsByTeamNameIgnoreCaseAndTeamIdNot("Pulse Analytics", 10L)).thenReturn(false);
+        when(teamRepository.save(existingTeam)).thenReturn(existingTeam);
+
+        TeamDetail detail = teamService.updateTeam(10L, new UpdateTeamRequest(" Pulse Analytics ", "   ", "   "));
+
+        assertNull(detail.teamDescription());
+        assertNull(detail.teamWebsiteUrl());
+    }
+
+    @Test
+    void should_AllowSameName_When_UpdatingCurrentTeamWithoutChangingUniqueness() {
+        Team existingTeam = buildTeam();
+        when(teamRepository.findDetailById(10L)).thenReturn(Optional.of(existingTeam));
+        when(teamRepository.existsByTeamNameIgnoreCaseAndTeamIdNot("Pulse Analytics", 10L)).thenReturn(false);
+        when(teamRepository.save(existingTeam)).thenReturn(existingTeam);
+
+        TeamDetail detail = teamService.updateTeam(10L, new UpdateTeamRequest(
+            "Pulse Analytics",
+            "Updated description",
+            "https://pulse.example.com"
+        ));
+
+        assertEquals("Pulse Analytics", detail.teamName());
+        assertEquals("Updated description", detail.teamDescription());
+    }
+
+    @Test
+    void should_ThrowNotFoundException_When_UpdatingMissingTeam() {
+        when(teamRepository.findDetailById(404L)).thenReturn(Optional.empty());
+
+        TeamNotFoundException ex = assertThrows(
+            TeamNotFoundException.class,
+            () -> teamService.updateTeam(404L, new UpdateTeamRequest("Requirements Hub", null, null))
+        );
+
+        assertEquals("No team found with id: 404", ex.getMessage());
+    }
+
+    @Test
+    void should_ThrowConflict_When_OtherTeamUsesRequestedNameIgnoringCase() {
+        Team existingTeam = buildTeam();
+        when(teamRepository.findDetailById(10L)).thenReturn(Optional.of(existingTeam));
+        when(teamRepository.existsByTeamNameIgnoreCaseAndTeamIdNot("requirements hub", 10L)).thenReturn(true);
+
+        TeamAlreadyExistsException ex = assertThrows(
+            TeamAlreadyExistsException.class,
+            () -> teamService.updateTeam(10L, new UpdateTeamRequest(" requirements hub ", null, null))
+        );
+
+        assertEquals("Team already exists with name: requirements hub", ex.getMessage());
+    }
+
+    @Test
+    void should_ThrowInvalidArgument_When_UpdateTeamNameIsBlank() {
+        Team existingTeam = buildTeam();
+        when(teamRepository.findDetailById(10L)).thenReturn(Optional.of(existingTeam));
+
+        InvalidTeamException ex = assertThrows(
+            InvalidTeamException.class,
+            () -> teamService.updateTeam(10L, new UpdateTeamRequest("   ", null, null))
+        );
+
+        assertEquals("Team name is required.", ex.getMessage());
+    }
+
+    @Test
+    void should_ThrowInvalidArgument_When_UpdateWebsiteUrlIsInvalid() {
+        Team existingTeam = buildTeam();
+        when(teamRepository.findDetailById(10L)).thenReturn(Optional.of(existingTeam));
+
+        InvalidTeamException ex = assertThrows(
+            InvalidTeamException.class,
+            () -> teamService.updateTeam(10L, new UpdateTeamRequest("Requirements Hub", null, "not-a-url"))
+        );
+
+        assertEquals("Team website URL must start with http:// or https://.", ex.getMessage());
     }
 
     private Team buildTeam() {

--- a/src/frontend/src/features/team/pages/TeamDetail.vue
+++ b/src/frontend/src/features/team/pages/TeamDetail.vue
@@ -13,6 +13,9 @@
         <v-col>
           <h2 class="text-h5 font-weight-bold">{{ team.teamName }}</h2>
         </v-col>
+        <v-col v-if="isAdmin" cols="auto">
+          <v-btn color="primary" prepend-icon="mdi-pencil" @click="openEditDialog">Edit Team</v-btn>
+        </v-col>
         <v-col cols="auto">
           <v-chip color="primary" variant="tonal">
             {{ team.sectionName }}
@@ -89,20 +92,120 @@
         </v-col>
       </v-row>
     </template>
+
+    <v-dialog v-model="dialog" max-width="700" persistent>
+      <v-card>
+        <v-card-title class="pa-4">
+          {{ step === 1 ? 'Edit Team' : 'Confirm Team Changes' }}
+        </v-card-title>
+        <v-divider />
+
+        <v-card-text v-if="step === 1" class="pa-4">
+          <v-text-field
+            v-model="form.teamName"
+            label="Team Name"
+            placeholder="e.g. Peer Evaluation Tool team"
+            :error-messages="errors.teamName"
+            class="mb-4"
+          />
+
+          <v-textarea
+            v-model="form.teamDescription"
+            label="Team Description"
+            rows="3"
+            class="mb-4"
+          />
+
+          <v-text-field
+            v-model="form.teamWebsiteUrl"
+            label="Team Website URL"
+            placeholder="https://example.com"
+            :error-messages="errors.teamWebsiteUrl"
+          />
+        </v-card-text>
+
+        <v-card-text v-else class="pa-4">
+          <v-alert type="info" variant="tonal" class="mb-4">
+            Please review the team changes before confirming.
+          </v-alert>
+          <v-table density="compact">
+            <tbody>
+              <tr>
+                <th class="text-left">Section</th>
+                <td>{{ team?.sectionName ?? '—' }}</td>
+              </tr>
+              <tr>
+                <th class="text-left">Team Name</th>
+                <td>{{ previewPayload.teamName }}</td>
+              </tr>
+              <tr>
+                <th class="text-left">Description</th>
+                <td>{{ previewPayload.teamDescription ?? '—' }}</td>
+              </tr>
+              <tr>
+                <th class="text-left">Website</th>
+                <td>{{ previewPayload.teamWebsiteUrl ?? '—' }}</td>
+              </tr>
+            </tbody>
+          </v-table>
+        </v-card-text>
+
+        <v-divider />
+        <v-card-actions class="pa-4">
+          <v-btn variant="text" @click="cancelEdit">Cancel</v-btn>
+          <v-spacer />
+          <v-btn v-if="step === 2" variant="outlined" @click="step = 1">Modify</v-btn>
+          <v-btn
+            color="primary"
+            :loading="saving"
+            @click="step === 1 ? goToPreview() : confirmEdit()"
+          >
+            {{ step === 1 ? 'Preview' : 'Confirm' }}
+          </v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
+
+    <v-snackbar v-model="snackbar.show" :color="snackbar.color" timeout="3000">
+      {{ snackbar.message }}
+    </v-snackbar>
   </v-container>
 </template>
 
 <script setup lang="ts">
-import { onMounted, ref } from 'vue'
+import { computed, onMounted, ref } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
-import { getTeam } from '../services/teamService'
-import type { TeamDetail } from '../services/teamTypes'
+import { useUserInfoStore } from '@/stores/userInfo'
+import { getTeam, updateTeam } from '../services/teamService'
+import type { TeamDetail, UpdateTeamRequest } from '../services/teamTypes'
 
 const route = useRoute()
 const router = useRouter()
+const userInfoStore = useUserInfoStore()
 
 const team = ref<TeamDetail | null>(null)
 const loading = ref(false)
+const dialog = ref(false)
+const step = ref(1)
+const saving = ref(false)
+const errors = ref<{ teamName?: string; teamWebsiteUrl?: string }>({})
+const snackbar = ref({ show: false, message: '', color: 'success' })
+
+const emptyForm = () => ({
+  teamName: '',
+  teamDescription: '',
+  teamWebsiteUrl: ''
+})
+
+const form = ref(emptyForm())
+
+const isAdmin = computed(() => userInfoStore.isAdmin)
+
+const previewPayload = computed<UpdateTeamRequest>(() => ({
+  teamName: form.value.teamName.trim(),
+  teamDescription: normalizeOptional(form.value.teamDescription),
+  teamWebsiteUrl: normalizeOptional(form.value.teamWebsiteUrl)
+}))
 
 onMounted(async () => {
   loading.value = true
@@ -120,4 +223,83 @@ onMounted(async () => {
     loading.value = false
   }
 })
+
+function openEditDialog() {
+  if (!team.value) return
+
+  form.value = {
+    teamName: team.value.teamName,
+    teamDescription: team.value.teamDescription ?? '',
+    teamWebsiteUrl: team.value.teamWebsiteUrl ?? ''
+  }
+  errors.value = {}
+  step.value = 1
+  dialog.value = true
+}
+
+function cancelEdit() {
+  dialog.value = false
+}
+
+function validate(): boolean {
+  errors.value = {}
+  let valid = true
+
+  if (!form.value.teamName.trim()) {
+    errors.value.teamName = 'Team name is required.'
+    valid = false
+  }
+
+  if (form.value.teamWebsiteUrl.trim()) {
+    try {
+      const url = new URL(form.value.teamWebsiteUrl.trim())
+      if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+        errors.value.teamWebsiteUrl = 'Team website URL must start with http:// or https://.'
+        valid = false
+      }
+    } catch {
+      errors.value.teamWebsiteUrl = 'Team website URL must be a valid absolute URL.'
+      valid = false
+    }
+  }
+
+  return valid
+}
+
+function goToPreview() {
+  if (!validate()) return
+  step.value = 2
+}
+
+async function confirmEdit() {
+  if (!team.value) return
+
+  saving.value = true
+  try {
+    const res = await updateTeam(team.value.teamId, previewPayload.value) as any
+    if (res.flag && res.data) {
+      team.value = res.data
+      dialog.value = false
+      snackbar.value = { show: true, message: 'Team updated successfully.', color: 'success' }
+    }
+  } catch (error: any) {
+    const message = error?.response?.data?.message
+    if (typeof message === 'string') {
+      if (message.toLowerCase().includes('team name')) {
+        errors.value.teamName = message
+        step.value = 1
+      } else if (message.toLowerCase().includes('website')) {
+        errors.value.teamWebsiteUrl = message
+        step.value = 1
+      }
+    }
+  } finally {
+    saving.value = false
+  }
+}
+
+function normalizeOptional(value: string): string | null {
+  const trimmed = value.trim()
+  return trimmed ? trimmed : null
+}
 </script>

--- a/src/frontend/src/features/team/services/teamService.ts
+++ b/src/frontend/src/features/team/services/teamService.ts
@@ -1,6 +1,6 @@
 import request from '@/shared/utils/request'
 import type { ApiResponse } from '@/shared/types/api'
-import type { CreateTeamRequest, FindTeamsParams, TeamDetail, TeamSummary } from './teamTypes'
+import type { CreateTeamRequest, FindTeamsParams, TeamDetail, TeamSummary, UpdateTeamRequest } from './teamTypes'
 
 const BASE = '/teams'
 
@@ -12,3 +12,6 @@ export const getTeam = (id: number) =>
 
 export const createTeam = (payload: CreateTeamRequest) =>
   request.post<ApiResponse<TeamDetail>>(BASE, payload)
+
+export const updateTeam = (id: number, payload: UpdateTeamRequest) =>
+  request.put<ApiResponse<TeamDetail>>(`${BASE}/${id}`, payload)

--- a/src/frontend/src/features/team/services/teamTypes.ts
+++ b/src/frontend/src/features/team/services/teamTypes.ts
@@ -27,6 +27,12 @@ export interface CreateTeamRequest {
   teamWebsiteUrl: string | null
 }
 
+export interface UpdateTeamRequest {
+  teamName: string
+  teamDescription: string | null
+  teamWebsiteUrl: string | null
+}
+
 export interface FindTeamsParams {
   sectionId?: number
   sectionName?: string


### PR DESCRIPTION
Implemented UC-10 so admins can edit an existing senior design team from the team detail page, with backend support for PUT /api/v1/teams/{id} plus validation and duplicate-name conflict handling. Added the admin-only frontend edit dialog with preview/confirm flow, updated team service/types, and backend test coverage; verified with mvn test and npm exec vite build.