### PR TITLE
feat(uc-12): wip assign students to teams

### DIFF
--- a/src/backend/src/main/java/team/projectpulse/auth/service/AuthService.java
+++ b/src/backend/src/main/java/team/projectpulse/auth/service/AuthService.java
@@ -93,6 +93,7 @@ public class AuthService {
         user.setEmail(email);
         user.setPassword(passwordEncoder.encode(req.password()));
         user.setRoles("student");
+        user.setSection(sectionRepository.findById(invite.getSectionId()).orElse(null));
         user.setEnabled(true);
         userRepository.save(user);
 

--- a/src/backend/src/main/java/team/projectpulse/team/controller/TeamExceptionHandler.java
+++ b/src/backend/src/main/java/team/projectpulse/team/controller/TeamExceptionHandler.java
@@ -7,6 +7,7 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 import team.projectpulse.system.Result;
 import team.projectpulse.system.StatusCode;
 import team.projectpulse.team.domain.InvalidTeamException;
+import team.projectpulse.team.domain.InvalidTeamStudentAssignmentException;
 import team.projectpulse.team.domain.TeamAlreadyExistsException;
 import team.projectpulse.team.domain.TeamNotFoundException;
 
@@ -28,6 +29,12 @@ public class TeamExceptionHandler {
     @ExceptionHandler(InvalidTeamException.class)
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     public Result<Void> handleInvalidTeam(InvalidTeamException ex) {
+        return Result.error(StatusCode.INVALID_ARGUMENT, ex.getMessage());
+    }
+
+    @ExceptionHandler(InvalidTeamStudentAssignmentException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public Result<Void> handleInvalidTeamStudentAssignment(InvalidTeamStudentAssignmentException ex) {
         return Result.error(StatusCode.INVALID_ARGUMENT, ex.getMessage());
     }
 }

--- a/src/backend/src/main/java/team/projectpulse/team/controller/TeamStudentAssignmentController.java
+++ b/src/backend/src/main/java/team/projectpulse/team/controller/TeamStudentAssignmentController.java
@@ -1,0 +1,41 @@
+package team.projectpulse.team.controller;
+
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import team.projectpulse.system.Result;
+import team.projectpulse.team.dto.TeamStudentAssignmentWorkspace;
+import team.projectpulse.team.dto.UpdateTeamStudentAssignmentsRequest;
+import team.projectpulse.team.service.TeamStudentAssignmentService;
+
+@RestController
+@RequestMapping("${api.endpoint.base-url}/team-student-assignments")
+public class TeamStudentAssignmentController {
+
+    private final TeamStudentAssignmentService teamStudentAssignmentService;
+
+    public TeamStudentAssignmentController(TeamStudentAssignmentService teamStudentAssignmentService) {
+        this.teamStudentAssignmentService = teamStudentAssignmentService;
+    }
+
+    @GetMapping
+    @PreAuthorize("hasRole('ADMIN')")
+    public Result<TeamStudentAssignmentWorkspace> loadWorkspace(@RequestParam Long sectionId) {
+        return Result.success(teamStudentAssignmentService.loadWorkspace(sectionId));
+    }
+
+    @PutMapping
+    @PreAuthorize("hasRole('ADMIN')")
+    public Result<TeamStudentAssignmentWorkspace> updateAssignments(
+        @RequestBody UpdateTeamStudentAssignmentsRequest request
+    ) {
+        return Result.success(
+            "Student team assignments saved successfully.",
+            teamStudentAssignmentService.updateAssignments(request)
+        );
+    }
+}

--- a/src/backend/src/main/java/team/projectpulse/team/domain/InvalidTeamStudentAssignmentException.java
+++ b/src/backend/src/main/java/team/projectpulse/team/domain/InvalidTeamStudentAssignmentException.java
@@ -1,0 +1,7 @@
+package team.projectpulse.team.domain;
+
+public class InvalidTeamStudentAssignmentException extends RuntimeException {
+    public InvalidTeamStudentAssignmentException(String message) {
+        super(message);
+    }
+}

--- a/src/backend/src/main/java/team/projectpulse/team/dto/StudentAssignmentCandidate.java
+++ b/src/backend/src/main/java/team/projectpulse/team/dto/StudentAssignmentCandidate.java
@@ -1,0 +1,8 @@
+package team.projectpulse.team.dto;
+
+public record StudentAssignmentCandidate(
+    Long studentId,
+    String fullName,
+    String email
+) {
+}

--- a/src/backend/src/main/java/team/projectpulse/team/dto/TeamStudentAssignmentInput.java
+++ b/src/backend/src/main/java/team/projectpulse/team/dto/TeamStudentAssignmentInput.java
@@ -1,0 +1,9 @@
+package team.projectpulse.team.dto;
+
+import java.util.List;
+
+public record TeamStudentAssignmentInput(
+    Long teamId,
+    List<Long> studentIds
+) {
+}

--- a/src/backend/src/main/java/team/projectpulse/team/dto/TeamStudentAssignmentTeam.java
+++ b/src/backend/src/main/java/team/projectpulse/team/dto/TeamStudentAssignmentTeam.java
@@ -1,0 +1,10 @@
+package team.projectpulse.team.dto;
+
+import java.util.List;
+
+public record TeamStudentAssignmentTeam(
+    Long teamId,
+    String teamName,
+    List<StudentAssignmentCandidate> assignedStudents
+) {
+}

--- a/src/backend/src/main/java/team/projectpulse/team/dto/TeamStudentAssignmentWorkspace.java
+++ b/src/backend/src/main/java/team/projectpulse/team/dto/TeamStudentAssignmentWorkspace.java
@@ -1,0 +1,11 @@
+package team.projectpulse.team.dto;
+
+import java.util.List;
+
+public record TeamStudentAssignmentWorkspace(
+    Long sectionId,
+    String sectionName,
+    List<TeamStudentAssignmentTeam> teams,
+    List<StudentAssignmentCandidate> students
+) {
+}

--- a/src/backend/src/main/java/team/projectpulse/team/dto/UpdateTeamStudentAssignmentsRequest.java
+++ b/src/backend/src/main/java/team/projectpulse/team/dto/UpdateTeamStudentAssignmentsRequest.java
@@ -1,0 +1,9 @@
+package team.projectpulse.team.dto;
+
+import java.util.List;
+
+public record UpdateTeamStudentAssignmentsRequest(
+    Long sectionId,
+    List<TeamStudentAssignmentInput> assignments
+) {
+}

--- a/src/backend/src/main/java/team/projectpulse/team/repository/TeamRepository.java
+++ b/src/backend/src/main/java/team/projectpulse/team/repository/TeamRepository.java
@@ -45,4 +45,13 @@ public interface TeamRepository extends JpaRepository<Team, Long> {
         where t.teamId = :teamId
         """)
     Optional<Team> findDetailById(@Param("teamId") Long teamId);
+
+    @Query("""
+        select distinct t from Team t
+        join fetch t.section s
+        left join fetch t.students st
+        where s.sectionId = :sectionId
+        order by lower(t.teamName)
+        """)
+    List<Team> findAllBySectionIdWithStudentsOrdered(@Param("sectionId") Long sectionId);
 }

--- a/src/backend/src/main/java/team/projectpulse/team/service/TeamStudentAssignmentService.java
+++ b/src/backend/src/main/java/team/projectpulse/team/service/TeamStudentAssignmentService.java
@@ -1,0 +1,227 @@
+package team.projectpulse.team.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import team.projectpulse.section.domain.Section;
+import team.projectpulse.section.domain.SectionNotFoundException;
+import team.projectpulse.section.repository.SectionRepository;
+import team.projectpulse.team.domain.InvalidTeamStudentAssignmentException;
+import team.projectpulse.team.domain.Team;
+import team.projectpulse.team.dto.StudentAssignmentCandidate;
+import team.projectpulse.team.dto.TeamStudentAssignmentInput;
+import team.projectpulse.team.dto.TeamStudentAssignmentTeam;
+import team.projectpulse.team.dto.TeamStudentAssignmentWorkspace;
+import team.projectpulse.team.dto.UpdateTeamStudentAssignmentsRequest;
+import team.projectpulse.team.repository.TeamRepository;
+import team.projectpulse.user.domain.User;
+import team.projectpulse.user.repository.UserRepository;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Service
+public class TeamStudentAssignmentService {
+
+    private static final Comparator<User> USER_COMPARATOR = Comparator
+        .comparing(User::getLastName, String.CASE_INSENSITIVE_ORDER)
+        .thenComparing(User::getFirstName, String.CASE_INSENSITIVE_ORDER)
+        .thenComparing(User::getEmail, String.CASE_INSENSITIVE_ORDER);
+
+    private final SectionRepository sectionRepository;
+    private final TeamRepository teamRepository;
+    private final UserRepository userRepository;
+
+    public TeamStudentAssignmentService(
+        SectionRepository sectionRepository,
+        TeamRepository teamRepository,
+        UserRepository userRepository
+    ) {
+        this.sectionRepository = sectionRepository;
+        this.teamRepository = teamRepository;
+        this.userRepository = userRepository;
+    }
+
+    public TeamStudentAssignmentWorkspace loadWorkspace(Long sectionId) {
+        Section section = requireSection(sectionId);
+        List<Team> teams = teamRepository.findAllBySectionIdWithStudentsOrdered(sectionId);
+        List<User> students = userRepository.findEnabledStudentsBySectionId(sectionId);
+        return toWorkspace(section, teams, students);
+    }
+
+    @Transactional
+    public TeamStudentAssignmentWorkspace updateAssignments(UpdateTeamStudentAssignmentsRequest request) {
+        if (request == null) {
+            throw new InvalidTeamStudentAssignmentException("Assignment request is required.");
+        }
+        if (request.sectionId() == null) {
+            throw new InvalidTeamStudentAssignmentException("Section is required.");
+        }
+
+        Section section = requireSection(request.sectionId());
+        List<Team> teams = teamRepository.findAllBySectionIdWithStudentsOrdered(request.sectionId());
+        List<User> eligibleStudents = userRepository.findEnabledStudentsBySectionId(request.sectionId());
+
+        if (teams.isEmpty()) {
+            throw new InvalidTeamStudentAssignmentException("At least one team must exist in the selected section.");
+        }
+        if (eligibleStudents.isEmpty()) {
+            throw new InvalidTeamStudentAssignmentException("At least one eligible student must exist in the selected section.");
+        }
+
+        Map<Long, Team> teamsById = teams.stream()
+            .collect(Collectors.toMap(Team::getTeamId, team -> team, (left, right) -> left, LinkedHashMap::new));
+        Map<Long, User> studentsById = eligibleStudents.stream()
+            .collect(Collectors.toMap(User::getId, user -> user, (left, right) -> left, LinkedHashMap::new));
+
+        Map<Long, List<Long>> assignmentsByTeam = validateAssignments(
+            request.assignments(),
+            request.sectionId(),
+            teamsById,
+            studentsById
+        );
+
+        for (Team team : teams) {
+            team.setStudents(new LinkedHashSet<>());
+        }
+
+        for (Map.Entry<Long, List<Long>> entry : assignmentsByTeam.entrySet()) {
+            Team team = teamsById.get(entry.getKey());
+            LinkedHashSet<User> assignedStudents = entry.getValue().stream()
+                .map(studentsById::get)
+                .collect(Collectors.toCollection(LinkedHashSet::new));
+            team.setStudents(assignedStudents);
+        }
+
+        teamRepository.saveAll(teams);
+
+        List<Team> refreshedTeams = teamRepository.findAllBySectionIdWithStudentsOrdered(request.sectionId());
+        return toWorkspace(section, refreshedTeams, eligibleStudents);
+    }
+
+    private Section requireSection(Long sectionId) {
+        if (sectionId == null) {
+            throw new InvalidTeamStudentAssignmentException("Section is required.");
+        }
+        return sectionRepository.findById(sectionId)
+            .orElseThrow(() -> new SectionNotFoundException(sectionId));
+    }
+
+    private Map<Long, List<Long>> validateAssignments(
+        List<TeamStudentAssignmentInput> assignments,
+        Long sectionId,
+        Map<Long, Team> teamsById,
+        Map<Long, User> studentsById
+    ) {
+        if (assignments == null || assignments.isEmpty()) {
+            throw new InvalidTeamStudentAssignmentException("Assignments are required.");
+        }
+
+        Set<Long> seenTeamIds = new LinkedHashSet<>();
+        Set<Long> seenStudentIds = new LinkedHashSet<>();
+        Map<Long, List<Long>> assignmentsByTeam = new LinkedHashMap<>();
+
+        for (TeamStudentAssignmentInput assignment : assignments) {
+            if (assignment == null || assignment.teamId() == null) {
+                throw new InvalidTeamStudentAssignmentException("Each assignment must include a team.");
+            }
+            if (!seenTeamIds.add(assignment.teamId())) {
+                throw new InvalidTeamStudentAssignmentException("Each team may only appear once in the assignment payload.");
+            }
+
+            Team team = teamsById.get(assignment.teamId());
+            if (team == null) {
+                throw new InvalidTeamStudentAssignmentException("Team " + assignment.teamId() + " does not belong to section " + sectionId + ".");
+            }
+
+            List<Long> studentIds = assignment.studentIds() == null ? List.of() : assignment.studentIds();
+            Set<Long> seenStudentsInTeam = new LinkedHashSet<>();
+            List<Long> normalizedStudentIds = new ArrayList<>();
+
+            for (Long studentId : studentIds) {
+                if (studentId == null) {
+                    throw new InvalidTeamStudentAssignmentException("Assigned student ids must not contain null values.");
+                }
+                if (!seenStudentsInTeam.add(studentId)) {
+                    throw new InvalidTeamStudentAssignmentException("A student may only appear once per team assignment.");
+                }
+
+                User student = studentsById.get(studentId);
+                if (student == null) {
+                    throw new InvalidTeamStudentAssignmentException("Student " + studentId + " does not belong to section " + sectionId + ".");
+                }
+                if (!isStudent(student)) {
+                    throw new InvalidTeamStudentAssignmentException("User " + studentId + " is not a student.");
+                }
+                if (!student.isEnabled()) {
+                    throw new InvalidTeamStudentAssignmentException("Student " + studentId + " is not enabled.");
+                }
+                if (student.getSection() == null || !Objects.equals(student.getSection().getSectionId(), sectionId)) {
+                    throw new InvalidTeamStudentAssignmentException("Student " + studentId + " does not belong to section " + sectionId + ".");
+                }
+                if (!seenStudentIds.add(studentId)) {
+                    throw new InvalidTeamStudentAssignmentException("Each student may only be assigned to one team.");
+                }
+
+                normalizedStudentIds.add(studentId);
+            }
+
+            assignmentsByTeam.put(assignment.teamId(), normalizedStudentIds);
+        }
+
+        if (!seenTeamIds.equals(teamsById.keySet())) {
+            throw new InvalidTeamStudentAssignmentException("Assignments must be provided for every team in the selected section.");
+        }
+        if (!seenStudentIds.equals(studentsById.keySet())) {
+            throw new InvalidTeamStudentAssignmentException("Every eligible student in the selected section must be assigned to exactly one team.");
+        }
+
+        return assignmentsByTeam;
+    }
+
+    private TeamStudentAssignmentWorkspace toWorkspace(Section section, List<Team> teams, List<User> students) {
+        List<StudentAssignmentCandidate> studentCandidates = students.stream()
+            .sorted(USER_COMPARATOR)
+            .map(this::toCandidate)
+            .toList();
+
+        List<TeamStudentAssignmentTeam> teamDtos = teams.stream()
+            .sorted(Comparator.comparing(Team::getTeamName, String.CASE_INSENSITIVE_ORDER))
+            .map(team -> new TeamStudentAssignmentTeam(
+                team.getTeamId(),
+                team.getTeamName(),
+                team.getStudents().stream()
+                    .sorted(USER_COMPARATOR)
+                    .map(this::toCandidate)
+                    .toList()
+            ))
+            .toList();
+
+        return new TeamStudentAssignmentWorkspace(
+            section.getSectionId(),
+            section.getSectionName(),
+            teamDtos,
+            studentCandidates
+        );
+    }
+
+    private StudentAssignmentCandidate toCandidate(User student) {
+        return new StudentAssignmentCandidate(
+            student.getId(),
+            (student.getFirstName() + " " + student.getLastName()).trim(),
+            student.getEmail()
+        );
+    }
+
+    private boolean isStudent(User user) {
+        String roles = user.getRoles() == null ? "" : user.getRoles().toLowerCase();
+        return List.of(roles.split("\\s+")).contains("student");
+    }
+}

--- a/src/backend/src/main/java/team/projectpulse/user/domain/User.java
+++ b/src/backend/src/main/java/team/projectpulse/user/domain/User.java
@@ -5,6 +5,7 @@ import jakarta.persistence.*;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
+import team.projectpulse.section.domain.Section;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -33,6 +34,10 @@ public class User implements UserDetails {
     /** Space-separated roles, e.g. "admin instructor" or "student" */
     @Column(nullable = false)
     private String roles;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "section_id")
+    private Section section;
 
     private boolean enabled;
 
@@ -88,6 +93,9 @@ public class User implements UserDetails {
 
     public String getRoles()                 { return roles; }
     public void setRoles(String v)           { this.roles = v; }
+
+    public Section getSection()              { return section; }
+    public void setSection(Section v)        { this.section = v; }
 
     public void setEnabled(boolean v)        { this.enabled = v; }
 }

--- a/src/backend/src/main/java/team/projectpulse/user/repository/UserRepository.java
+++ b/src/backend/src/main/java/team/projectpulse/user/repository/UserRepository.java
@@ -1,11 +1,24 @@
 package team.projectpulse.user.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import team.projectpulse.user.domain.User;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByEmail(String email);
     boolean existsByEmailIgnoreCase(String email);
+
+    @Query("""
+        select u from User u
+        left join fetch u.section s
+        where u.enabled = true
+          and s.sectionId = :sectionId
+          and lower(concat(' ', coalesce(u.roles, ''), ' ')) like '% student %'
+        order by lower(u.lastName), lower(u.firstName), lower(u.email)
+        """)
+    List<User> findEnabledStudentsBySectionId(@Param("sectionId") Long sectionId);
 }

--- a/src/backend/src/main/resources/db/migration/V6__user_section_membership.sql
+++ b/src/backend/src/main/resources/db/migration/V6__user_section_membership.sql
@@ -1,0 +1,28 @@
+-- V6: User section membership for student assignment
+
+ALTER TABLE users
+    ADD COLUMN section_id BIGINT NULL;
+
+ALTER TABLE users
+    ADD CONSTRAINT fk_users_section
+        FOREIGN KEY (section_id) REFERENCES sections(section_id) ON DELETE SET NULL;
+
+-- Resolve each student's section membership deterministically to the minimum
+-- section_id across their existing team memberships.
+UPDATE users u
+JOIN (
+    SELECT ts.user_id, MIN(t.section_id) AS resolved_section_id
+    FROM team_students ts
+    JOIN teams t ON t.team_id = ts.team_id
+    GROUP BY ts.user_id
+) resolved ON resolved.user_id = u.id
+SET u.section_id = resolved.resolved_section_id
+WHERE LOWER(CONCAT(' ', u.roles, ' ')) LIKE '% student %';
+
+-- Remove cross-section memberships that do not match the resolved student section.
+DELETE ts
+FROM team_students ts
+JOIN teams t ON t.team_id = ts.team_id
+JOIN users u ON u.id = ts.user_id
+WHERE u.section_id IS NOT NULL
+  AND t.section_id <> u.section_id;

--- a/src/backend/src/test/java/team/projectpulse/team/controller/TeamStudentAssignmentControllerIntegrationTest.java
+++ b/src/backend/src/test/java/team/projectpulse/team/controller/TeamStudentAssignmentControllerIntegrationTest.java
@@ -1,0 +1,143 @@
+package team.projectpulse.team.controller;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import team.projectpulse.section.domain.SectionNotFoundException;
+import team.projectpulse.team.domain.InvalidTeamStudentAssignmentException;
+import team.projectpulse.team.dto.StudentAssignmentCandidate;
+import team.projectpulse.team.dto.TeamStudentAssignmentTeam;
+import team.projectpulse.team.dto.TeamStudentAssignmentWorkspace;
+import team.projectpulse.team.service.TeamStudentAssignmentService;
+
+import java.util.List;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class TeamStudentAssignmentControllerIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private TeamStudentAssignmentService teamStudentAssignmentService;
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void should_LoadWorkspace_When_AdminRequestsAssignments() throws Exception {
+        when(teamStudentAssignmentService.loadWorkspace(1L)).thenReturn(buildWorkspace());
+
+        mockMvc.perform(get("/api/v1/team-student-assignments").param("sectionId", "1"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.flag").value(true))
+            .andExpect(jsonPath("$.data.sectionName").value("Spring 2026 - Section A"))
+            .andExpect(jsonPath("$.data.teams[0].teamName").value("Pulse Analytics"))
+            .andExpect(jsonPath("$.data.students[0].fullName").value("Ava Johnson"));
+
+        verify(teamStudentAssignmentService).loadWorkspace(1L);
+    }
+
+    @Test
+    @WithMockUser(roles = "INSTRUCTOR")
+    void should_ReturnForbidden_When_InstructorRequestsAssignments() throws Exception {
+        mockMvc.perform(get("/api/v1/team-student-assignments").param("sectionId", "1"))
+            .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @WithMockUser(roles = "STUDENT")
+    void should_ReturnForbidden_When_StudentRequestsAssignments() throws Exception {
+        mockMvc.perform(get("/api/v1/team-student-assignments").param("sectionId", "1"))
+            .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void should_ReturnUnauthorized_When_UnauthenticatedUserRequestsAssignments() throws Exception {
+        mockMvc.perform(get("/api/v1/team-student-assignments").param("sectionId", "1"))
+            .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void should_SaveAssignments_When_AdminConfirmsAssignments() throws Exception {
+        when(teamStudentAssignmentService.updateAssignments(org.mockito.ArgumentMatchers.any())).thenReturn(buildWorkspace());
+
+        mockMvc.perform(put("/api/v1/team-student-assignments")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                    {
+                      "sectionId": 1,
+                      "assignments": [
+                        { "teamId": 2001, "studentIds": [100] }
+                      ]
+                    }
+                    """))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.flag").value(true))
+            .andExpect(jsonPath("$.message").value("Student team assignments saved successfully."))
+            .andExpect(jsonPath("$.data.teams[0].assignedStudents[0].studentId").value(100));
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void should_ReturnBadRequest_When_AssignmentPayloadIsInvalid() throws Exception {
+        when(teamStudentAssignmentService.updateAssignments(org.mockito.ArgumentMatchers.any()))
+            .thenThrow(new InvalidTeamStudentAssignmentException("Every eligible student in the selected section must be assigned to exactly one team."));
+
+        mockMvc.perform(put("/api/v1/team-student-assignments")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                    {
+                      "sectionId": 1,
+                      "assignments": [
+                        { "teamId": 2001, "studentIds": [] }
+                      ]
+                    }
+                    """))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.flag").value(false))
+            .andExpect(jsonPath("$.code").value(400))
+            .andExpect(jsonPath("$.message").value("Every eligible student in the selected section must be assigned to exactly one team."));
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void should_ReturnNotFound_When_SectionDoesNotExist() throws Exception {
+        when(teamStudentAssignmentService.loadWorkspace(999L)).thenThrow(new SectionNotFoundException(999L));
+
+        mockMvc.perform(get("/api/v1/team-student-assignments").param("sectionId", "999"))
+            .andExpect(status().isNotFound())
+            .andExpect(jsonPath("$.flag").value(false))
+            .andExpect(jsonPath("$.code").value(404))
+            .andExpect(jsonPath("$.message").value("No section found with id: 999"));
+    }
+
+    private TeamStudentAssignmentWorkspace buildWorkspace() {
+        return new TeamStudentAssignmentWorkspace(
+            1L,
+            "Spring 2026 - Section A",
+            List.of(
+                new TeamStudentAssignmentTeam(
+                    2001L,
+                    "Pulse Analytics",
+                    List.of(new StudentAssignmentCandidate(100L, "Ava Johnson", "ava@tcu.edu"))
+                )
+            ),
+            List.of(new StudentAssignmentCandidate(100L, "Ava Johnson", "ava@tcu.edu"))
+        );
+    }
+}

--- a/src/backend/src/test/java/team/projectpulse/team/repository/TeamRepositoryIntegrationTest.java
+++ b/src/backend/src/test/java/team/projectpulse/team/repository/TeamRepositoryIntegrationTest.java
@@ -123,6 +123,17 @@ class TeamRepositoryIntegrationTest {
         assertEquals(false, exists);
     }
 
+    @Test
+    void should_FetchAllTeamsBySectionWithStudentsOrderedByTeamName() {
+        SeededData data = seedTeams();
+
+        List<Team> teams = teamRepository.findAllBySectionIdWithStudentsOrdered(data.sectionAId());
+
+        assertEquals(List.of("Pulse Analytics", "Review Board"), teams.stream().map(Team::getTeamName).toList());
+        assertEquals(List.of("Ava", "Liam"), teams.getFirst().getStudents().stream().map(User::getFirstName).sorted().toList());
+        assertEquals(List.of("Mia"), teams.get(1).getStudents().stream().map(User::getFirstName).toList());
+    }
+
     private SeededData seedTeams() {
         Section sectionA = new Section();
         sectionA.setSectionName("Spring 2026 - Section A");
@@ -151,7 +162,7 @@ class TeamRepositoryIntegrationTest {
         entityManager.flush();
         entityManager.clear();
 
-        return new SeededData("Review Board", "Pulse Analytics", "Gamma Studio", pulse.getTeamId(), review.getTeamId());
+        return new SeededData(sectionA.getSectionId(), "Review Board", "Pulse Analytics", "Gamma Studio", pulse.getTeamId(), review.getTeamId());
     }
 
     private User persistUser(String firstName, String lastName, String email, String roles) {
@@ -178,5 +189,5 @@ class TeamRepositoryIntegrationTest {
         return team;
     }
 
-    private record SeededData(String teamBravo, String teamAlpha, String teamGamma, Long pulseAnalyticsId, Long reviewBoardId) {}
+    private record SeededData(Long sectionAId, String teamBravo, String teamAlpha, String teamGamma, Long pulseAnalyticsId, Long reviewBoardId) {}
 }

--- a/src/backend/src/test/java/team/projectpulse/team/service/TeamStudentAssignmentServiceTest.java
+++ b/src/backend/src/test/java/team/projectpulse/team/service/TeamStudentAssignmentServiceTest.java
@@ -1,0 +1,281 @@
+package team.projectpulse.team.service;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import team.projectpulse.section.domain.Section;
+import team.projectpulse.section.domain.SectionNotFoundException;
+import team.projectpulse.section.repository.SectionRepository;
+import team.projectpulse.team.domain.InvalidTeamStudentAssignmentException;
+import team.projectpulse.team.domain.Team;
+import team.projectpulse.team.dto.TeamStudentAssignmentInput;
+import team.projectpulse.team.dto.TeamStudentAssignmentWorkspace;
+import team.projectpulse.team.dto.UpdateTeamStudentAssignmentsRequest;
+import team.projectpulse.team.repository.TeamRepository;
+import team.projectpulse.user.domain.User;
+import team.projectpulse.user.repository.UserRepository;
+
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class TeamStudentAssignmentServiceTest {
+
+    @Mock
+    private SectionRepository sectionRepository;
+
+    @Mock
+    private TeamRepository teamRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @InjectMocks
+    private TeamStudentAssignmentService service;
+
+    @Test
+    void should_ReturnWorkspace_When_SectionExists() {
+        Section section = buildSection(1L, "Spring 2026 - Section A");
+        User ava = buildStudent(100L, "Ava", "Johnson", "ava@tcu.edu", section, true);
+        User mia = buildStudent(101L, "Mia", "Chen", "mia@tcu.edu", section, true);
+        Team requirementsHub = buildTeam(2002L, "Requirements Hub", section, List.of(mia));
+        Team pulseAnalytics = buildTeam(2001L, "Pulse Analytics", section, List.of(ava));
+
+        when(sectionRepository.findById(1L)).thenReturn(Optional.of(section));
+        when(teamRepository.findAllBySectionIdWithStudentsOrdered(1L)).thenReturn(List.of(requirementsHub, pulseAnalytics));
+        when(userRepository.findEnabledStudentsBySectionId(1L)).thenReturn(List.of(ava, mia));
+
+        TeamStudentAssignmentWorkspace workspace = service.loadWorkspace(1L);
+
+        assertEquals(1L, workspace.sectionId());
+        assertEquals("Spring 2026 - Section A", workspace.sectionName());
+        assertEquals(List.of("Pulse Analytics", "Requirements Hub"), workspace.teams().stream().map(team -> team.teamName()).toList());
+        assertEquals(List.of("Mia Chen", "Ava Johnson"), workspace.students().stream().map(student -> student.fullName()).toList());
+    }
+
+    @Test
+    void should_ThrowNotFound_When_SectionDoesNotExist() {
+        when(sectionRepository.findById(55L)).thenReturn(Optional.empty());
+
+        SectionNotFoundException ex = assertThrows(
+            SectionNotFoundException.class,
+            () -> service.loadWorkspace(55L)
+        );
+
+        assertEquals("No section found with id: 55", ex.getMessage());
+    }
+
+    @Test
+    void should_SaveAssignments_When_RequestIsValid() {
+        Section section = buildSection(1L, "Spring 2026 - Section A");
+        User ava = buildStudent(100L, "Ava", "Johnson", "ava@tcu.edu", section, true);
+        User mia = buildStudent(101L, "Mia", "Chen", "mia@tcu.edu", section, true);
+        Team pulseAnalytics = buildTeam(2001L, "Pulse Analytics", section, List.of(ava));
+        Team requirementsHub = buildTeam(2002L, "Requirements Hub", section, List.of(mia));
+        List<Team> teams = List.of(pulseAnalytics, requirementsHub);
+        List<User> students = List.of(ava, mia);
+
+        when(sectionRepository.findById(1L)).thenReturn(Optional.of(section));
+        when(teamRepository.findAllBySectionIdWithStudentsOrdered(1L)).thenReturn(teams, teams);
+        when(userRepository.findEnabledStudentsBySectionId(1L)).thenReturn(students);
+
+        TeamStudentAssignmentWorkspace workspace = service.updateAssignments(
+            new UpdateTeamStudentAssignmentsRequest(
+                1L,
+                List.of(
+                    new TeamStudentAssignmentInput(2001L, List.of(101L)),
+                    new TeamStudentAssignmentInput(2002L, List.of(100L))
+                )
+            )
+        );
+
+        assertEquals(List.of("Mia Chen"), workspace.teams().getFirst().assignedStudents().stream().map(student -> student.fullName()).toList());
+        assertEquals(List.of("Ava Johnson"), workspace.teams().get(1).assignedStudents().stream().map(student -> student.fullName()).toList());
+        assertEquals(List.of("Mia"), pulseAnalytics.getStudents().stream().map(User::getFirstName).toList());
+        assertEquals(List.of("Ava"), requirementsHub.getStudents().stream().map(User::getFirstName).toList());
+        verify(teamRepository).saveAll(teams);
+    }
+
+    @Test
+    void should_ThrowInvalidArgument_When_SectionIdIsMissing() {
+        InvalidTeamStudentAssignmentException ex = assertThrows(
+            InvalidTeamStudentAssignmentException.class,
+            () -> service.updateAssignments(new UpdateTeamStudentAssignmentsRequest(null, List.of()))
+        );
+
+        assertEquals("Section is required.", ex.getMessage());
+    }
+
+    @Test
+    void should_ThrowInvalidArgument_When_AssignmentContainsDuplicateTeamIds() {
+        Section section = buildSection(1L, "Spring 2026 - Section A");
+        User ava = buildStudent(100L, "Ava", "Johnson", "ava@tcu.edu", section, true);
+        User mia = buildStudent(101L, "Mia", "Chen", "mia@tcu.edu", section, true);
+        Team pulseAnalytics = buildTeam(2001L, "Pulse Analytics", section, List.of());
+        Team requirementsHub = buildTeam(2002L, "Requirements Hub", section, List.of());
+
+        when(sectionRepository.findById(1L)).thenReturn(Optional.of(section));
+        when(teamRepository.findAllBySectionIdWithStudentsOrdered(1L)).thenReturn(List.of(pulseAnalytics, requirementsHub));
+        when(userRepository.findEnabledStudentsBySectionId(1L)).thenReturn(List.of(ava, mia));
+
+        InvalidTeamStudentAssignmentException ex = assertThrows(
+            InvalidTeamStudentAssignmentException.class,
+            () -> service.updateAssignments(
+                new UpdateTeamStudentAssignmentsRequest(
+                    1L,
+                    List.of(
+                        new TeamStudentAssignmentInput(2001L, List.of(100L)),
+                        new TeamStudentAssignmentInput(2001L, List.of(101L))
+                    )
+                )
+            )
+        );
+
+        assertEquals("Each team may only appear once in the assignment payload.", ex.getMessage());
+    }
+
+    @Test
+    void should_ThrowInvalidArgument_When_AssignmentContainsDuplicateStudentIds() {
+        Section section = buildSection(1L, "Spring 2026 - Section A");
+        User ava = buildStudent(100L, "Ava", "Johnson", "ava@tcu.edu", section, true);
+        User mia = buildStudent(101L, "Mia", "Chen", "mia@tcu.edu", section, true);
+        Team pulseAnalytics = buildTeam(2001L, "Pulse Analytics", section, List.of());
+        Team requirementsHub = buildTeam(2002L, "Requirements Hub", section, List.of());
+
+        when(sectionRepository.findById(1L)).thenReturn(Optional.of(section));
+        when(teamRepository.findAllBySectionIdWithStudentsOrdered(1L)).thenReturn(List.of(pulseAnalytics, requirementsHub));
+        when(userRepository.findEnabledStudentsBySectionId(1L)).thenReturn(List.of(ava, mia));
+
+        InvalidTeamStudentAssignmentException ex = assertThrows(
+            InvalidTeamStudentAssignmentException.class,
+            () -> service.updateAssignments(
+                new UpdateTeamStudentAssignmentsRequest(
+                    1L,
+                    List.of(
+                        new TeamStudentAssignmentInput(2001L, List.of(100L)),
+                        new TeamStudentAssignmentInput(2002L, List.of(100L, 101L))
+                    )
+                )
+            )
+        );
+
+        assertEquals("Each student may only be assigned to one team.", ex.getMessage());
+    }
+
+    @Test
+    void should_ThrowInvalidArgument_When_NotEverySectionStudentIsAssigned() {
+        Section section = buildSection(1L, "Spring 2026 - Section A");
+        User ava = buildStudent(100L, "Ava", "Johnson", "ava@tcu.edu", section, true);
+        User mia = buildStudent(101L, "Mia", "Chen", "mia@tcu.edu", section, true);
+        Team pulseAnalytics = buildTeam(2001L, "Pulse Analytics", section, List.of());
+        Team requirementsHub = buildTeam(2002L, "Requirements Hub", section, List.of());
+
+        when(sectionRepository.findById(1L)).thenReturn(Optional.of(section));
+        when(teamRepository.findAllBySectionIdWithStudentsOrdered(1L)).thenReturn(List.of(pulseAnalytics, requirementsHub));
+        when(userRepository.findEnabledStudentsBySectionId(1L)).thenReturn(List.of(ava, mia));
+
+        InvalidTeamStudentAssignmentException ex = assertThrows(
+            InvalidTeamStudentAssignmentException.class,
+            () -> service.updateAssignments(
+                new UpdateTeamStudentAssignmentsRequest(
+                    1L,
+                    List.of(
+                        new TeamStudentAssignmentInput(2001L, List.of(100L)),
+                        new TeamStudentAssignmentInput(2002L, List.of())
+                    )
+                )
+            )
+        );
+
+        assertEquals("Every eligible student in the selected section must be assigned to exactly one team.", ex.getMessage());
+    }
+
+    @Test
+    void should_ThrowInvalidArgument_When_TeamDoesNotBelongToSection() {
+        Section section = buildSection(1L, "Spring 2026 - Section A");
+        User ava = buildStudent(100L, "Ava", "Johnson", "ava@tcu.edu", section, true);
+        Team pulseAnalytics = buildTeam(2001L, "Pulse Analytics", section, List.of());
+
+        when(sectionRepository.findById(1L)).thenReturn(Optional.of(section));
+        when(teamRepository.findAllBySectionIdWithStudentsOrdered(1L)).thenReturn(List.of(pulseAnalytics));
+        when(userRepository.findEnabledStudentsBySectionId(1L)).thenReturn(List.of(ava));
+
+        InvalidTeamStudentAssignmentException ex = assertThrows(
+            InvalidTeamStudentAssignmentException.class,
+            () -> service.updateAssignments(
+                new UpdateTeamStudentAssignmentsRequest(
+                    1L,
+                    List.of(new TeamStudentAssignmentInput(9999L, List.of(100L)))
+                )
+            )
+        );
+
+        assertEquals("Team 9999 does not belong to section 1.", ex.getMessage());
+    }
+
+    @Test
+    void should_ThrowInvalidArgument_When_StudentDoesNotBelongToSection() {
+        Section section = buildSection(1L, "Spring 2026 - Section A");
+        User ava = buildStudent(100L, "Ava", "Johnson", "ava@tcu.edu", section, true);
+        Team pulseAnalytics = buildTeam(2001L, "Pulse Analytics", section, List.of());
+
+        when(sectionRepository.findById(1L)).thenReturn(Optional.of(section));
+        when(teamRepository.findAllBySectionIdWithStudentsOrdered(1L)).thenReturn(List.of(pulseAnalytics));
+        when(userRepository.findEnabledStudentsBySectionId(1L)).thenReturn(List.of(ava));
+
+        InvalidTeamStudentAssignmentException ex = assertThrows(
+            InvalidTeamStudentAssignmentException.class,
+            () -> service.updateAssignments(
+                new UpdateTeamStudentAssignmentsRequest(
+                    1L,
+                    List.of(new TeamStudentAssignmentInput(2001L, List.of(999L)))
+                )
+            )
+        );
+
+        assertEquals("Student 999 does not belong to section 1.", ex.getMessage());
+    }
+
+    private Section buildSection(Long sectionId, String sectionName) {
+        Section section = new Section();
+        section.setSectionId(sectionId);
+        section.setSectionName(sectionName);
+        return section;
+    }
+
+    private Team buildTeam(Long teamId, String teamName, Section section, List<User> students) {
+        Team team = new Team();
+        team.setTeamId(teamId);
+        team.setTeamName(teamName);
+        team.setSection(section);
+        team.setStudents(new LinkedHashSet<>(students));
+        return team;
+    }
+
+    private User buildStudent(
+        Long studentId,
+        String firstName,
+        String lastName,
+        String email,
+        Section section,
+        boolean enabled
+    ) {
+        User user = new User();
+        user.setId(studentId);
+        user.setFirstName(firstName);
+        user.setLastName(lastName);
+        user.setEmail(email);
+        user.setRoles("student");
+        user.setSection(section);
+        user.setEnabled(enabled);
+        return user;
+    }
+}

--- a/src/backend/src/test/java/team/projectpulse/user/repository/UserRepositoryIntegrationTest.java
+++ b/src/backend/src/test/java/team/projectpulse/user/repository/UserRepositoryIntegrationTest.java
@@ -1,0 +1,71 @@
+package team.projectpulse.user.repository;
+
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import org.springframework.test.context.ActiveProfiles;
+import team.projectpulse.section.domain.Section;
+import team.projectpulse.user.domain.User;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@DataJpaTest
+@ActiveProfiles("test")
+class UserRepositoryIntegrationTest {
+
+    @Autowired
+    private EntityManager entityManager;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Test
+    void should_ReturnOnlyEnabledStudentsInSectionOrderedByName() {
+        Section sectionA = persistSection("Spring 2026 - Section A");
+        Section sectionB = persistSection("Spring 2026 - Section B");
+
+        persistUser("Zoe", "Zimmer", "zoe@tcu.edu", "student", true, sectionA);
+        persistUser("Amy", "Adams", "amy@tcu.edu", "student", true, sectionA);
+        persistUser("Ian", "Stone", "ian@tcu.edu", "student", false, sectionA);
+        persistUser("Noah", "Bennett", "noah@tcu.edu", "instructor", true, sectionA);
+        persistUser("Mia", "Chen", "mia@tcu.edu", "student", true, sectionB);
+
+        entityManager.flush();
+        entityManager.clear();
+
+        List<User> students = userRepository.findEnabledStudentsBySectionId(sectionA.getSectionId());
+
+        assertEquals(List.of("Amy", "Zoe"), students.stream().map(User::getFirstName).toList());
+        assertEquals(List.of("amy@tcu.edu", "zoe@tcu.edu"), students.stream().map(User::getEmail).toList());
+    }
+
+    private Section persistSection(String sectionName) {
+        Section section = new Section();
+        section.setSectionName(sectionName);
+        section.setActive(true);
+        entityManager.persist(section);
+        return section;
+    }
+
+    private void persistUser(
+        String firstName,
+        String lastName,
+        String email,
+        String roles,
+        boolean enabled,
+        Section section
+    ) {
+        User user = new User();
+        user.setFirstName(firstName);
+        user.setLastName(lastName);
+        user.setEmail(email);
+        user.setPassword("encoded");
+        user.setRoles(roles);
+        user.setEnabled(enabled);
+        user.setSection(section);
+        entityManager.persist(user);
+    }
+}

--- a/src/frontend/src/features/team/pages/TeamStudentAssignments.vue
+++ b/src/frontend/src/features/team/pages/TeamStudentAssignments.vue
@@ -1,0 +1,651 @@
+<template>
+  <v-container>
+    <v-btn variant="text" prepend-icon="mdi-arrow-left" class="mb-4" @click="router.push({ name: 'teams' })">
+      Back to Teams
+    </v-btn>
+
+    <v-row class="mb-4" align="center">
+      <v-col>
+        <h2 class="text-h5 font-weight-bold">Assign Students to Senior Design Teams</h2>
+        <div class="text-body-2 text-medium-emphasis">
+          Select a section, stage assignments, review them, then confirm the final roster.
+        </div>
+      </v-col>
+    </v-row>
+
+    <v-card variant="outlined" class="mb-4">
+      <v-card-text class="pa-4">
+        <v-row align="center">
+          <v-col cols="12" md="6">
+            <v-select
+              v-model="selectedSectionId"
+              :items="sections"
+              item-title="sectionName"
+              item-value="sectionId"
+              label="Section"
+              :loading="sectionsLoading"
+              :disabled="sectionsLoading || saving"
+              clearable
+              @update:model-value="loadWorkspace"
+            />
+          </v-col>
+          <v-col cols="12" md="6" class="text-md-right">
+            <v-chip v-if="workspace" color="primary" variant="tonal" class="mr-2">
+              {{ workspace.teams.length }} teams
+            </v-chip>
+            <v-chip v-if="workspace" color="secondary" variant="tonal">
+              {{ workspace.students.length }} eligible students
+            </v-chip>
+          </v-col>
+        </v-row>
+
+        <v-alert v-if="validationMessage" type="warning" variant="tonal" class="mt-2">
+          {{ validationMessage }}
+        </v-alert>
+      </v-card-text>
+    </v-card>
+
+    <v-row v-if="workspaceLoading">
+      <v-col class="text-center">
+        <v-progress-circular indeterminate />
+      </v-col>
+    </v-row>
+
+    <v-alert v-else-if="!selectedSectionId" type="info" variant="tonal">
+      Select a section to load its teams and student roster.
+    </v-alert>
+
+    <template v-else-if="workspace">
+      <template v-if="step === 1">
+        <v-row>
+          <v-col cols="12" lg="8">
+            <v-card variant="outlined" class="mb-4">
+              <v-card-title class="pa-4 pb-2 d-flex align-center">
+                <span>Teams in {{ workspace.sectionName }}</span>
+                <v-spacer />
+                <v-chip color="primary" variant="tonal">
+                  {{ assignedCount }}/{{ workspace.students.length }} assigned
+                </v-chip>
+              </v-card-title>
+              <v-card-text>
+                <v-alert v-if="workspace.teams.length === 0" type="warning" variant="tonal">
+                  At least one team must exist in the selected section before assigning students.
+                </v-alert>
+                <v-row v-else>
+                  <v-col v-for="team in stagedTeams" :key="team.teamId" cols="12">
+                    <v-card
+                      variant="outlined"
+                      :class="['team-card', { 'team-card--selected': team.teamId === selectedTeamId }]"
+                    >
+                      <v-card-title class="pa-4 pb-2 d-flex align-center">
+                        <span>{{ team.teamName }}</span>
+                        <v-spacer />
+                        <v-chip size="small" variant="tonal" color="primary" class="mr-2">
+                          {{ team.assignedStudents.length }} students
+                        </v-chip>
+                        <v-btn
+                          size="small"
+                          color="primary"
+                          variant="text"
+                          @click="selectedTeamId = team.teamId"
+                        >
+                          {{ team.teamId === selectedTeamId ? 'Selected' : 'Select Team' }}
+                        </v-btn>
+                      </v-card-title>
+                      <v-card-text>
+                        <div v-if="team.assignedStudents.length === 0" class="text-medium-emphasis">
+                          No students assigned yet.
+                        </div>
+                        <div v-else class="assigned-list">
+                          <v-chip
+                            v-for="student in team.assignedStudents"
+                            :key="student.studentId"
+                            class="mr-2 mb-2"
+                            color="primary"
+                            variant="tonal"
+                          >
+                            {{ student.fullName }}
+                            <template #append>
+                              <v-btn
+                                icon="mdi-close"
+                                size="x-small"
+                                variant="text"
+                                class="ml-1"
+                                @click.stop="removeStudent(team.teamId, student.studentId)"
+                              />
+                            </template>
+                          </v-chip>
+                        </div>
+                      </v-card-text>
+                    </v-card>
+                  </v-col>
+                </v-row>
+              </v-card-text>
+            </v-card>
+          </v-col>
+
+          <v-col cols="12" lg="4">
+            <v-card variant="outlined" class="mb-4">
+              <v-card-title class="pa-4 pb-2">Student Pool</v-card-title>
+              <v-card-text>
+                <v-alert type="info" variant="tonal" density="compact" class="mb-4">
+                  Select one team, then choose students to assign or move. Reassigning a student removes them from the prior team automatically.
+                </v-alert>
+
+                <v-alert v-if="workspace.students.length === 0" type="warning" variant="tonal">
+                  At least one eligible student must exist in the selected section before assignments can be saved.
+                </v-alert>
+
+                <v-list v-else lines="two" density="compact">
+                  <v-list-item
+                    v-for="student in workspace.students"
+                    :key="student.studentId"
+                    :active="selectedStudentIds.includes(student.studentId)"
+                    @click="toggleStudentSelection(student.studentId)"
+                  >
+                    <template #prepend>
+                      <v-checkbox-btn
+                        :model-value="selectedStudentIds.includes(student.studentId)"
+                        @click.stop
+                        @update:model-value="toggleStudentSelection(student.studentId)"
+                      />
+                    </template>
+
+                    <v-list-item-title>{{ student.fullName }}</v-list-item-title>
+                    <v-list-item-subtitle>{{ student.email }}</v-list-item-subtitle>
+
+                    <template #append>
+                      <v-chip
+                        v-if="assignedTeamNameByStudentId(student.studentId)"
+                        size="small"
+                        color="primary"
+                        variant="tonal"
+                      >
+                        {{ assignedTeamNameByStudentId(student.studentId) }}
+                      </v-chip>
+                      <v-chip v-else size="small" color="warning" variant="tonal">
+                        Unassigned
+                      </v-chip>
+                    </template>
+                  </v-list-item>
+                </v-list>
+
+                <v-divider class="my-4" />
+
+                <v-btn
+                  block
+                  color="primary"
+                  prepend-icon="mdi-account-arrow-right"
+                  :disabled="!canAssignSelectedStudents"
+                  @click="assignSelectedStudents"
+                >
+                  Assign to Selected Team
+                </v-btn>
+              </v-card-text>
+            </v-card>
+
+            <v-card variant="outlined">
+              <v-card-title class="pa-4 pb-2">Current Status</v-card-title>
+              <v-card-text>
+                <div class="text-body-2 mb-2">
+                  Selected team:
+                  <strong>{{ selectedTeamName }}</strong>
+                </div>
+                <div class="text-body-2 mb-2">
+                  Unassigned students:
+                  <strong>{{ unassignedCount }}</strong>
+                </div>
+                <div class="text-body-2">
+                  Selected students:
+                  <strong>{{ selectedStudentIds.length }}</strong>
+                </div>
+              </v-card-text>
+              <v-card-actions class="pa-4 pt-0">
+                <v-btn variant="text" @click="resetStagedAssignments">Reset</v-btn>
+                <v-spacer />
+                <v-btn color="primary" @click="goToPreview">Preview</v-btn>
+              </v-card-actions>
+            </v-card>
+          </v-col>
+        </v-row>
+      </template>
+
+      <template v-else>
+        <v-card variant="outlined" class="mb-4">
+          <v-card-title class="pa-4 pb-2">Confirm Student Assignments</v-card-title>
+          <v-card-text>
+            <v-alert type="info" variant="tonal" class="mb-4">
+              Please review the team assignments before confirming. The save will replace the current memberships for this section.
+            </v-alert>
+
+            <v-table density="compact" class="mb-4">
+              <tbody>
+                <tr>
+                  <th class="text-left">Section</th>
+                  <td>{{ workspace.sectionName }}</td>
+                </tr>
+                <tr>
+                  <th class="text-left">Teams</th>
+                  <td>{{ stagedTeams.length }}</td>
+                </tr>
+                <tr>
+                  <th class="text-left">Students Assigned</th>
+                  <td>{{ assignedCount }}</td>
+                </tr>
+              </tbody>
+            </v-table>
+
+            <v-row>
+              <v-col v-for="team in stagedTeams" :key="team.teamId" cols="12" md="6">
+                <v-card variant="outlined" class="h-100">
+                  <v-card-title class="text-subtitle-1 font-weight-bold">{{ team.teamName }}</v-card-title>
+                  <v-card-text>
+                    <div v-if="team.assignedStudents.length === 0" class="text-medium-emphasis">No students assigned.</div>
+                    <v-chip
+                      v-for="student in team.assignedStudents"
+                      :key="student.studentId"
+                      size="small"
+                      variant="tonal"
+                      color="primary"
+                      class="mr-1 mb-1"
+                    >
+                      {{ student.fullName }}
+                    </v-chip>
+                  </v-card-text>
+                </v-card>
+              </v-col>
+            </v-row>
+          </v-card-text>
+          <v-divider />
+          <v-card-actions class="pa-4">
+            <v-btn variant="text" @click="cancelPreview">Cancel</v-btn>
+            <v-spacer />
+            <v-btn variant="outlined" @click="step = 1">Modify</v-btn>
+            <v-btn color="primary" :loading="saving" @click="confirmAssignments">Confirm</v-btn>
+          </v-card-actions>
+        </v-card>
+
+        <v-card variant="outlined">
+          <v-card-title class="pa-4 pb-2">Manual Notification Preview</v-card-title>
+          <v-card-text>
+            <div class="text-body-2 mb-3">
+              After saving, use this list to notify students of their assigned team.
+            </div>
+            <v-table density="compact">
+              <thead>
+                <tr>
+                  <th>Student</th>
+                  <th>Email</th>
+                  <th>Assigned Team</th>
+                  <th>Section</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr v-for="item in previewNotificationSummary" :key="item.studentId">
+                  <td>{{ item.fullName }}</td>
+                  <td>{{ item.email }}</td>
+                  <td>{{ item.teamName }}</td>
+                  <td>{{ item.sectionName }}</td>
+                </tr>
+              </tbody>
+            </v-table>
+          </v-card-text>
+        </v-card>
+      </template>
+
+      <v-card v-if="savedNotificationSummary.length" variant="outlined" class="mt-4">
+        <v-card-title class="pa-4 pb-2">Notify Students</v-card-title>
+        <v-card-text>
+          <div class="text-body-2 mb-3">
+            Assignments were saved successfully. Use this summary to notify students manually.
+          </div>
+          <v-table density="compact">
+            <thead>
+              <tr>
+                <th>Student</th>
+                <th>Email</th>
+                <th>Assigned Team</th>
+                <th>Section</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr v-for="item in savedNotificationSummary" :key="item.studentId">
+                <td>{{ item.fullName }}</td>
+                <td>{{ item.email }}</td>
+                <td>{{ item.teamName }}</td>
+                <td>{{ item.sectionName }}</td>
+              </tr>
+            </tbody>
+          </v-table>
+        </v-card-text>
+      </v-card>
+    </template>
+
+    <v-snackbar v-model="snackbar.show" :color="snackbar.color" timeout="3500">
+      {{ snackbar.message }}
+    </v-snackbar>
+  </v-container>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted, ref } from 'vue'
+import { useRouter } from 'vue-router'
+import { findSections } from '@/features/section/services/sectionService'
+import type { SectionSummary } from '@/features/section/services/sectionTypes'
+import {
+  getTeamStudentAssignmentWorkspace,
+  updateTeamStudentAssignments
+} from '../services/teamService'
+import type {
+  StudentAssignmentCandidate,
+  TeamStudentAssignmentTeam,
+  TeamStudentAssignmentWorkspace,
+  UpdateTeamStudentAssignmentsRequest
+} from '../services/teamTypes'
+
+interface NotificationSummaryItem {
+  studentId: number
+  fullName: string
+  email: string
+  teamName: string
+  sectionName: string
+}
+
+const router = useRouter()
+
+const sections = ref<SectionSummary[]>([])
+const selectedSectionId = ref<number | null>(null)
+const workspace = ref<TeamStudentAssignmentWorkspace | null>(null)
+const stagedTeams = ref<TeamStudentAssignmentTeam[]>([])
+const selectedTeamId = ref<number | null>(null)
+const selectedStudentIds = ref<number[]>([])
+const sectionsLoading = ref(false)
+const workspaceLoading = ref(false)
+const saving = ref(false)
+const step = ref(1)
+const validationMessage = ref('')
+const savedNotificationSummary = ref<NotificationSummaryItem[]>([])
+const snackbar = ref({ show: false, message: '', color: 'success' })
+
+const assignedCount = computed(() =>
+  stagedTeams.value.reduce((total, team) => total + team.assignedStudents.length, 0)
+)
+
+const unassignedCount = computed(() => {
+  const totalStudents = workspace.value?.students.length ?? 0
+  return Math.max(totalStudents - assignedCount.value, 0)
+})
+
+const selectedTeamName = computed(() =>
+  stagedTeams.value.find((team) => team.teamId === selectedTeamId.value)?.teamName ?? 'None selected'
+)
+
+const canAssignSelectedStudents = computed(() =>
+  selectedTeamId.value !== null && selectedStudentIds.value.length > 0
+)
+
+const previewNotificationSummary = computed(() =>
+  buildNotificationSummary(stagedTeams.value, workspace.value?.sectionName ?? '')
+)
+
+onMounted(async () => {
+  await loadSections()
+})
+
+async function loadSections() {
+  sectionsLoading.value = true
+  try {
+    const res = await findSections() as any
+    sections.value = res.flag ? (res.data ?? []) : []
+
+    if (sections.value.length === 1) {
+      selectedSectionId.value = sections.value[0].sectionId
+      await loadWorkspace()
+    }
+  } catch {
+    sections.value = []
+    snackbar.value = { show: true, message: 'Failed to load sections.', color: 'error' }
+  } finally {
+    sectionsLoading.value = false
+  }
+}
+
+async function loadWorkspace() {
+  validationMessage.value = ''
+  savedNotificationSummary.value = []
+  step.value = 1
+  selectedStudentIds.value = []
+
+  if (!selectedSectionId.value) {
+    workspace.value = null
+    stagedTeams.value = []
+    selectedTeamId.value = null
+    return
+  }
+
+  workspaceLoading.value = true
+  try {
+    const res = await getTeamStudentAssignmentWorkspace(selectedSectionId.value) as any
+    if (res.flag && res.data) {
+      workspace.value = res.data
+      stagedTeams.value = cloneTeams(res.data.teams)
+      selectedTeamId.value = stagedTeams.value[0]?.teamId ?? null
+      return
+    }
+
+    workspace.value = null
+    stagedTeams.value = []
+    selectedTeamId.value = null
+    snackbar.value = { show: true, message: res.message || 'Failed to load assignments.', color: 'error' }
+  } catch (error: any) {
+    workspace.value = null
+    stagedTeams.value = []
+    selectedTeamId.value = null
+    const message = error?.response?.data?.message || 'Failed to load assignments.'
+    snackbar.value = { show: true, message, color: 'error' }
+  } finally {
+    workspaceLoading.value = false
+  }
+}
+
+function toggleStudentSelection(studentId: number) {
+  if (selectedStudentIds.value.includes(studentId)) {
+    selectedStudentIds.value = selectedStudentIds.value.filter((id) => id !== studentId)
+    return
+  }
+  selectedStudentIds.value = [...selectedStudentIds.value, studentId]
+}
+
+function assignSelectedStudents() {
+  if (!selectedTeamId.value || !workspace.value) {
+    return
+  }
+
+  const selectedStudents = workspace.value.students.filter((student) =>
+    selectedStudentIds.value.includes(student.studentId)
+  )
+
+  stagedTeams.value = stagedTeams.value.map((team) => ({
+    ...team,
+    assignedStudents: team.assignedStudents.filter(
+      (student) => !selectedStudentIds.value.includes(student.studentId)
+    )
+  }))
+
+  const teamIndex = stagedTeams.value.findIndex((team) => team.teamId === selectedTeamId.value)
+  if (teamIndex >= 0) {
+    const mergedStudents = [
+      ...stagedTeams.value[teamIndex].assignedStudents,
+      ...selectedStudents.filter((student) =>
+        !stagedTeams.value[teamIndex].assignedStudents.some(
+          (assignedStudent) => assignedStudent.studentId === student.studentId
+        )
+      )
+    ].sort(compareStudents)
+
+    stagedTeams.value[teamIndex] = {
+      ...stagedTeams.value[teamIndex],
+      assignedStudents: mergedStudents
+    }
+  }
+
+  selectedStudentIds.value = []
+  validationMessage.value = ''
+}
+
+function removeStudent(teamId: number, studentId: number) {
+  stagedTeams.value = stagedTeams.value.map((team) => {
+    if (team.teamId !== teamId) {
+      return team
+    }
+    return {
+      ...team,
+      assignedStudents: team.assignedStudents.filter((student) => student.studentId !== studentId)
+    }
+  })
+}
+
+function resetStagedAssignments() {
+  if (!workspace.value) {
+    return
+  }
+
+  stagedTeams.value = cloneTeams(workspace.value.teams)
+  selectedTeamId.value = stagedTeams.value[0]?.teamId ?? null
+  selectedStudentIds.value = []
+  validationMessage.value = ''
+}
+
+function goToPreview() {
+  const message = validateBeforePreview()
+  if (message) {
+    validationMessage.value = message
+    return
+  }
+
+  validationMessage.value = ''
+  step.value = 2
+}
+
+function cancelPreview() {
+  resetStagedAssignments()
+  step.value = 1
+}
+
+async function confirmAssignments() {
+  if (!workspace.value) {
+    return
+  }
+
+  saving.value = true
+  try {
+    const payload: UpdateTeamStudentAssignmentsRequest = {
+      sectionId: workspace.value.sectionId,
+      assignments: stagedTeams.value.map((team) => ({
+        teamId: team.teamId,
+        studentIds: team.assignedStudents.map((student) => student.studentId)
+      }))
+    }
+
+    const res = await updateTeamStudentAssignments(payload) as any
+    if (res.flag && res.data) {
+      workspace.value = res.data
+      stagedTeams.value = cloneTeams(res.data.teams)
+      selectedTeamId.value = stagedTeams.value[0]?.teamId ?? null
+      selectedStudentIds.value = []
+      savedNotificationSummary.value = buildNotificationSummary(res.data.teams, res.data.sectionName)
+      validationMessage.value = ''
+      step.value = 1
+      snackbar.value = { show: true, message: 'Student team assignments saved successfully.', color: 'success' }
+      return
+    }
+
+    snackbar.value = {
+      show: true,
+      message: res.message || 'Failed to save student assignments.',
+      color: 'error'
+    }
+  } catch (error: any) {
+    const message = error?.response?.data?.message || 'Failed to save student assignments.'
+    snackbar.value = { show: true, message, color: 'error' }
+  } finally {
+    saving.value = false
+  }
+}
+
+function assignedTeamNameByStudentId(studentId: number) {
+  return stagedTeams.value.find((team) =>
+    team.assignedStudents.some((student) => student.studentId === studentId)
+  )?.teamName ?? null
+}
+
+function validateBeforePreview() {
+  if (!selectedSectionId.value || !workspace.value) {
+    return 'Section is required.'
+  }
+  if (workspace.value.teams.length === 0) {
+    return 'At least one team must exist in the selected section.'
+  }
+  if (workspace.value.students.length === 0) {
+    return 'At least one eligible student must exist in the selected section.'
+  }
+
+  const assignedStudentIds = stagedTeams.value.flatMap((team) =>
+    team.assignedStudents.map((student) => student.studentId)
+  )
+
+  if (assignedStudentIds.length !== workspace.value.students.length) {
+    return 'Every eligible student in the selected section must be assigned to exactly one team before preview.'
+  }
+
+  const uniqueStudentIds = new Set(assignedStudentIds)
+  if (uniqueStudentIds.size !== assignedStudentIds.length) {
+    return 'Each student may only be assigned to one team.'
+  }
+
+  return ''
+}
+
+function cloneTeams(teams: TeamStudentAssignmentTeam[]) {
+  return teams.map((team) => ({
+    ...team,
+    assignedStudents: [...team.assignedStudents].sort(compareStudents)
+  }))
+}
+
+function compareStudents(left: StudentAssignmentCandidate, right: StudentAssignmentCandidate) {
+  return left.fullName.localeCompare(right.fullName, undefined, { sensitivity: 'base' })
+    || left.email.localeCompare(right.email, undefined, { sensitivity: 'base' })
+}
+
+function buildNotificationSummary(teams: TeamStudentAssignmentTeam[], sectionName: string) {
+  return teams
+    .flatMap((team) => team.assignedStudents.map((student) => ({
+      studentId: student.studentId,
+      fullName: student.fullName,
+      email: student.email,
+      teamName: team.teamName,
+      sectionName
+    })))
+    .sort((left, right) =>
+      left.fullName.localeCompare(right.fullName, undefined, { sensitivity: 'base' })
+      || left.email.localeCompare(right.email, undefined, { sensitivity: 'base' })
+    )
+}
+</script>
+
+<style scoped lang="scss">
+.team-card {
+  border-color: rgba(var(--v-theme-outline), 0.5);
+}
+
+.team-card--selected {
+  border-color: rgb(var(--v-theme-primary));
+  box-shadow: 0 0 0 1px rgba(var(--v-theme-primary), 0.2);
+}
+
+.assigned-list {
+  display: flex;
+  flex-wrap: wrap;
+}
+</style>

--- a/src/frontend/src/features/team/pages/TeamStudentAssignments.vue
+++ b/src/frontend/src/features/team/pages/TeamStudentAssignments.vue
@@ -398,8 +398,9 @@ async function loadSections() {
     const res = await findSections() as any
     sections.value = res.flag ? (res.data ?? []) : []
 
-    if (sections.value.length === 1) {
-      selectedSectionId.value = sections.value[0].sectionId
+    const onlySection = sections.value[0]
+    if (sections.value.length === 1 && onlySection) {
+      selectedSectionId.value = onlySection.sectionId
       await loadWorkspace()
     }
   } catch {
@@ -474,17 +475,22 @@ function assignSelectedStudents() {
 
   const teamIndex = stagedTeams.value.findIndex((team) => team.teamId === selectedTeamId.value)
   if (teamIndex >= 0) {
+    const currentTeam = stagedTeams.value[teamIndex]
+    if (!currentTeam) {
+      return
+    }
+
     const mergedStudents = [
-      ...stagedTeams.value[teamIndex].assignedStudents,
+      ...currentTeam.assignedStudents,
       ...selectedStudents.filter((student) =>
-        !stagedTeams.value[teamIndex].assignedStudents.some(
+        !currentTeam.assignedStudents.some(
           (assignedStudent) => assignedStudent.studentId === student.studentId
         )
       )
     ].sort(compareStudents)
 
     stagedTeams.value[teamIndex] = {
-      ...stagedTeams.value[teamIndex],
+      ...currentTeam,
       assignedStudents: mergedStudents
     }
   }

--- a/src/frontend/src/features/team/pages/Teams.vue
+++ b/src/frontend/src/features/team/pages/Teams.vue
@@ -3,7 +3,12 @@
     <v-row class="mb-4" align="center">
       <v-col><h2 class="text-h5 font-weight-bold">Senior Design Teams</h2></v-col>
       <v-col v-if="isAdmin" cols="auto">
-        <v-btn color="primary" prepend-icon="mdi-plus" @click="openCreateDialog">Create Team</v-btn>
+        <div class="header-actions">
+          <v-btn variant="outlined" prepend-icon="mdi-account-switch" @click="openAssignmentsPage">
+            Assign Students
+          </v-btn>
+          <v-btn color="primary" prepend-icon="mdi-plus" @click="openCreateDialog">Create Team</v-btn>
+        </div>
       </v-col>
     </v-row>
 
@@ -300,6 +305,10 @@ function viewTeam(teamId: number) {
   router.push({ name: 'team-detail', params: { id: teamId } })
 }
 
+function openAssignmentsPage() {
+  router.push({ name: 'team-student-assignments' })
+}
+
 async function openCreateDialog() {
   form.value = emptyForm()
   errors.value = {}
@@ -394,5 +403,10 @@ function isValidAbsoluteHttpUrl(value: string) {
 <style scoped lang="scss">
 .chip-group {
   min-width: 180px;
+}
+
+.header-actions {
+  display: flex;
+  gap: 12px;
 }
 </style>

--- a/src/frontend/src/features/team/services/teamService.ts
+++ b/src/frontend/src/features/team/services/teamService.ts
@@ -1,8 +1,17 @@
 import request from '@/shared/utils/request'
 import type { ApiResponse } from '@/shared/types/api'
-import type { CreateTeamRequest, FindTeamsParams, TeamDetail, TeamSummary, UpdateTeamRequest } from './teamTypes'
+import type {
+  CreateTeamRequest,
+  FindTeamsParams,
+  TeamDetail,
+  TeamStudentAssignmentWorkspace,
+  TeamSummary,
+  UpdateTeamRequest,
+  UpdateTeamStudentAssignmentsRequest
+} from './teamTypes'
 
 const BASE = '/teams'
+const ASSIGNMENT_BASE = '/team-student-assignments'
 
 export const findTeams = (params?: FindTeamsParams) =>
   request.get<ApiResponse<TeamSummary[]>>(BASE, { params: params ?? {} })
@@ -15,3 +24,9 @@ export const createTeam = (payload: CreateTeamRequest) =>
 
 export const updateTeam = (id: number, payload: UpdateTeamRequest) =>
   request.put<ApiResponse<TeamDetail>>(`${BASE}/${id}`, payload)
+
+export const getTeamStudentAssignmentWorkspace = (sectionId: number) =>
+  request.get<ApiResponse<TeamStudentAssignmentWorkspace>>(ASSIGNMENT_BASE, { params: { sectionId } })
+
+export const updateTeamStudentAssignments = (payload: UpdateTeamStudentAssignmentsRequest) =>
+  request.put<ApiResponse<TeamStudentAssignmentWorkspace>>(ASSIGNMENT_BASE, payload)

--- a/src/frontend/src/features/team/services/teamTypes.ts
+++ b/src/frontend/src/features/team/services/teamTypes.ts
@@ -33,6 +33,35 @@ export interface UpdateTeamRequest {
   teamWebsiteUrl: string | null
 }
 
+export interface StudentAssignmentCandidate {
+  studentId: number
+  fullName: string
+  email: string
+}
+
+export interface TeamStudentAssignmentTeam {
+  teamId: number
+  teamName: string
+  assignedStudents: StudentAssignmentCandidate[]
+}
+
+export interface TeamStudentAssignmentWorkspace {
+  sectionId: number
+  sectionName: string
+  teams: TeamStudentAssignmentTeam[]
+  students: StudentAssignmentCandidate[]
+}
+
+export interface TeamStudentAssignmentInput {
+  teamId: number
+  studentIds: number[]
+}
+
+export interface UpdateTeamStudentAssignmentsRequest {
+  sectionId: number
+  assignments: TeamStudentAssignmentInput[]
+}
+
 export interface FindTeamsParams {
   sectionId?: number
   sectionName?: string

--- a/src/frontend/src/router/routes.ts
+++ b/src/frontend/src/router/routes.ts
@@ -70,6 +70,12 @@ export const routes = [
         meta: { title: 'Teams', icon: 'mdi-account-group', isMenuItem: true, requiresAuth: true, roles: ['admin', 'instructor'] }
       },
       {
+        path: '/teams/assign-students',
+        component: () => import('@/features/team/pages/TeamStudentAssignments.vue'),
+        name: 'team-student-assignments',
+        meta: { requiresAuth: true, roles: ['admin'] }
+      },
+      {
         path: '/teams/:id',
         component: () => import('@/features/team/pages/TeamDetail.vue'),
         name: 'team-detail',


### PR DESCRIPTION
Implemented UC-12 so admins can assign students to senior design teams by section, with a dedicated assignment page, confirmation flow, and manual notification summary after save. Added backend support for section-scoped team/student assignment, user section membership, validation, migration updates, and UC-12 test coverage.
