### PR TITLE
feat(uc-13): implement remove student from team flow

### DIFF
--- a/src/backend/src/main/java/team/projectpulse/team/controller/TeamController.java
+++ b/src/backend/src/main/java/team/projectpulse/team/controller/TeamController.java
@@ -1,6 +1,7 @@
 package team.projectpulse.team.controller;
 
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -55,5 +56,14 @@ public class TeamController {
     @PreAuthorize("hasRole('ADMIN')")
     public Result<TeamDetail> updateTeam(@PathVariable Long id, @RequestBody UpdateTeamRequest request) {
         return Result.success("Team updated successfully.", teamService.updateTeam(id, request));
+    }
+
+    @DeleteMapping("/{teamId}/students/{studentId}")
+    @PreAuthorize("hasRole('ADMIN')")
+    public Result<TeamDetail> removeStudentFromTeam(@PathVariable Long teamId, @PathVariable Long studentId) {
+        return Result.success(
+            "Student removed from team successfully.",
+            teamService.removeStudentFromTeam(teamId, studentId)
+        );
     }
 }

--- a/src/backend/src/main/java/team/projectpulse/team/controller/TeamExceptionHandler.java
+++ b/src/backend/src/main/java/team/projectpulse/team/controller/TeamExceptionHandler.java
@@ -8,6 +8,7 @@ import team.projectpulse.system.Result;
 import team.projectpulse.system.StatusCode;
 import team.projectpulse.team.domain.InvalidTeamException;
 import team.projectpulse.team.domain.InvalidTeamStudentAssignmentException;
+import team.projectpulse.team.domain.StudentNotFoundException;
 import team.projectpulse.team.domain.TeamAlreadyExistsException;
 import team.projectpulse.team.domain.TeamNotFoundException;
 
@@ -36,5 +37,11 @@ public class TeamExceptionHandler {
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     public Result<Void> handleInvalidTeamStudentAssignment(InvalidTeamStudentAssignmentException ex) {
         return Result.error(StatusCode.INVALID_ARGUMENT, ex.getMessage());
+    }
+
+    @ExceptionHandler(StudentNotFoundException.class)
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    public Result<Void> handleStudentNotFound(StudentNotFoundException ex) {
+        return Result.notFound(ex.getMessage());
     }
 }

--- a/src/backend/src/main/java/team/projectpulse/team/domain/StudentNotFoundException.java
+++ b/src/backend/src/main/java/team/projectpulse/team/domain/StudentNotFoundException.java
@@ -1,0 +1,8 @@
+package team.projectpulse.team.domain;
+
+public class StudentNotFoundException extends RuntimeException {
+
+    public StudentNotFoundException(Long studentId) {
+        super("No student found with id: " + studentId);
+    }
+}

--- a/src/backend/src/main/java/team/projectpulse/team/dto/TeamDetail.java
+++ b/src/backend/src/main/java/team/projectpulse/team/dto/TeamDetail.java
@@ -9,6 +9,7 @@ public record TeamDetail(
     String teamName,
     String teamDescription,
     String teamWebsiteUrl,
+    List<TeamMemberDetail> teamMembers,
     List<String> teamMemberNames,
     List<String> instructorNames
 ) {

--- a/src/backend/src/main/java/team/projectpulse/team/dto/TeamMemberDetail.java
+++ b/src/backend/src/main/java/team/projectpulse/team/dto/TeamMemberDetail.java
@@ -1,0 +1,8 @@
+package team.projectpulse.team.dto;
+
+public record TeamMemberDetail(
+    Long studentId,
+    String fullName,
+    String email
+) {
+}

--- a/src/backend/src/main/java/team/projectpulse/team/service/TeamService.java
+++ b/src/backend/src/main/java/team/projectpulse/team/service/TeamService.java
@@ -5,17 +5,22 @@ import team.projectpulse.section.domain.Section;
 import team.projectpulse.section.repository.SectionRepository;
 import team.projectpulse.team.domain.Team;
 import team.projectpulse.team.domain.InvalidTeamException;
+import team.projectpulse.team.domain.InvalidTeamStudentAssignmentException;
+import team.projectpulse.team.domain.StudentNotFoundException;
 import team.projectpulse.team.domain.TeamAlreadyExistsException;
 import team.projectpulse.team.domain.TeamNotFoundException;
 import team.projectpulse.team.dto.CreateTeamRequest;
 import team.projectpulse.team.dto.TeamDetail;
+import team.projectpulse.team.dto.TeamMemberDetail;
 import team.projectpulse.team.dto.TeamSummary;
 import team.projectpulse.team.dto.UpdateTeamRequest;
 import team.projectpulse.team.repository.TeamRepository;
 import team.projectpulse.user.domain.User;
+import team.projectpulse.user.repository.UserRepository;
 
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.Comparator;
 import java.util.List;
 import java.util.stream.StreamSupport;
 
@@ -24,10 +29,12 @@ public class TeamService {
 
     private final TeamRepository teamRepository;
     private final SectionRepository sectionRepository;
+    private final UserRepository userRepository;
 
-    public TeamService(TeamRepository teamRepository, SectionRepository sectionRepository) {
+    public TeamService(TeamRepository teamRepository, SectionRepository sectionRepository, UserRepository userRepository) {
         this.teamRepository = teamRepository;
         this.sectionRepository = sectionRepository;
+        this.userRepository = userRepository;
     }
 
     public List<TeamSummary> findTeams(Long sectionId, String sectionName, String teamName, String instructor) {
@@ -106,6 +113,27 @@ public class TeamService {
         return toDetail(teamRepository.save(team));
     }
 
+    public TeamDetail removeStudentFromTeam(Long teamId, Long studentId) {
+        Team team = teamRepository.findDetailById(teamId)
+            .orElseThrow(() -> new TeamNotFoundException(teamId));
+
+        User student = userRepository.findById(studentId)
+            .orElseThrow(() -> new StudentNotFoundException(studentId));
+
+        boolean assignedToTeam = team.getStudents().stream()
+            .anyMatch(teamStudent -> teamStudent.getId().equals(student.getId()));
+
+        if (!assignedToTeam) {
+            throw new InvalidTeamStudentAssignmentException(
+                "Student " + studentId + " is not assigned to team " + teamId + "."
+            );
+        }
+
+        team.getStudents().removeIf(teamStudent -> teamStudent.getId().equals(student.getId()));
+
+        return toDetail(teamRepository.save(team));
+    }
+
     private TeamSummary toSummary(Team team) {
         return new TeamSummary(
             team.getTeamId(),
@@ -127,9 +155,19 @@ public class TeamService {
             team.getTeamName(),
             team.getTeamDescription(),
             team.getTeamWebsiteUrl(),
+            toSortedTeamMembers(team.getStudents()),
             toSortedNames(team.getStudents()),
             toSortedNames(team.getInstructors())
         );
+    }
+
+    private List<TeamMemberDetail> toSortedTeamMembers(Iterable<User> users) {
+        return StreamSupport.stream(users.spliterator(), false)
+            .sorted(Comparator
+                .comparing(this::toDisplayName, String.CASE_INSENSITIVE_ORDER)
+                .thenComparing(User::getEmail, String.CASE_INSENSITIVE_ORDER))
+            .map(user -> new TeamMemberDetail(user.getId(), toDisplayName(user), user.getEmail()))
+            .toList();
     }
 
     private String toDisplayName(User user) {

--- a/src/backend/src/test/java/team/projectpulse/team/controller/TeamControllerIntegrationTest.java
+++ b/src/backend/src/test/java/team/projectpulse/team/controller/TeamControllerIntegrationTest.java
@@ -11,17 +11,22 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import team.projectpulse.section.domain.SectionNotFoundException;
 import team.projectpulse.team.domain.InvalidTeamException;
+import team.projectpulse.team.domain.InvalidTeamStudentAssignmentException;
+import team.projectpulse.team.domain.StudentNotFoundException;
 import team.projectpulse.team.domain.TeamAlreadyExistsException;
 import team.projectpulse.team.domain.TeamNotFoundException;
 import team.projectpulse.team.dto.TeamDetail;
+import team.projectpulse.team.dto.TeamMemberDetail;
 import team.projectpulse.team.dto.TeamSummary;
 import team.projectpulse.team.service.TeamService;
 
 import java.util.List;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
@@ -92,6 +97,7 @@ class TeamControllerIntegrationTest {
                 "Pulse Analytics",
                 "desc",
                 "https://pulse.example.com",
+                List.of(new TeamMemberDetail(100L, "Ava Johnson", "ava@tcu.edu")),
                 List.of("Ava Johnson"),
                 List.of("Ivy Stone")
             ));
@@ -117,6 +123,7 @@ class TeamControllerIntegrationTest {
                 "Review Board",
                 null,
                 null,
+                List.of(),
                 List.of(),
                 List.of()
             ));
@@ -166,6 +173,7 @@ class TeamControllerIntegrationTest {
                 "Requirements Hub",
                 "desc",
                 "https://requirements-hub.example.com",
+                List.of(),
                 List.of(),
                 List.of()
             ));
@@ -272,6 +280,7 @@ class TeamControllerIntegrationTest {
                 "Centralized workspace",
                 "https://requirements-hub.example.com",
                 List.of(),
+                List.of(),
                 List.of("Ivy Stone")
             ));
 
@@ -362,5 +371,91 @@ class TeamControllerIntegrationTest {
             .andExpect(jsonPath("$.flag").value(false))
             .andExpect(jsonPath("$.code").value(400))
             .andExpect(jsonPath("$.message").value("Team name is required."));
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void should_RemoveStudentFromTeam_When_AdminRequestsRemoval() throws Exception {
+        when(teamService.removeStudentFromTeam(10L, 100L))
+            .thenReturn(new TeamDetail(
+                10L,
+                2L,
+                "Spring 2026 - Section A",
+                "Requirements Hub",
+                "Centralized workspace",
+                "https://requirements-hub.example.com",
+                List.of(),
+                List.of(),
+                List.of("Ivy Stone")
+            ));
+
+        mockMvc.perform(delete("/api/v1/teams/10/students/100"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.flag").value(true))
+            .andExpect(jsonPath("$.message").value("Student removed from team successfully."))
+            .andExpect(jsonPath("$.data.teamId").value(10))
+            .andExpect(jsonPath("$.data.teamMembers").isArray())
+            .andExpect(jsonPath("$.data.teamMemberNames").isArray());
+
+        verify(teamService).removeStudentFromTeam(10L, 100L);
+    }
+
+    @Test
+    @WithMockUser(roles = "INSTRUCTOR")
+    void should_ReturnForbidden_When_InstructorRequestsStudentRemoval() throws Exception {
+        mockMvc.perform(delete("/api/v1/teams/10/students/100"))
+            .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @WithMockUser(roles = "STUDENT")
+    void should_ReturnForbidden_When_StudentRequestsStudentRemoval() throws Exception {
+        mockMvc.perform(delete("/api/v1/teams/10/students/100"))
+            .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void should_ReturnUnauthorized_When_UnauthenticatedRequestRemovesStudent() throws Exception {
+        mockMvc.perform(delete("/api/v1/teams/10/students/100"))
+            .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void should_ReturnNotFound_When_RemovingStudentFromMissingTeam() throws Exception {
+        when(teamService.removeStudentFromTeam(999L, 100L))
+            .thenThrow(new TeamNotFoundException(999L));
+
+        mockMvc.perform(delete("/api/v1/teams/999/students/100"))
+            .andExpect(status().isNotFound())
+            .andExpect(jsonPath("$.flag").value(false))
+            .andExpect(jsonPath("$.code").value(404))
+            .andExpect(jsonPath("$.message").value("No team found with id: 999"));
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void should_ReturnNotFound_When_RemovedStudentDoesNotExist() throws Exception {
+        when(teamService.removeStudentFromTeam(10L, 404L))
+            .thenThrow(new StudentNotFoundException(404L));
+
+        mockMvc.perform(delete("/api/v1/teams/10/students/404"))
+            .andExpect(status().isNotFound())
+            .andExpect(jsonPath("$.flag").value(false))
+            .andExpect(jsonPath("$.code").value(404))
+            .andExpect(jsonPath("$.message").value("No student found with id: 404"));
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void should_ReturnBadRequest_When_StudentIsNotAssignedToTeam() throws Exception {
+        when(teamService.removeStudentFromTeam(10L, 100L))
+            .thenThrow(new InvalidTeamStudentAssignmentException("Student 100 is not assigned to team 10."));
+
+        mockMvc.perform(delete("/api/v1/teams/10/students/100"))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.flag").value(false))
+            .andExpect(jsonPath("$.code").value(400))
+            .andExpect(jsonPath("$.message").value("Student 100 is not assigned to team 10."));
     }
 }

--- a/src/backend/src/test/java/team/projectpulse/team/service/TeamServiceTest.java
+++ b/src/backend/src/test/java/team/projectpulse/team/service/TeamServiceTest.java
@@ -9,15 +9,19 @@ import team.projectpulse.section.domain.Section;
 import team.projectpulse.section.domain.SectionNotFoundException;
 import team.projectpulse.section.repository.SectionRepository;
 import team.projectpulse.team.domain.InvalidTeamException;
+import team.projectpulse.team.domain.InvalidTeamStudentAssignmentException;
+import team.projectpulse.team.domain.StudentNotFoundException;
 import team.projectpulse.team.domain.Team;
 import team.projectpulse.team.domain.TeamAlreadyExistsException;
 import team.projectpulse.team.domain.TeamNotFoundException;
 import team.projectpulse.team.dto.CreateTeamRequest;
 import team.projectpulse.team.dto.TeamDetail;
+import team.projectpulse.team.dto.TeamMemberDetail;
 import team.projectpulse.team.dto.TeamSummary;
 import team.projectpulse.team.dto.UpdateTeamRequest;
 import team.projectpulse.team.repository.TeamRepository;
 import team.projectpulse.user.domain.User;
+import team.projectpulse.user.repository.UserRepository;
 
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -37,6 +41,9 @@ class TeamServiceTest {
 
     @Mock
     private SectionRepository sectionRepository;
+
+    @Mock
+    private UserRepository userRepository;
 
     @InjectMocks
     private TeamService teamService;
@@ -94,6 +101,10 @@ class TeamServiceTest {
         assertEquals("Pulse Analytics", detail.teamName());
         assertEquals("Analytics dashboard", detail.teamDescription());
         assertEquals("https://pulse.example.com", detail.teamWebsiteUrl());
+        assertEquals(List.of(
+            new TeamMemberDetail(2L, "Amy Adams", "amy@tcu.edu"),
+            new TeamMemberDetail(1L, "Zoe Zeta", "zoe@tcu.edu")
+        ), detail.teamMembers());
         assertEquals(List.of("Amy Adams", "Zoe Zeta"), detail.teamMemberNames());
         assertEquals(List.of("Ivy Stone", "Noah Bennett"), detail.instructorNames());
         verify(teamRepository).findDetailById(10L);
@@ -108,6 +119,8 @@ class TeamServiceTest {
 
         assertEquals(List.of("Amy Adams", "Zoe Zeta"), detail.teamMemberNames());
         assertEquals(List.of("Ivy Stone", "Noah Bennett"), detail.instructorNames());
+        assertEquals("Amy Adams", detail.teamMembers().getFirst().fullName());
+        assertEquals("amy@tcu.edu", detail.teamMembers().getFirst().email());
     }
 
     @Test
@@ -146,6 +159,7 @@ class TeamServiceTest {
         assertEquals("Requirements Hub", detail.teamName());
         assertEquals("Centralized workspace", detail.teamDescription());
         assertEquals("https://requirements-hub.example.com", detail.teamWebsiteUrl());
+        assertEquals(List.of(), detail.teamMembers());
         assertEquals(List.of(), detail.teamMemberNames());
         assertEquals(List.of(), detail.instructorNames());
         verify(sectionRepository).findById(2L);
@@ -235,6 +249,7 @@ class TeamServiceTest {
 
         assertEquals(List.of(), detail.teamMemberNames());
         assertEquals(List.of(), detail.instructorNames());
+        assertEquals(List.of(), detail.teamMembers());
     }
 
     @Test
@@ -253,6 +268,10 @@ class TeamServiceTest {
         assertEquals("Requirements Hub", detail.teamName());
         assertEquals("Centralized workspace", detail.teamDescription());
         assertEquals("https://requirements-hub.example.com", detail.teamWebsiteUrl());
+        assertEquals(List.of(
+            new TeamMemberDetail(2L, "Amy Adams", "amy@tcu.edu"),
+            new TeamMemberDetail(1L, "Zoe Zeta", "zoe@tcu.edu")
+        ), detail.teamMembers());
         assertEquals(List.of("Amy Adams", "Zoe Zeta"), detail.teamMemberNames());
         assertEquals(List.of("Ivy Stone", "Noah Bennett"), detail.instructorNames());
         verify(teamRepository).findDetailById(10L);
@@ -342,16 +361,141 @@ class TeamServiceTest {
         assertEquals("Team website URL must start with http:// or https://.", ex.getMessage());
     }
 
+    @Test
+    void should_RemoveStudentFromTeam_When_RequestIsValid() {
+        Team existingTeam = buildTeam();
+        User student = existingTeam.getStudents().stream()
+            .filter(teamStudent -> teamStudent.getId().equals(1L))
+            .findFirst()
+            .orElseThrow();
+        when(teamRepository.findDetailById(10L)).thenReturn(Optional.of(existingTeam));
+        when(userRepository.findById(1L)).thenReturn(Optional.of(student));
+        when(teamRepository.save(existingTeam)).thenReturn(existingTeam);
+
+        TeamDetail detail = teamService.removeStudentFromTeam(10L, 1L);
+
+        assertEquals(List.of(new TeamMemberDetail(2L, "Amy Adams", "amy@tcu.edu")), detail.teamMembers());
+        assertEquals(List.of("Amy Adams"), detail.teamMemberNames());
+        assertEquals(List.of("Ivy Stone", "Noah Bennett"), detail.instructorNames());
+        verify(teamRepository).findDetailById(10L);
+        verify(userRepository).findById(1L);
+        verify(teamRepository).save(existingTeam);
+    }
+
+    @Test
+    void should_RemoveLastStudentFromTeam_When_LastMemberIsRemoved() {
+        Team existingTeam = buildTeam();
+        User onlyStudent = new User();
+        onlyStudent.setId(5L);
+        onlyStudent.setFirstName("Ava");
+        onlyStudent.setLastName("Johnson");
+        onlyStudent.setEmail("ava@tcu.edu");
+        existingTeam.setStudents(new LinkedHashSet<>(List.of(onlyStudent)));
+
+        when(teamRepository.findDetailById(10L)).thenReturn(Optional.of(existingTeam));
+        when(userRepository.findById(5L)).thenReturn(Optional.of(onlyStudent));
+        when(teamRepository.save(existingTeam)).thenReturn(existingTeam);
+
+        TeamDetail detail = teamService.removeStudentFromTeam(10L, 5L);
+
+        assertEquals(List.of(), detail.teamMembers());
+        assertEquals(List.of(), detail.teamMemberNames());
+    }
+
+    @Test
+    void should_ThrowTeamNotFound_When_RemovingStudentFromMissingTeam() {
+        when(teamRepository.findDetailById(404L)).thenReturn(Optional.empty());
+
+        TeamNotFoundException ex = assertThrows(
+            TeamNotFoundException.class,
+            () -> teamService.removeStudentFromTeam(404L, 1L)
+        );
+
+        assertEquals("No team found with id: 404", ex.getMessage());
+    }
+
+    @Test
+    void should_ThrowStudentNotFound_When_StudentIdDoesNotExist() {
+        Team existingTeam = buildTeam();
+        when(teamRepository.findDetailById(10L)).thenReturn(Optional.of(existingTeam));
+        when(userRepository.findById(404L)).thenReturn(Optional.empty());
+
+        StudentNotFoundException ex = assertThrows(
+            StudentNotFoundException.class,
+            () -> teamService.removeStudentFromTeam(10L, 404L)
+        );
+
+        assertEquals("No student found with id: 404", ex.getMessage());
+    }
+
+    @Test
+    void should_ThrowInvalidArgument_When_StudentIsNotAssignedToTeam() {
+        Team existingTeam = buildTeam();
+        User student = new User();
+        student.setId(55L);
+        student.setFirstName("Mia");
+        student.setLastName("Chen");
+        student.setEmail("mia@tcu.edu");
+        when(teamRepository.findDetailById(10L)).thenReturn(Optional.of(existingTeam));
+        when(userRepository.findById(55L)).thenReturn(Optional.of(student));
+
+        InvalidTeamStudentAssignmentException ex = assertThrows(
+            InvalidTeamStudentAssignmentException.class,
+            () -> teamService.removeStudentFromTeam(10L, 55L)
+        );
+
+        assertEquals("Student 55 is not assigned to team 10.", ex.getMessage());
+    }
+
+    @Test
+    void should_PreserveSectionAndInstructors_When_RemovingStudent() {
+        Team existingTeam = buildTeam();
+        User student = existingTeam.getStudents().stream()
+            .filter(teamStudent -> teamStudent.getId().equals(1L))
+            .findFirst()
+            .orElseThrow();
+        when(teamRepository.findDetailById(10L)).thenReturn(Optional.of(existingTeam));
+        when(userRepository.findById(1L)).thenReturn(Optional.of(student));
+        when(teamRepository.save(existingTeam)).thenReturn(existingTeam);
+
+        TeamDetail detail = teamService.removeStudentFromTeam(10L, 1L);
+
+        assertEquals(2L, detail.sectionId());
+        assertEquals("Spring 2026 - Section A", detail.sectionName());
+        assertEquals(List.of("Ivy Stone", "Noah Bennett"), detail.instructorNames());
+    }
+
+    @Test
+    void should_ReturnTeamDetailWithTeamMembersAndNames_When_RemovalSucceeds() {
+        Team existingTeam = buildTeam();
+        User student = existingTeam.getStudents().stream()
+            .filter(teamStudent -> teamStudent.getId().equals(2L))
+            .findFirst()
+            .orElseThrow();
+        when(teamRepository.findDetailById(10L)).thenReturn(Optional.of(existingTeam));
+        when(userRepository.findById(2L)).thenReturn(Optional.of(student));
+        when(teamRepository.save(existingTeam)).thenReturn(existingTeam);
+
+        TeamDetail detail = teamService.removeStudentFromTeam(10L, 2L);
+
+        assertEquals(List.of(new TeamMemberDetail(1L, "Zoe Zeta", "zoe@tcu.edu")), detail.teamMembers());
+        assertEquals(List.of("Zoe Zeta"), detail.teamMemberNames());
+    }
+
     private Team buildTeam() {
         Section section = buildSection();
 
         User student1 = new User();
+        student1.setId(1L);
         student1.setFirstName("Zoe");
         student1.setLastName("Zeta");
+        student1.setEmail("zoe@tcu.edu");
 
         User student2 = new User();
+        student2.setId(2L);
         student2.setFirstName("Amy");
         student2.setLastName("Adams");
+        student2.setEmail("amy@tcu.edu");
 
         User instructor1 = new User();
         instructor1.setFirstName("Noah");

--- a/src/frontend/src/features/team/pages/TeamDetail.vue
+++ b/src/frontend/src/features/team/pages/TeamDetail.vue
@@ -50,19 +50,32 @@
       <v-row>
         <v-col cols="12" md="6">
           <v-card variant="outlined" class="fill-height">
-            <v-card-title class="text-subtitle-1 font-weight-bold pa-4 pb-2">Team Members</v-card-title>
+            <v-card-title class="text-subtitle-1 font-weight-bold pa-4 pb-2 d-flex align-center">
+              <span>Team Members</span>
+              <v-spacer />
+              <v-btn
+                v-if="isAdmin && team.teamMembers.length > 0"
+                size="small"
+                color="error"
+                variant="outlined"
+                prepend-icon="mdi-account-remove"
+                @click="openRemoveDialog"
+              >
+                Remove Student
+              </v-btn>
+            </v-card-title>
             <v-card-text>
-              <v-alert v-if="team.teamMemberNames.length === 0" type="info" variant="tonal" density="compact">
+              <v-alert v-if="team.teamMembers.length === 0" type="info" variant="tonal" density="compact">
                 No team members assigned.
               </v-alert>
               <div v-else>
                 <v-chip
-                  v-for="member in team.teamMemberNames"
-                  :key="member"
+                  v-for="member in team.teamMembers"
+                  :key="member.studentId"
                   size="small"
                   class="mr-1 mb-1"
                 >
-                  {{ member }}
+                  {{ member.fullName }}
                 </v-chip>
               </div>
             </v-card-text>
@@ -91,21 +104,54 @@
           </v-card>
         </v-col>
       </v-row>
+
+      <v-card v-if="removedStudentNotification" variant="outlined" class="mt-4">
+        <v-card-title class="text-subtitle-1 font-weight-bold pa-4 pb-2">Notify Student</v-card-title>
+        <v-card-text>
+          <div class="text-body-2 mb-3">
+            Use this summary to notify the student manually about the team removal.
+          </div>
+          <v-table density="compact">
+            <tbody>
+              <tr>
+                <th class="text-left">Student</th>
+                <td>{{ removedStudentNotification.fullName }}</td>
+              </tr>
+              <tr>
+                <th class="text-left">Email</th>
+                <td>{{ removedStudentNotification.email }}</td>
+              </tr>
+              <tr>
+                <th class="text-left">Previous Team</th>
+                <td>{{ removedStudentNotification.teamName }}</td>
+              </tr>
+              <tr>
+                <th class="text-left">Section</th>
+                <td>{{ removedStudentNotification.sectionName }}</td>
+              </tr>
+              <tr>
+                <th class="text-left">Status</th>
+                <td>{{ removedStudentNotification.status }}</td>
+              </tr>
+            </tbody>
+          </v-table>
+        </v-card-text>
+      </v-card>
     </template>
 
-    <v-dialog v-model="dialog" max-width="700" persistent>
+    <v-dialog v-model="editDialog" max-width="700" persistent>
       <v-card>
         <v-card-title class="pa-4">
-          {{ step === 1 ? 'Edit Team' : 'Confirm Team Changes' }}
+          {{ editStep === 1 ? 'Edit Team' : 'Confirm Team Changes' }}
         </v-card-title>
         <v-divider />
 
-        <v-card-text v-if="step === 1" class="pa-4">
+        <v-card-text v-if="editStep === 1" class="pa-4">
           <v-text-field
             v-model="form.teamName"
             label="Team Name"
             placeholder="e.g. Peer Evaluation Tool team"
-            :error-messages="errors.teamName"
+            :error-messages="editErrors.teamName"
             class="mb-4"
           />
 
@@ -120,7 +166,7 @@
             v-model="form.teamWebsiteUrl"
             label="Team Website URL"
             placeholder="https://example.com"
-            :error-messages="errors.teamWebsiteUrl"
+            :error-messages="editErrors.teamWebsiteUrl"
           />
         </v-card-text>
 
@@ -154,13 +200,128 @@
         <v-card-actions class="pa-4">
           <v-btn variant="text" @click="cancelEdit">Cancel</v-btn>
           <v-spacer />
-          <v-btn v-if="step === 2" variant="outlined" @click="step = 1">Modify</v-btn>
+          <v-btn v-if="editStep === 2" variant="outlined" @click="editStep = 1">Modify</v-btn>
           <v-btn
             color="primary"
-            :loading="saving"
-            @click="step === 1 ? goToPreview() : confirmEdit()"
+            :loading="editSaving"
+            @click="editStep === 1 ? goToEditPreview() : confirmEdit()"
           >
-            {{ step === 1 ? 'Preview' : 'Confirm' }}
+            {{ editStep === 1 ? 'Preview' : 'Confirm' }}
+          </v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
+
+    <v-dialog v-model="removeDialog" max-width="720" persistent>
+      <v-card>
+        <v-card-title class="pa-4">
+          {{ removeStep === 1 ? 'Remove Student' : 'Confirm Student Removal' }}
+        </v-card-title>
+        <v-divider />
+
+        <v-card-text v-if="removeStep === 1" class="pa-4">
+          <v-select
+            v-model="selectedStudentId"
+            :items="team?.teamMembers ?? []"
+            item-title="fullName"
+            item-value="studentId"
+            label="Student to Remove"
+            :error-messages="removeErrors.studentId"
+          />
+
+          <v-card v-if="selectedTeamMember" variant="outlined" class="mt-4">
+            <v-card-text>
+              <div class="text-caption text-medium-emphasis">Selected Student Email</div>
+              <div>{{ selectedTeamMember.email }}</div>
+            </v-card-text>
+          </v-card>
+        </v-card-text>
+
+        <v-card-text v-else class="pa-4">
+          <v-alert type="warning" variant="tonal" class="mb-4">
+            Please review the student removal before confirming.
+          </v-alert>
+
+          <v-table density="compact" class="mb-4">
+            <tbody>
+              <tr>
+                <th class="text-left">Section</th>
+                <td>{{ team?.sectionName ?? '—' }}</td>
+              </tr>
+              <tr>
+                <th class="text-left">Team</th>
+                <td>{{ team?.teamName ?? '—' }}</td>
+              </tr>
+              <tr>
+                <th class="text-left">Student</th>
+                <td>{{ selectedTeamMember?.fullName ?? '—' }}</td>
+              </tr>
+              <tr>
+                <th class="text-left">Email</th>
+                <td>{{ selectedTeamMember?.email ?? '—' }}</td>
+              </tr>
+            </tbody>
+          </v-table>
+
+          <div class="text-subtitle-2 font-weight-bold mb-2">Remaining Team Members</div>
+          <v-alert
+            v-if="remainingTeamMembers.length === 0"
+            type="info"
+            variant="tonal"
+            density="compact"
+            class="mb-4"
+          >
+            No team members will remain after this removal.
+          </v-alert>
+          <div v-else class="mb-4">
+            <v-chip
+              v-for="member in remainingTeamMembers"
+              :key="member.studentId"
+              size="small"
+              class="mr-1 mb-1"
+            >
+              {{ member.fullName }}
+            </v-chip>
+          </div>
+
+          <div class="text-subtitle-2 font-weight-bold mb-2">Manual Notification Preview</div>
+          <v-table density="compact">
+            <tbody>
+              <tr>
+                <th class="text-left">Student</th>
+                <td>{{ selectedTeamMember?.fullName ?? '—' }}</td>
+              </tr>
+              <tr>
+                <th class="text-left">Email</th>
+                <td>{{ selectedTeamMember?.email ?? '—' }}</td>
+              </tr>
+              <tr>
+                <th class="text-left">Previous Team</th>
+                <td>{{ team?.teamName ?? '—' }}</td>
+              </tr>
+              <tr>
+                <th class="text-left">Section</th>
+                <td>{{ team?.sectionName ?? '—' }}</td>
+              </tr>
+              <tr>
+                <th class="text-left">Status</th>
+                <td>Removed from team</td>
+              </tr>
+            </tbody>
+          </v-table>
+        </v-card-text>
+
+        <v-divider />
+        <v-card-actions class="pa-4">
+          <v-btn variant="text" @click="cancelRemove">Cancel</v-btn>
+          <v-spacer />
+          <v-btn v-if="removeStep === 2" variant="outlined" @click="removeStep = 1">Modify</v-btn>
+          <v-btn
+            color="error"
+            :loading="removeSaving"
+            @click="removeStep === 1 ? goToRemovePreview() : confirmRemove()"
+          >
+            {{ removeStep === 1 ? 'Preview' : 'Confirm' }}
           </v-btn>
         </v-card-actions>
       </v-card>
@@ -176,8 +337,16 @@
 import { computed, onMounted, ref } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { useUserInfoStore } from '@/stores/userInfo'
-import { getTeam, updateTeam } from '../services/teamService'
-import type { TeamDetail, UpdateTeamRequest } from '../services/teamTypes'
+import { getTeam, removeStudentFromTeam, updateTeam } from '../services/teamService'
+import type { TeamDetail, TeamMemberDetail, UpdateTeamRequest } from '../services/teamTypes'
+
+interface RemovedStudentNotification {
+  fullName: string
+  email: string
+  teamName: string
+  sectionName: string
+  status: string
+}
 
 const route = useRoute()
 const router = useRouter()
@@ -185,10 +354,16 @@ const userInfoStore = useUserInfoStore()
 
 const team = ref<TeamDetail | null>(null)
 const loading = ref(false)
-const dialog = ref(false)
-const step = ref(1)
-const saving = ref(false)
-const errors = ref<{ teamName?: string; teamWebsiteUrl?: string }>({})
+const editDialog = ref(false)
+const editStep = ref(1)
+const editSaving = ref(false)
+const editErrors = ref<{ teamName?: string; teamWebsiteUrl?: string }>({})
+const removeDialog = ref(false)
+const removeStep = ref(1)
+const removeSaving = ref(false)
+const removeErrors = ref<{ studentId?: string }>({})
+const selectedStudentId = ref<number | null>(null)
+const removedStudentNotification = ref<RemovedStudentNotification | null>(null)
 const snackbar = ref({ show: false, message: '', color: 'success' })
 
 const emptyForm = () => ({
@@ -206,6 +381,14 @@ const previewPayload = computed<UpdateTeamRequest>(() => ({
   teamDescription: normalizeOptional(form.value.teamDescription),
   teamWebsiteUrl: normalizeOptional(form.value.teamWebsiteUrl)
 }))
+
+const selectedTeamMember = computed<TeamMemberDetail | null>(() =>
+  team.value?.teamMembers.find((member) => member.studentId === selectedStudentId.value) ?? null
+)
+
+const remainingTeamMembers = computed(() =>
+  team.value?.teamMembers.filter((member) => member.studentId !== selectedStudentId.value) ?? []
+)
 
 onMounted(async () => {
   loading.value = true
@@ -232,21 +415,35 @@ function openEditDialog() {
     teamDescription: team.value.teamDescription ?? '',
     teamWebsiteUrl: team.value.teamWebsiteUrl ?? ''
   }
-  errors.value = {}
-  step.value = 1
-  dialog.value = true
+  editErrors.value = {}
+  editStep.value = 1
+  editDialog.value = true
 }
 
 function cancelEdit() {
-  dialog.value = false
+  editDialog.value = false
 }
 
-function validate(): boolean {
-  errors.value = {}
+function openRemoveDialog() {
+  selectedStudentId.value = null
+  removeErrors.value = {}
+  removeStep.value = 1
+  removeDialog.value = true
+}
+
+function cancelRemove() {
+  removeDialog.value = false
+  removeErrors.value = {}
+  selectedStudentId.value = null
+  removeStep.value = 1
+}
+
+function validateEdit(): boolean {
+  editErrors.value = {}
   let valid = true
 
   if (!form.value.teamName.trim()) {
-    errors.value.teamName = 'Team name is required.'
+    editErrors.value.teamName = 'Team name is required.'
     valid = false
   }
 
@@ -254,11 +451,11 @@ function validate(): boolean {
     try {
       const url = new URL(form.value.teamWebsiteUrl.trim())
       if (url.protocol !== 'http:' && url.protocol !== 'https:') {
-        errors.value.teamWebsiteUrl = 'Team website URL must start with http:// or https://.'
+        editErrors.value.teamWebsiteUrl = 'Team website URL must start with http:// or https://.'
         valid = false
       }
     } catch {
-      errors.value.teamWebsiteUrl = 'Team website URL must be a valid absolute URL.'
+      editErrors.value.teamWebsiteUrl = 'Team website URL must be a valid absolute URL.'
       valid = false
     }
   }
@@ -266,35 +463,84 @@ function validate(): boolean {
   return valid
 }
 
-function goToPreview() {
-  if (!validate()) return
-  step.value = 2
+function validateRemove(): boolean {
+  removeErrors.value = {}
+  if (!selectedStudentId.value) {
+    removeErrors.value.studentId = 'Student is required.'
+    return false
+  }
+  return true
+}
+
+function goToEditPreview() {
+  if (!validateEdit()) return
+  editStep.value = 2
+}
+
+function goToRemovePreview() {
+  if (!validateRemove()) return
+  removeStep.value = 2
 }
 
 async function confirmEdit() {
   if (!team.value) return
 
-  saving.value = true
+  editSaving.value = true
   try {
     const res = await updateTeam(team.value.teamId, previewPayload.value) as any
     if (res.flag && res.data) {
       team.value = res.data
-      dialog.value = false
+      editDialog.value = false
       snackbar.value = { show: true, message: 'Team updated successfully.', color: 'success' }
     }
   } catch (error: any) {
     const message = error?.response?.data?.message
     if (typeof message === 'string') {
       if (message.toLowerCase().includes('team name')) {
-        errors.value.teamName = message
-        step.value = 1
+        editErrors.value.teamName = message
+        editStep.value = 1
       } else if (message.toLowerCase().includes('website')) {
-        errors.value.teamWebsiteUrl = message
-        step.value = 1
+        editErrors.value.teamWebsiteUrl = message
+        editStep.value = 1
       }
     }
   } finally {
-    saving.value = false
+    editSaving.value = false
+  }
+}
+
+async function confirmRemove() {
+  if (!team.value || !selectedTeamMember.value) return
+
+  removeSaving.value = true
+  const removedStudent = selectedTeamMember.value
+
+  try {
+    const res = await removeStudentFromTeam(team.value.teamId, removedStudent.studentId) as any
+    if (res.flag && res.data) {
+      const updatedTeam = res.data as TeamDetail
+      team.value = updatedTeam
+      removedStudentNotification.value = {
+        fullName: removedStudent.fullName,
+        email: removedStudent.email,
+        teamName: updatedTeam.teamName,
+        sectionName: updatedTeam.sectionName,
+        status: 'Removed from team'
+      }
+      removeDialog.value = false
+      removeErrors.value = {}
+      selectedStudentId.value = null
+      removeStep.value = 1
+      snackbar.value = { show: true, message: 'Student removed from team successfully.', color: 'success' }
+      return
+    }
+
+    snackbar.value = { show: true, message: res.message || 'Failed to remove student from team.', color: 'error' }
+  } catch (error: any) {
+    const message = error?.response?.data?.message || 'Failed to remove student from team.'
+    snackbar.value = { show: true, message, color: 'error' }
+  } finally {
+    removeSaving.value = false
   }
 }
 

--- a/src/frontend/src/features/team/services/teamService.ts
+++ b/src/frontend/src/features/team/services/teamService.ts
@@ -25,6 +25,9 @@ export const createTeam = (payload: CreateTeamRequest) =>
 export const updateTeam = (id: number, payload: UpdateTeamRequest) =>
   request.put<ApiResponse<TeamDetail>>(`${BASE}/${id}`, payload)
 
+export const removeStudentFromTeam = (teamId: number, studentId: number) =>
+  request.delete<ApiResponse<TeamDetail>>(`${BASE}/${teamId}/students/${studentId}`)
+
 export const getTeamStudentAssignmentWorkspace = (sectionId: number) =>
   request.get<ApiResponse<TeamStudentAssignmentWorkspace>>(ASSIGNMENT_BASE, { params: { sectionId } })
 

--- a/src/frontend/src/features/team/services/teamTypes.ts
+++ b/src/frontend/src/features/team/services/teamTypes.ts
@@ -16,8 +16,15 @@ export interface TeamDetail {
   teamName: string
   teamDescription: string | null
   teamWebsiteUrl: string | null
+  teamMembers: TeamMemberDetail[]
   teamMemberNames: string[]
   instructorNames: string[]
+}
+
+export interface TeamMemberDetail {
+  studentId: number
+  fullName: string
+  email: string
 }
 
 export interface CreateTeamRequest {


### PR DESCRIPTION
Implemented UC-13 so admins can remove a student from a senior design team from the team detail page, with backend support for DELETE /api/v1/teams/{teamId}/students/{studentId}, confirmation before save, and a manual notification summary after removal. Added enriched team member detail data to the team detail response, updated the frontend removal flow, and added backend test coverage alongside frontend type-check/build verification.