### PR TITLE
feat(uc-14): implement delete team flow

### DIFF
--- a/src/backend/src/main/java/team/projectpulse/team/controller/TeamController.java
+++ b/src/backend/src/main/java/team/projectpulse/team/controller/TeamController.java
@@ -58,6 +58,13 @@ public class TeamController {
         return Result.success("Team updated successfully.", teamService.updateTeam(id, request));
     }
 
+    @DeleteMapping("/{id}")
+    @PreAuthorize("hasRole('ADMIN')")
+    public Result<Void> deleteTeam(@PathVariable Long id) {
+        teamService.deleteTeam(id);
+        return Result.success("Team deleted successfully.", null);
+    }
+
     @DeleteMapping("/{teamId}/students/{studentId}")
     @PreAuthorize("hasRole('ADMIN')")
     public Result<TeamDetail> removeStudentFromTeam(@PathVariable Long teamId, @PathVariable Long studentId) {

--- a/src/backend/src/main/java/team/projectpulse/team/service/TeamService.java
+++ b/src/backend/src/main/java/team/projectpulse/team/service/TeamService.java
@@ -113,6 +113,13 @@ public class TeamService {
         return toDetail(teamRepository.save(team));
     }
 
+    public void deleteTeam(Long id) {
+        Team team = teamRepository.findDetailById(id)
+            .orElseThrow(() -> new TeamNotFoundException(id));
+
+        teamRepository.delete(team);
+    }
+
     public TeamDetail removeStudentFromTeam(Long teamId, Long studentId) {
         Team team = teamRepository.findDetailById(teamId)
             .orElseThrow(() -> new TeamNotFoundException(teamId));

--- a/src/backend/src/test/java/team/projectpulse/team/controller/TeamControllerIntegrationTest.java
+++ b/src/backend/src/test/java/team/projectpulse/team/controller/TeamControllerIntegrationTest.java
@@ -375,6 +375,53 @@ class TeamControllerIntegrationTest {
 
     @Test
     @WithMockUser(roles = "ADMIN")
+    void should_DeleteTeamWrappedInResult_When_AdminRequestsDelete() throws Exception {
+        mockMvc.perform(delete("/api/v1/teams/10"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.flag").value(true))
+            .andExpect(jsonPath("$.code").value(200))
+            .andExpect(jsonPath("$.message").value("Team deleted successfully."))
+            .andExpect(jsonPath("$.data").isEmpty());
+
+        verify(teamService).deleteTeam(10L);
+    }
+
+    @Test
+    @WithMockUser(roles = "INSTRUCTOR")
+    void should_ReturnForbidden_When_InstructorRequestsTeamDelete() throws Exception {
+        mockMvc.perform(delete("/api/v1/teams/10"))
+            .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @WithMockUser(roles = "STUDENT")
+    void should_ReturnForbidden_When_StudentRequestsTeamDelete() throws Exception {
+        mockMvc.perform(delete("/api/v1/teams/10"))
+            .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void should_ReturnUnauthorized_When_UnauthenticatedRequestDeletesTeam() throws Exception {
+        mockMvc.perform(delete("/api/v1/teams/10"))
+            .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void should_ReturnNotFound_When_DeletedTeamDoesNotExist() throws Exception {
+        org.mockito.Mockito.doThrow(new TeamNotFoundException(999L))
+            .when(teamService)
+            .deleteTeam(999L);
+
+        mockMvc.perform(delete("/api/v1/teams/999"))
+            .andExpect(status().isNotFound())
+            .andExpect(jsonPath("$.flag").value(false))
+            .andExpect(jsonPath("$.code").value(404))
+            .andExpect(jsonPath("$.message").value("No team found with id: 999"));
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
     void should_RemoveStudentFromTeam_When_AdminRequestsRemoval() throws Exception {
         when(teamService.removeStudentFromTeam(10L, 100L))
             .thenReturn(new TeamDetail(

--- a/src/backend/src/test/java/team/projectpulse/team/service/TeamServiceTest.java
+++ b/src/backend/src/test/java/team/projectpulse/team/service/TeamServiceTest.java
@@ -30,6 +30,7 @@ import java.util.Optional;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -359,6 +360,41 @@ class TeamServiceTest {
         );
 
         assertEquals("Team website URL must start with http:// or https://.", ex.getMessage());
+    }
+
+    @Test
+    void should_DeleteTeam_When_TeamExists() {
+        Team existingTeam = buildTeam();
+        when(teamRepository.findDetailById(10L)).thenReturn(Optional.of(existingTeam));
+
+        teamService.deleteTeam(10L);
+
+        verify(teamRepository).findDetailById(10L);
+        verify(teamRepository).delete(existingTeam);
+    }
+
+    @Test
+    void should_ThrowNotFoundException_When_DeletingMissingTeam() {
+        when(teamRepository.findDetailById(404L)).thenReturn(Optional.empty());
+
+        TeamNotFoundException ex = assertThrows(
+            TeamNotFoundException.class,
+            () -> teamService.deleteTeam(404L)
+        );
+
+        assertEquals("No team found with id: 404", ex.getMessage());
+        verify(teamRepository, never()).delete(org.mockito.ArgumentMatchers.any(Team.class));
+    }
+
+    @Test
+    void should_LoadExistingTeamBeforeDelete_When_DeletingTeam() {
+        Team existingTeam = buildTeam();
+        when(teamRepository.findDetailById(10L)).thenReturn(Optional.of(existingTeam));
+
+        teamService.deleteTeam(10L);
+
+        verify(teamRepository).findDetailById(10L);
+        verify(teamRepository).delete(existingTeam);
     }
 
     @Test

--- a/src/frontend/src/features/team/pages/TeamDetail.vue
+++ b/src/frontend/src/features/team/pages/TeamDetail.vue
@@ -14,7 +14,12 @@
           <h2 class="text-h5 font-weight-bold">{{ team.teamName }}</h2>
         </v-col>
         <v-col v-if="isAdmin" cols="auto">
-          <v-btn color="primary" prepend-icon="mdi-pencil" @click="openEditDialog">Edit Team</v-btn>
+          <div class="admin-actions">
+            <v-btn color="primary" prepend-icon="mdi-pencil" @click="openEditDialog">Edit Team</v-btn>
+            <v-btn color="error" variant="outlined" prepend-icon="mdi-delete" @click="openDeleteDialog">
+              Delete Team
+            </v-btn>
+          </div>
         </v-col>
         <v-col cols="auto">
           <v-chip color="primary" variant="tonal">
@@ -327,6 +332,138 @@
       </v-card>
     </v-dialog>
 
+    <v-dialog v-model="deleteDialog" max-width="760" persistent>
+      <v-card>
+        <v-card-title class="pa-4">
+          {{ deleteStep === 1 ? 'Delete Team' : 'Confirm Team Deletion' }}
+        </v-card-title>
+        <v-divider />
+
+        <v-card-text v-if="deleteStep === 1" class="pa-4">
+          <v-alert type="warning" variant="tonal" class="mb-4">
+            Deleting this senior design team is permanent and cannot be undone.
+          </v-alert>
+
+          <div class="text-body-2 mb-4">
+            If you continue, the system will physically delete this team. Students and instructors will be removed
+            from the team automatically. Associated WARs and peer evaluations would also be deleted if those
+            records existed.
+          </div>
+
+          <v-table density="compact" class="mb-4">
+            <tbody>
+              <tr>
+                <th class="text-left">Section</th>
+                <td>{{ team?.sectionName ?? '—' }}</td>
+              </tr>
+              <tr>
+                <th class="text-left">Team</th>
+                <td>{{ team?.teamName ?? '—' }}</td>
+              </tr>
+              <tr>
+                <th class="text-left">Deletion Strategy</th>
+                <td>Physical delete</td>
+              </tr>
+              <tr>
+                <th class="text-left">Current Scope</th>
+                <td>Existing team and membership data in the current system</td>
+              </tr>
+            </tbody>
+          </v-table>
+
+          <v-alert type="info" variant="tonal">
+            WAR and peer-evaluation modules are not present in this repo yet, so this implementation deletes the
+            existing team and membership records now and defers future related-record cleanup until those modules exist.
+          </v-alert>
+        </v-card-text>
+
+        <v-card-text v-else class="pa-4">
+          <v-alert type="warning" variant="tonal" class="mb-4">
+            Please review the deletion consequences before confirming.
+          </v-alert>
+
+          <v-table density="compact" class="mb-4">
+            <tbody>
+              <tr>
+                <th class="text-left">Section</th>
+                <td>{{ team?.sectionName ?? '—' }}</td>
+              </tr>
+              <tr>
+                <th class="text-left">Team</th>
+                <td>{{ team?.teamName ?? '—' }}</td>
+              </tr>
+              <tr>
+                <th class="text-left">Status</th>
+                <td>Permanently delete this team</td>
+              </tr>
+            </tbody>
+          </v-table>
+
+          <div class="text-subtitle-2 font-weight-bold mb-2">Students to Remove</div>
+          <v-alert
+            v-if="!team?.teamMembers.length"
+            type="info"
+            variant="tonal"
+            density="compact"
+            class="mb-4"
+          >
+            No students are currently assigned to this team.
+          </v-alert>
+          <div v-else class="mb-4">
+            <v-chip
+              v-for="member in team.teamMembers"
+              :key="member.studentId"
+              size="small"
+              class="mr-1 mb-1"
+            >
+              {{ member.fullName }}
+            </v-chip>
+          </div>
+
+          <div class="text-subtitle-2 font-weight-bold mb-2">Instructors to Remove</div>
+          <v-alert
+            v-if="!team?.instructorNames.length"
+            type="info"
+            variant="tonal"
+            density="compact"
+            class="mb-4"
+          >
+            No instructors are currently assigned to this team.
+          </v-alert>
+          <div v-else class="mb-4">
+            <v-chip
+              v-for="instructor in team.instructorNames"
+              :key="instructor"
+              size="small"
+              color="primary"
+              variant="tonal"
+              class="mr-1 mb-1"
+            >
+              {{ instructor }}
+            </v-chip>
+          </div>
+
+          <v-alert type="error" variant="tonal">
+            This action cannot be undone.
+          </v-alert>
+        </v-card-text>
+
+        <v-divider />
+        <v-card-actions class="pa-4">
+          <v-btn variant="text" @click="cancelDelete">Cancel</v-btn>
+          <v-spacer />
+          <v-btn v-if="deleteStep === 2" variant="outlined" @click="deleteStep = 1">Modify</v-btn>
+          <v-btn
+            color="error"
+            :loading="deleteSaving"
+            @click="deleteStep === 1 ? goToDeletePreview() : confirmDelete()"
+          >
+            {{ deleteStep === 1 ? 'Preview' : 'Confirm' }}
+          </v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
+
     <v-snackbar v-model="snackbar.show" :color="snackbar.color" timeout="3000">
       {{ snackbar.message }}
     </v-snackbar>
@@ -337,8 +474,9 @@
 import { computed, onMounted, ref } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { useUserInfoStore } from '@/stores/userInfo'
-import { getTeam, removeStudentFromTeam, updateTeam } from '../services/teamService'
-import type { TeamDetail, TeamMemberDetail, UpdateTeamRequest } from '../services/teamTypes'
+import { deleteTeam, getTeam, removeStudentFromTeam, updateTeam } from '../services/teamService'
+import { useTeamNotificationsStore } from '../stores/teamNotifications'
+import type { TeamDeletionNotification, TeamDetail, TeamMemberDetail, UpdateTeamRequest } from '../services/teamTypes'
 
 interface RemovedStudentNotification {
   fullName: string
@@ -351,6 +489,7 @@ interface RemovedStudentNotification {
 const route = useRoute()
 const router = useRouter()
 const userInfoStore = useUserInfoStore()
+const teamNotificationsStore = useTeamNotificationsStore()
 
 const team = ref<TeamDetail | null>(null)
 const loading = ref(false)
@@ -363,6 +502,9 @@ const removeStep = ref(1)
 const removeSaving = ref(false)
 const removeErrors = ref<{ studentId?: string }>({})
 const selectedStudentId = ref<number | null>(null)
+const deleteDialog = ref(false)
+const deleteStep = ref(1)
+const deleteSaving = ref(false)
 const removedStudentNotification = ref<RemovedStudentNotification | null>(null)
 const snackbar = ref({ show: false, message: '', color: 'success' })
 
@@ -438,6 +580,16 @@ function cancelRemove() {
   removeStep.value = 1
 }
 
+function openDeleteDialog() {
+  deleteStep.value = 1
+  deleteDialog.value = true
+}
+
+function cancelDelete() {
+  deleteDialog.value = false
+  deleteStep.value = 1
+}
+
 function validateEdit(): boolean {
   editErrors.value = {}
   let valid = true
@@ -480,6 +632,10 @@ function goToEditPreview() {
 function goToRemovePreview() {
   if (!validateRemove()) return
   removeStep.value = 2
+}
+
+function goToDeletePreview() {
+  deleteStep.value = 2
 }
 
 async function confirmEdit() {
@@ -544,8 +700,52 @@ async function confirmRemove() {
   }
 }
 
+async function confirmDelete() {
+  if (!team.value) return
+
+  deleteSaving.value = true
+  const notification = buildDeletedTeamNotification(team.value)
+
+  try {
+    const res = await deleteTeam(team.value.teamId) as any
+    if (res.flag) {
+      teamNotificationsStore.setDeletedTeamNotification(notification)
+      await router.push({ name: 'teams' })
+      return
+    }
+
+    snackbar.value = { show: true, message: res.message || 'Failed to delete team.', color: 'error' }
+  } catch (error: any) {
+    const message = error?.response?.data?.message || 'Failed to delete team.'
+    snackbar.value = { show: true, message, color: 'error' }
+  } finally {
+    deleteSaving.value = false
+  }
+}
+
+function buildDeletedTeamNotification(currentTeam: TeamDetail): TeamDeletionNotification {
+  return {
+    teamId: currentTeam.teamId,
+    teamName: currentTeam.teamName,
+    sectionName: currentTeam.sectionName,
+    studentNotifications: currentTeam.teamMembers.map((member) => ({
+      fullName: member.fullName,
+      email: member.email
+    })),
+    instructorNotifications: currentTeam.instructorNames.map((fullName) => ({ fullName })),
+    status: 'Team deleted'
+  }
+}
+
 function normalizeOptional(value: string): string | null {
   const trimmed = value.trim()
   return trimmed ? trimmed : null
 }
 </script>
+
+<style scoped lang="scss">
+.admin-actions {
+  display: flex;
+  gap: 12px;
+}
+</style>

--- a/src/frontend/src/features/team/pages/Teams.vue
+++ b/src/frontend/src/features/team/pages/Teams.vue
@@ -12,6 +12,89 @@
       </v-col>
     </v-row>
 
+    <v-row v-if="deletedTeamNotification" class="mb-4">
+      <v-col cols="12">
+        <v-card variant="outlined">
+          <v-card-title class="pa-4 pb-2 d-flex align-center">
+            <span>Notify Affected Users</span>
+            <v-spacer />
+            <v-btn variant="text" size="small" @click="dismissDeletedTeamNotification">Dismiss</v-btn>
+          </v-card-title>
+          <v-card-text class="pt-0">
+            <div class="text-body-2 mb-3">
+              Use this summary to notify affected students and instructors manually about the deleted team.
+            </div>
+
+            <v-table density="compact" class="mb-4">
+              <tbody>
+                <tr>
+                  <th class="text-left">Team</th>
+                  <td>{{ deletedTeamNotification.teamName }}</td>
+                </tr>
+                <tr>
+                  <th class="text-left">Section</th>
+                  <td>{{ deletedTeamNotification.sectionName }}</td>
+                </tr>
+                <tr>
+                  <th class="text-left">Status</th>
+                  <td>{{ deletedTeamNotification.status }}</td>
+                </tr>
+              </tbody>
+            </v-table>
+
+            <div class="text-subtitle-2 font-weight-bold mb-2">Affected Students</div>
+            <v-alert
+              v-if="deletedTeamNotification.studentNotifications.length === 0"
+              type="info"
+              variant="tonal"
+              density="compact"
+              class="mb-4"
+            >
+              No students were assigned to the deleted team.
+            </v-alert>
+            <v-table v-else density="compact" class="mb-4">
+              <thead>
+                <tr>
+                  <th class="text-left">Student</th>
+                  <th class="text-left">Email</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr v-for="student in deletedTeamNotification.studentNotifications" :key="student.email ?? student.fullName">
+                  <td>{{ student.fullName }}</td>
+                  <td>{{ student.email ?? '—' }}</td>
+                </tr>
+              </tbody>
+            </v-table>
+
+            <div class="text-subtitle-2 font-weight-bold mb-2">Affected Instructors</div>
+            <v-alert
+              v-if="deletedTeamNotification.instructorNotifications.length === 0"
+              type="info"
+              variant="tonal"
+              density="compact"
+            >
+              No instructors were assigned to the deleted team.
+            </v-alert>
+            <v-table v-else density="compact">
+              <thead>
+                <tr>
+                  <th class="text-left">Instructor</th>
+                  <th class="text-left">Email</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr v-for="instructor in deletedTeamNotification.instructorNotifications" :key="instructor.fullName">
+                  <td>{{ instructor.fullName }}</td>
+                  <td>{{ instructor.email ?? '—' }}</td>
+                </tr>
+              </tbody>
+            </v-table>
+          </v-card-text>
+        </v-card>
+      </v-col>
+    </v-row>
+
     <v-row class="mb-4">
       <v-col cols="12" md="4">
         <v-text-field
@@ -234,12 +317,14 @@ import { computed, onMounted, ref } from 'vue'
 import { useRouter } from 'vue-router'
 import { findSections } from '@/features/section/services/sectionService'
 import { useUserInfoStore } from '@/stores/userInfo'
+import { useTeamNotificationsStore } from '../stores/teamNotifications'
 import { createTeam, findTeams } from '../services/teamService'
 import type { SectionSummary } from '@/features/section/services/sectionTypes'
 import type { CreateTeamRequest, FindTeamsParams, TeamSummary } from '../services/teamTypes'
 
 const router = useRouter()
 const userInfoStore = useUserInfoStore()
+const teamNotificationsStore = useTeamNotificationsStore()
 const teams = ref<TeamSummary[]>([])
 const loading = ref(false)
 const filters = ref<FindTeamsParams>({
@@ -265,6 +350,7 @@ const errors = ref<{ sectionId?: string; teamName?: string; teamWebsiteUrl?: str
 const snackbar = ref({ show: false, message: '', color: 'success' })
 
 const isAdmin = computed(() => userInfoStore.isAdmin)
+const deletedTeamNotification = computed(() => teamNotificationsStore.deletedTeamNotification)
 
 const previewPayload = computed<CreateTeamRequest>(() => ({
   sectionId: form.value.sectionId ?? 0,
@@ -277,7 +363,12 @@ const selectedSectionName = computed(() => {
   return sections.value.find((section) => section.sectionId === form.value.sectionId)?.sectionName ?? '—'
 })
 
-onMounted(() => search())
+onMounted(async () => {
+  if (deletedTeamNotification.value) {
+    snackbar.value = { show: true, message: 'Team deleted successfully.', color: 'success' }
+  }
+  await search()
+})
 
 async function search() {
   loading.value = true
@@ -303,6 +394,10 @@ function clearFilters() {
 
 function viewTeam(teamId: number) {
   router.push({ name: 'team-detail', params: { id: teamId } })
+}
+
+function dismissDeletedTeamNotification() {
+  teamNotificationsStore.clearDeletedTeamNotification()
 }
 
 function openAssignmentsPage() {

--- a/src/frontend/src/features/team/services/teamService.ts
+++ b/src/frontend/src/features/team/services/teamService.ts
@@ -25,6 +25,9 @@ export const createTeam = (payload: CreateTeamRequest) =>
 export const updateTeam = (id: number, payload: UpdateTeamRequest) =>
   request.put<ApiResponse<TeamDetail>>(`${BASE}/${id}`, payload)
 
+export const deleteTeam = (id: number) =>
+  request.delete<ApiResponse<null>>(`${BASE}/${id}`)
+
 export const removeStudentFromTeam = (teamId: number, studentId: number) =>
   request.delete<ApiResponse<TeamDetail>>(`${BASE}/${teamId}/students/${studentId}`)
 

--- a/src/frontend/src/features/team/services/teamTypes.ts
+++ b/src/frontend/src/features/team/services/teamTypes.ts
@@ -27,6 +27,20 @@ export interface TeamMemberDetail {
   email: string
 }
 
+export interface TeamNotificationRecipient {
+  fullName: string
+  email?: string
+}
+
+export interface TeamDeletionNotification {
+  teamId: number
+  teamName: string
+  sectionName: string
+  studentNotifications: TeamNotificationRecipient[]
+  instructorNotifications: TeamNotificationRecipient[]
+  status: string
+}
+
 export interface CreateTeamRequest {
   sectionId: number
   teamName: string

--- a/src/frontend/src/features/team/stores/teamNotifications.ts
+++ b/src/frontend/src/features/team/stores/teamNotifications.ts
@@ -1,0 +1,21 @@
+import { defineStore } from 'pinia'
+import { ref } from 'vue'
+import type { TeamDeletionNotification } from '../services/teamTypes'
+
+export const useTeamNotificationsStore = defineStore('teamNotifications', () => {
+  const deletedTeamNotification = ref<TeamDeletionNotification | null>(null)
+
+  function setDeletedTeamNotification(notification: TeamDeletionNotification) {
+    deletedTeamNotification.value = notification
+  }
+
+  function clearDeletedTeamNotification() {
+    deletedTeamNotification.value = null
+  }
+
+  return {
+    deletedTeamNotification,
+    setDeletedTeamNotification,
+    clearDeletedTeamNotification
+  }
+})


### PR DESCRIPTION
Implements UC-14: admins can now delete a senior design team from the team detail page through a warning/preview/confirm flow. This adds the backend DELETE /api/v1/teams/{id} endpoint, physical team deletion in the service layer, and a post-delete manual notification summary on the Teams page for affected students and instructors. Frontend npm run type-check and npm exec vite build passed; backend mvn test is still blocked in this environment by the existing Mockito/JDK 25 issue.