### PR TITLE
feat(UC-11): implement admin invite students by email

### DIFF
--- a/src/backend/src/main/java/team/projectpulse/invite/controller/InviteController.java
+++ b/src/backend/src/main/java/team/projectpulse/invite/controller/InviteController.java
@@ -1,0 +1,43 @@
+package team.projectpulse.invite.controller;
+
+import jakarta.validation.Valid;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+import team.projectpulse.invite.dto.InvitePreview;
+import team.projectpulse.invite.dto.InvitePreviewRequest;
+import team.projectpulse.invite.dto.InviteSendRequest;
+import team.projectpulse.invite.dto.InviteSendResult;
+import team.projectpulse.invite.service.InviteService;
+import team.projectpulse.system.Result;
+import team.projectpulse.user.domain.User;
+
+@RestController
+@RequestMapping("${api.endpoint.base-url}/sections/{sectionId}/invites")
+public class InviteController {
+
+    private final InviteService inviteService;
+
+    public InviteController(InviteService inviteService) {
+        this.inviteService = inviteService;
+    }
+
+    @PreAuthorize("hasRole('ADMIN')")
+    @PostMapping("/preview")
+    public Result<InvitePreview> preview(@PathVariable Long sectionId,
+                                         @Valid @RequestBody InvitePreviewRequest request,
+                                         Authentication authentication) {
+        User admin = (User) authentication.getPrincipal();
+        return Result.success(inviteService.preview(sectionId, request.emailsInput(), admin));
+    }
+
+    @PreAuthorize("hasRole('ADMIN')")
+    @PostMapping("/send")
+    public Result<InviteSendResult> send(@PathVariable Long sectionId,
+                                          @Valid @RequestBody InviteSendRequest request,
+                                          Authentication authentication) {
+        User admin = (User) authentication.getPrincipal();
+        return Result.success("Invitations sent successfully.",
+                inviteService.send(sectionId, request.emails(), admin));
+    }
+}

--- a/src/backend/src/main/java/team/projectpulse/invite/controller/InviteExceptionHandler.java
+++ b/src/backend/src/main/java/team/projectpulse/invite/controller/InviteExceptionHandler.java
@@ -1,0 +1,21 @@
+package team.projectpulse.invite.controller;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import team.projectpulse.invite.domain.InvalidEmailFormatException;
+import team.projectpulse.system.Result;
+import team.projectpulse.system.StatusCode;
+
+import java.util.List;
+
+@RestControllerAdvice
+public class InviteExceptionHandler {
+
+    @ExceptionHandler(InvalidEmailFormatException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public Result<List<String>> handleInvalidEmailFormat(InvalidEmailFormatException ex) {
+        return new Result<>(false, StatusCode.INVALID_ARGUMENT, ex.getMessage(), ex.getInvalidEmails());
+    }
+}

--- a/src/backend/src/main/java/team/projectpulse/invite/domain/InvalidEmailFormatException.java
+++ b/src/backend/src/main/java/team/projectpulse/invite/domain/InvalidEmailFormatException.java
@@ -1,0 +1,19 @@
+package team.projectpulse.invite.domain;
+
+import java.util.List;
+
+public class InvalidEmailFormatException extends RuntimeException {
+
+    private final List<String> invalidEmails;
+
+    public InvalidEmailFormatException(List<String> invalidEmails) {
+        super(invalidEmails.isEmpty()
+                ? "No valid email addresses provided."
+                : "Invalid email address(es): " + String.join(", ", invalidEmails));
+        this.invalidEmails = invalidEmails;
+    }
+
+    public List<String> getInvalidEmails() {
+        return invalidEmails;
+    }
+}

--- a/src/backend/src/main/java/team/projectpulse/invite/dto/InvitePreview.java
+++ b/src/backend/src/main/java/team/projectpulse/invite/dto/InvitePreview.java
@@ -1,0 +1,5 @@
+package team.projectpulse.invite.dto;
+
+import java.util.List;
+
+public record InvitePreview(List<String> emails, int emailCount, String subject, String body) {}

--- a/src/backend/src/main/java/team/projectpulse/invite/dto/InvitePreviewRequest.java
+++ b/src/backend/src/main/java/team/projectpulse/invite/dto/InvitePreviewRequest.java
@@ -1,0 +1,5 @@
+package team.projectpulse.invite.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record InvitePreviewRequest(@NotBlank String emailsInput) {}

--- a/src/backend/src/main/java/team/projectpulse/invite/dto/InviteSendRequest.java
+++ b/src/backend/src/main/java/team/projectpulse/invite/dto/InviteSendRequest.java
@@ -1,0 +1,7 @@
+package team.projectpulse.invite.dto;
+
+import jakarta.validation.constraints.NotEmpty;
+
+import java.util.List;
+
+public record InviteSendRequest(@NotEmpty List<String> emails) {}

--- a/src/backend/src/main/java/team/projectpulse/invite/dto/InviteSendResult.java
+++ b/src/backend/src/main/java/team/projectpulse/invite/dto/InviteSendResult.java
@@ -1,0 +1,3 @@
+package team.projectpulse.invite.dto;
+
+public record InviteSendResult(int sentCount) {}

--- a/src/backend/src/main/java/team/projectpulse/invite/service/EmailService.java
+++ b/src/backend/src/main/java/team/projectpulse/invite/service/EmailService.java
@@ -1,0 +1,28 @@
+package team.projectpulse.invite.service;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+
+@Service
+public class EmailService {
+
+    private final JavaMailSender mailSender;
+
+    @Value("${spring.mail.username}")
+    private String fromAddress;
+
+    public EmailService(JavaMailSender mailSender) {
+        this.mailSender = mailSender;
+    }
+
+    public void send(String to, String subject, String body) {
+        SimpleMailMessage message = new SimpleMailMessage();
+        message.setFrom(fromAddress);
+        message.setTo(to);
+        message.setSubject(subject);
+        message.setText(body);
+        mailSender.send(message);
+    }
+}

--- a/src/backend/src/main/java/team/projectpulse/invite/service/InviteService.java
+++ b/src/backend/src/main/java/team/projectpulse/invite/service/InviteService.java
@@ -1,0 +1,107 @@
+package team.projectpulse.invite.service;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import team.projectpulse.invite.domain.InvalidEmailFormatException;
+import team.projectpulse.invite.dto.InvitePreview;
+import team.projectpulse.invite.dto.InviteSendResult;
+import team.projectpulse.section.domain.SectionNotFoundException;
+import team.projectpulse.section.repository.SectionRepository;
+import team.projectpulse.user.domain.User;
+
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.List;
+import java.util.regex.Pattern;
+
+@Service
+public class InviteService {
+
+    private static final String EMAIL_SUBJECT =
+            "Welcome to The Peer Evaluation Tool - Complete Your Registration";
+
+    private static final Pattern EMAIL_PATTERN = Pattern.compile(
+            "^[a-zA-Z0-9._%+\\-]+@[a-zA-Z0-9.\\-]+\\.[a-zA-Z]{2,}$"
+    );
+
+    private final EmailService emailService;
+    private final SectionRepository sectionRepository;
+
+    @Value("${front-end.url}")
+    private String frontendUrl;
+
+    public InviteService(EmailService emailService, SectionRepository sectionRepository) {
+        this.emailService = emailService;
+        this.sectionRepository = sectionRepository;
+    }
+
+    public InvitePreview preview(Long sectionId, String emailsInput, User admin) {
+        sectionRepository.findById(sectionId)
+                .orElseThrow(() -> new SectionNotFoundException(sectionId));
+
+        List<String> emails = parseEmails(emailsInput);
+        validateEmails(emails);
+
+        String body = buildEmailBody(
+                admin.getFirstName() + " " + admin.getLastName(),
+                admin.getEmail(),
+                "[Registration link]"
+        );
+
+        return new InvitePreview(emails, emails.size(), EMAIL_SUBJECT, body);
+    }
+
+    public InviteSendResult send(Long sectionId, List<String> emails, User admin) {
+        sectionRepository.findById(sectionId)
+                .orElseThrow(() -> new SectionNotFoundException(sectionId));
+
+        String adminName = admin.getFirstName() + " " + admin.getLastName();
+        String adminEmail = admin.getEmail();
+
+        for (String email : emails) {
+            String registrationLink = frontendUrl + "/register?email="
+                    + URLEncoder.encode(email, StandardCharsets.UTF_8);
+            String body = buildEmailBody(adminName, adminEmail, registrationLink);
+            emailService.send(email, EMAIL_SUBJECT, body);
+        }
+
+        return new InviteSendResult(emails.size());
+    }
+
+    private List<String> parseEmails(String input) {
+        return Arrays.stream(input.split(";"))
+                .map(String::trim)
+                .filter(e -> !e.isBlank())
+                .distinct()
+                .toList();
+    }
+
+    private void validateEmails(List<String> emails) {
+        if (emails.isEmpty()) {
+            throw new InvalidEmailFormatException(List.of());
+        }
+        List<String> invalid = emails.stream()
+                .filter(e -> !EMAIL_PATTERN.matcher(e).matches())
+                .toList();
+        if (!invalid.isEmpty()) {
+            throw new InvalidEmailFormatException(invalid);
+        }
+    }
+
+    private String buildEmailBody(String adminName, String adminEmail, String registrationLink) {
+        return """
+                Hello,
+
+                %s has invited you to join The Peer Evaluation Tool. To complete your registration, please use the link below:
+                %s
+
+                If you have any questions or need assistance, feel free to contact %s or our team directly.
+
+                Please note: This email is not monitored, so do not reply directly to this message.
+
+                Best regards,
+                Peer Evaluation Tool Team
+                """.formatted(adminName, registrationLink, adminEmail);
+    }
+}

--- a/src/frontend/src/features/section/pages/SectionDetail.vue
+++ b/src/frontend/src/features/section/pages/SectionDetail.vue
@@ -14,12 +14,20 @@
         <v-col>
           <h2 class="text-h5 font-weight-bold">{{ section.sectionName }}</h2>
         </v-col>
-        <v-col cols="auto">
-          <v-chip :color="section.active ? 'success' : 'default'" variant="tonal" class="mr-2">
+        <v-col cols="auto" class="d-flex align-center ga-2">
+          <v-chip :color="section.active ? 'success' : 'default'" variant="tonal">
             {{ section.active ? 'Active' : 'Inactive' }}
           </v-chip>
-          <v-btn color="primary" prepend-icon="mdi-pencil" variant="outlined" @click="openEditDialog">
+          <v-btn color="primary" prepend-icon="mdi-pencil" variant="outlined" size="small" @click="openEditDialog">
             Edit
+          </v-btn>
+          <v-btn
+            color="primary"
+            prepend-icon="mdi-email-plus-outline"
+            size="small"
+            @click="router.push({ name: 'section-invite', params: { id: section.sectionId } })"
+          >
+            Invite Students
           </v-btn>
         </v-col>
       </v-row>

--- a/src/frontend/src/features/section/pages/SectionInvite.vue
+++ b/src/frontend/src/features/section/pages/SectionInvite.vue
@@ -1,0 +1,142 @@
+<template>
+  <v-container max-width="720">
+    <v-btn variant="text" prepend-icon="mdi-arrow-left" class="mb-4"
+           @click="router.push({ name: 'section-detail', params: { id: sectionId } })">
+      Back to Section
+    </v-btn>
+
+    <h2 class="text-h5 font-weight-bold mb-6">Invite Students</h2>
+
+    <!-- Step 1: Enter emails -->
+    <v-card v-if="step === 1" variant="outlined">
+      <v-card-title class="text-subtitle-1 font-weight-bold pa-4 pb-2">
+        Step 1 of 2 — Enter Student Emails
+      </v-card-title>
+      <v-card-text>
+        <p class="text-body-2 text-medium-emphasis mb-4">
+          Enter one or more student email addresses separated by semicolons.
+          Spaces between emails are ignored.
+        </p>
+        <v-textarea
+          v-model="emailsInput"
+          label="Student emails"
+          placeholder="alice@example.com; bob@example.com; carol@example.com"
+          rows="5"
+          variant="outlined"
+          :error-messages="inputError"
+          @input="inputError = ''"
+        />
+      </v-card-text>
+      <v-card-actions class="pa-4 pt-0">
+        <v-spacer />
+        <v-btn color="primary" :loading="loading" @click="handlePreview">
+          Next — Preview Email
+        </v-btn>
+      </v-card-actions>
+    </v-card>
+
+    <!-- Step 2: Preview & confirm -->
+    <template v-else-if="step === 2 && preview">
+      <v-card variant="outlined" class="mb-4">
+        <v-card-title class="text-subtitle-1 font-weight-bold pa-4 pb-2">
+          Step 2 of 2 — Confirm &amp; Send
+        </v-card-title>
+        <v-card-text>
+          <v-alert type="info" variant="tonal" density="compact" class="mb-4">
+            <strong>{{ preview.emailCount }}</strong>
+            {{ preview.emailCount === 1 ? 'invitation' : 'invitations' }} will be sent.
+          </v-alert>
+
+          <div class="text-caption text-medium-emphasis mb-1">Recipients</div>
+          <div class="mb-4">
+            <v-chip
+              v-for="email in preview.emails"
+              :key="email"
+              size="small"
+              class="mr-1 mb-1"
+            >{{ email }}</v-chip>
+          </div>
+
+          <div class="text-caption text-medium-emphasis mb-1">Email Message</div>
+          <v-sheet
+            rounded="lg"
+            border
+            class="pa-4 text-body-2"
+            style="white-space: pre-wrap; font-family: monospace; background: #f8f9fa;"
+          >
+            <div class="mb-1"><strong>Subject:</strong> {{ preview.subject }}</div>
+            <v-divider class="my-2" />
+            {{ preview.body }}
+          </v-sheet>
+        </v-card-text>
+        <v-card-actions class="pa-4 pt-0">
+          <v-btn variant="text" @click="step = 1">Modify Details</v-btn>
+          <v-spacer />
+          <v-btn color="primary" :loading="loading" @click="handleSend">
+            Send Invitations
+          </v-btn>
+        </v-card-actions>
+      </v-card>
+    </template>
+  </v-container>
+</template>
+
+<script setup lang="ts">
+import { ref, computed } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import { useNotifyStore } from '@/stores/notify'
+import { previewInvites, sendInvites } from '../services/inviteService'
+import type { InvitePreview } from '../services/inviteService'
+
+const route = useRoute()
+const router = useRouter()
+const notifyStore = useNotifyStore()
+
+const sectionId = computed(() => Number(route.params.id))
+
+const step = ref<1 | 2>(1)
+const emailsInput = ref('')
+const preview = ref<InvitePreview | null>(null)
+const loading = ref(false)
+const inputError = ref('')
+
+async function handlePreview() {
+  if (!emailsInput.value.trim()) {
+    inputError.value = 'Please enter at least one email address.'
+    return
+  }
+  loading.value = true
+  try {
+    const res = await previewInvites(sectionId.value, emailsInput.value) as any
+    if (res.flag) {
+      preview.value = res.data
+      step.value = 2
+    } else {
+      inputError.value = res.message
+    }
+  } catch (err: any) {
+    const msg = err?.response?.data?.message
+    inputError.value = msg || 'Failed to validate emails. Please try again.'
+  } finally {
+    loading.value = false
+  }
+}
+
+async function handleSend() {
+  if (!preview.value) return
+  loading.value = true
+  try {
+    const res = await sendInvites(sectionId.value, preview.value.emails) as any
+    if (res.flag) {
+      notifyStore.success(`${res.data.sentCount} invitation(s) sent successfully.`)
+      router.push({ name: 'section-detail', params: { id: sectionId.value } })
+    } else {
+      notifyStore.error(res.message)
+    }
+  } catch {
+    notifyStore.error('Failed to send invitations. Please try again.')
+  } finally {
+    loading.value = false
+  }
+}
+</script>

--- a/src/frontend/src/features/section/services/inviteService.ts
+++ b/src/frontend/src/features/section/services/inviteService.ts
@@ -1,0 +1,21 @@
+import request from '@/shared/utils/request'
+import type { ApiResponse } from '@/shared/types/api'
+
+const base = (sectionId: number) => `/sections/${sectionId}/invites`
+
+export interface InvitePreview {
+  emails: string[]
+  emailCount: number
+  subject: string
+  body: string
+}
+
+export interface InviteSendResult {
+  sentCount: number
+}
+
+export const previewInvites = (sectionId: number, emailsInput: string) =>
+  request.post<ApiResponse<InvitePreview>>(`${base(sectionId)}/preview`, { emailsInput })
+
+export const sendInvites = (sectionId: number, emails: string[]) =>
+  request.post<ApiResponse<InviteSendResult>>(`${base(sectionId)}/send`, { emails })

--- a/src/frontend/src/router/routes.ts
+++ b/src/frontend/src/router/routes.ts
@@ -61,6 +61,12 @@ export const routes = [
         name: 'section-detail',
         meta: { requiresAuth: true, roles: ['admin'] }
       },
+      {
+        path: '/sections/:id/invite',
+        component: () => import('@/features/section/pages/SectionInvite.vue'),
+        name: 'section-invite',
+        meta: { requiresAuth: true, roles: ['admin'] }
+      },
 
       // ── Teams ────────────────────────────────────────────────────────────
       {


### PR DESCRIPTION
- Backend: invite module with InviteController, InviteService, EmailService
  - POST /api/v1/sections/{id}/invites/preview — parses & validates semicolon-separated emails, returns count + email preview (admin only)
  - POST /api/v1/sections/{id}/invites/send — sends registration email to each address via Spring Mail with per-student registration link
  - InvalidEmailFormatException + handler for malformed addresses
- Frontend: SectionInvite.vue two-step flow
  - Step 1: textarea input for semicolon-separated emails
  - Step 2: shows recipient count, recipient chips, full email preview
  - Admin can go back to modify or confirm to send
- Added /sections/:id/invite route (admin-only)
- Added "Invite Students" button to SectionDetail header