### PR TITLE
feat(uc-19): implement instructor team assignments

### DIFF
--- a/src/backend/src/main/java/team/projectpulse/team/controller/TeamExceptionHandler.java
+++ b/src/backend/src/main/java/team/projectpulse/team/controller/TeamExceptionHandler.java
@@ -7,6 +7,7 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 import team.projectpulse.system.Result;
 import team.projectpulse.system.StatusCode;
 import team.projectpulse.team.domain.InvalidTeamException;
+import team.projectpulse.team.domain.InvalidTeamInstructorAssignmentException;
 import team.projectpulse.team.domain.InvalidTeamStudentAssignmentException;
 import team.projectpulse.team.domain.StudentNotFoundException;
 import team.projectpulse.team.domain.TeamAlreadyExistsException;
@@ -36,6 +37,12 @@ public class TeamExceptionHandler {
     @ExceptionHandler(InvalidTeamStudentAssignmentException.class)
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     public Result<Void> handleInvalidTeamStudentAssignment(InvalidTeamStudentAssignmentException ex) {
+        return Result.error(StatusCode.INVALID_ARGUMENT, ex.getMessage());
+    }
+
+    @ExceptionHandler(InvalidTeamInstructorAssignmentException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public Result<Void> handleInvalidTeamInstructorAssignment(InvalidTeamInstructorAssignmentException ex) {
         return Result.error(StatusCode.INVALID_ARGUMENT, ex.getMessage());
     }
 

--- a/src/backend/src/main/java/team/projectpulse/team/controller/TeamInstructorAssignmentController.java
+++ b/src/backend/src/main/java/team/projectpulse/team/controller/TeamInstructorAssignmentController.java
@@ -1,0 +1,41 @@
+package team.projectpulse.team.controller;
+
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import team.projectpulse.system.Result;
+import team.projectpulse.team.dto.TeamInstructorAssignmentWorkspace;
+import team.projectpulse.team.dto.UpdateTeamInstructorAssignmentsRequest;
+import team.projectpulse.team.service.TeamInstructorAssignmentService;
+
+@RestController
+@RequestMapping("${api.endpoint.base-url}/team-instructor-assignments")
+public class TeamInstructorAssignmentController {
+
+    private final TeamInstructorAssignmentService teamInstructorAssignmentService;
+
+    public TeamInstructorAssignmentController(TeamInstructorAssignmentService teamInstructorAssignmentService) {
+        this.teamInstructorAssignmentService = teamInstructorAssignmentService;
+    }
+
+    @GetMapping
+    @PreAuthorize("hasRole('ADMIN')")
+    public Result<TeamInstructorAssignmentWorkspace> loadWorkspace(@RequestParam Long sectionId) {
+        return Result.success(teamInstructorAssignmentService.loadWorkspace(sectionId));
+    }
+
+    @PutMapping
+    @PreAuthorize("hasRole('ADMIN')")
+    public Result<TeamInstructorAssignmentWorkspace> updateAssignments(
+        @RequestBody UpdateTeamInstructorAssignmentsRequest request
+    ) {
+        return Result.success(
+            "Instructor team assignments saved successfully.",
+            teamInstructorAssignmentService.updateAssignments(request)
+        );
+    }
+}

--- a/src/backend/src/main/java/team/projectpulse/team/domain/InvalidTeamInstructorAssignmentException.java
+++ b/src/backend/src/main/java/team/projectpulse/team/domain/InvalidTeamInstructorAssignmentException.java
@@ -1,0 +1,8 @@
+package team.projectpulse.team.domain;
+
+public class InvalidTeamInstructorAssignmentException extends RuntimeException {
+
+    public InvalidTeamInstructorAssignmentException(String message) {
+        super(message);
+    }
+}

--- a/src/backend/src/main/java/team/projectpulse/team/dto/InstructorAssignmentCandidate.java
+++ b/src/backend/src/main/java/team/projectpulse/team/dto/InstructorAssignmentCandidate.java
@@ -1,0 +1,11 @@
+package team.projectpulse.team.dto;
+
+import java.util.List;
+
+public record InstructorAssignmentCandidate(
+    Long instructorId,
+    String fullName,
+    String email,
+    List<String> assignedTeamNames
+) {
+}

--- a/src/backend/src/main/java/team/projectpulse/team/dto/TeamInstructorAssignmentInput.java
+++ b/src/backend/src/main/java/team/projectpulse/team/dto/TeamInstructorAssignmentInput.java
@@ -1,0 +1,9 @@
+package team.projectpulse.team.dto;
+
+import java.util.List;
+
+public record TeamInstructorAssignmentInput(
+    Long teamId,
+    List<Long> instructorIds
+) {
+}

--- a/src/backend/src/main/java/team/projectpulse/team/dto/TeamInstructorAssignmentInstructor.java
+++ b/src/backend/src/main/java/team/projectpulse/team/dto/TeamInstructorAssignmentInstructor.java
@@ -1,0 +1,8 @@
+package team.projectpulse.team.dto;
+
+public record TeamInstructorAssignmentInstructor(
+    Long instructorId,
+    String fullName,
+    String email
+) {
+}

--- a/src/backend/src/main/java/team/projectpulse/team/dto/TeamInstructorAssignmentTeam.java
+++ b/src/backend/src/main/java/team/projectpulse/team/dto/TeamInstructorAssignmentTeam.java
@@ -1,0 +1,10 @@
+package team.projectpulse.team.dto;
+
+import java.util.List;
+
+public record TeamInstructorAssignmentTeam(
+    Long teamId,
+    String teamName,
+    List<TeamInstructorAssignmentInstructor> assignedInstructors
+) {
+}

--- a/src/backend/src/main/java/team/projectpulse/team/dto/TeamInstructorAssignmentWorkspace.java
+++ b/src/backend/src/main/java/team/projectpulse/team/dto/TeamInstructorAssignmentWorkspace.java
@@ -1,0 +1,11 @@
+package team.projectpulse.team.dto;
+
+import java.util.List;
+
+public record TeamInstructorAssignmentWorkspace(
+    Long sectionId,
+    String sectionName,
+    List<TeamInstructorAssignmentTeam> teams,
+    List<InstructorAssignmentCandidate> instructors
+) {
+}

--- a/src/backend/src/main/java/team/projectpulse/team/dto/UpdateTeamInstructorAssignmentsRequest.java
+++ b/src/backend/src/main/java/team/projectpulse/team/dto/UpdateTeamInstructorAssignmentsRequest.java
@@ -1,0 +1,9 @@
+package team.projectpulse.team.dto;
+
+import java.util.List;
+
+public record UpdateTeamInstructorAssignmentsRequest(
+    Long sectionId,
+    List<TeamInstructorAssignmentInput> assignments
+) {
+}

--- a/src/backend/src/main/java/team/projectpulse/team/repository/TeamRepository.java
+++ b/src/backend/src/main/java/team/projectpulse/team/repository/TeamRepository.java
@@ -54,4 +54,13 @@ public interface TeamRepository extends JpaRepository<Team, Long> {
         order by lower(t.teamName)
         """)
     List<Team> findAllBySectionIdWithStudentsOrdered(@Param("sectionId") Long sectionId);
+
+    @Query("""
+        select distinct t from Team t
+        join fetch t.section s
+        left join fetch t.instructors i
+        where s.sectionId = :sectionId
+        order by lower(t.teamName)
+        """)
+    List<Team> findAllBySectionIdWithInstructorsOrdered(@Param("sectionId") Long sectionId);
 }

--- a/src/backend/src/main/java/team/projectpulse/team/service/TeamInstructorAssignmentService.java
+++ b/src/backend/src/main/java/team/projectpulse/team/service/TeamInstructorAssignmentService.java
@@ -1,0 +1,242 @@
+package team.projectpulse.team.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import team.projectpulse.section.domain.Section;
+import team.projectpulse.section.domain.SectionNotFoundException;
+import team.projectpulse.section.repository.SectionRepository;
+import team.projectpulse.team.domain.InvalidTeamInstructorAssignmentException;
+import team.projectpulse.team.domain.Team;
+import team.projectpulse.team.dto.InstructorAssignmentCandidate;
+import team.projectpulse.team.dto.TeamInstructorAssignmentInput;
+import team.projectpulse.team.dto.TeamInstructorAssignmentInstructor;
+import team.projectpulse.team.dto.TeamInstructorAssignmentTeam;
+import team.projectpulse.team.dto.TeamInstructorAssignmentWorkspace;
+import team.projectpulse.team.dto.UpdateTeamInstructorAssignmentsRequest;
+import team.projectpulse.team.repository.TeamRepository;
+import team.projectpulse.user.domain.User;
+import team.projectpulse.user.repository.UserRepository;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Service
+public class TeamInstructorAssignmentService {
+
+    private static final Comparator<User> USER_COMPARATOR = Comparator
+        .comparing(User::getLastName, String.CASE_INSENSITIVE_ORDER)
+        .thenComparing(User::getFirstName, String.CASE_INSENSITIVE_ORDER)
+        .thenComparing(User::getEmail, String.CASE_INSENSITIVE_ORDER);
+
+    private final SectionRepository sectionRepository;
+    private final TeamRepository teamRepository;
+    private final UserRepository userRepository;
+
+    public TeamInstructorAssignmentService(
+        SectionRepository sectionRepository,
+        TeamRepository teamRepository,
+        UserRepository userRepository
+    ) {
+        this.sectionRepository = sectionRepository;
+        this.teamRepository = teamRepository;
+        this.userRepository = userRepository;
+    }
+
+    public TeamInstructorAssignmentWorkspace loadWorkspace(Long sectionId) {
+        Section section = requireSection(sectionId);
+        List<Team> teams = teamRepository.findAllBySectionIdWithInstructorsOrdered(sectionId);
+        List<User> instructors = userRepository.findEnabledInstructorsOrdered();
+        return toWorkspace(section, teams, instructors);
+    }
+
+    @Transactional
+    public TeamInstructorAssignmentWorkspace updateAssignments(UpdateTeamInstructorAssignmentsRequest request) {
+        if (request == null) {
+            throw new InvalidTeamInstructorAssignmentException("Assignment request is required.");
+        }
+        if (request.sectionId() == null) {
+            throw new InvalidTeamInstructorAssignmentException("Section is required.");
+        }
+
+        Section section = requireSection(request.sectionId());
+        List<Team> teams = teamRepository.findAllBySectionIdWithInstructorsOrdered(request.sectionId());
+        List<User> eligibleInstructors = userRepository.findEnabledInstructorsOrdered();
+
+        if (teams.isEmpty()) {
+            throw new InvalidTeamInstructorAssignmentException("At least one team must exist in the selected section.");
+        }
+        if (eligibleInstructors.isEmpty()) {
+            throw new InvalidTeamInstructorAssignmentException("At least one enabled instructor must exist before assignments can be saved.");
+        }
+
+        Map<Long, Team> teamsById = teams.stream()
+            .collect(Collectors.toMap(Team::getTeamId, team -> team, (left, right) -> left, LinkedHashMap::new));
+        Map<Long, User> instructorsById = eligibleInstructors.stream()
+            .collect(Collectors.toMap(User::getId, user -> user, (left, right) -> left, LinkedHashMap::new));
+
+        Map<Long, List<Long>> assignmentsByTeam = validateAssignments(
+            request.assignments(),
+            request.sectionId(),
+            teamsById,
+            instructorsById
+        );
+
+        for (Team team : teams) {
+            team.setInstructors(new LinkedHashSet<>());
+        }
+
+        for (Map.Entry<Long, List<Long>> entry : assignmentsByTeam.entrySet()) {
+            Team team = teamsById.get(entry.getKey());
+            LinkedHashSet<User> assignedInstructors = entry.getValue().stream()
+                .map(instructorsById::get)
+                .collect(Collectors.toCollection(LinkedHashSet::new));
+            team.setInstructors(assignedInstructors);
+        }
+
+        teamRepository.saveAll(teams);
+
+        List<Team> refreshedTeams = teamRepository.findAllBySectionIdWithInstructorsOrdered(request.sectionId());
+        return toWorkspace(section, refreshedTeams, eligibleInstructors);
+    }
+
+    private Section requireSection(Long sectionId) {
+        if (sectionId == null) {
+            throw new InvalidTeamInstructorAssignmentException("Section is required.");
+        }
+        return sectionRepository.findById(sectionId)
+            .orElseThrow(() -> new SectionNotFoundException(sectionId));
+    }
+
+    private Map<Long, List<Long>> validateAssignments(
+        List<TeamInstructorAssignmentInput> assignments,
+        Long sectionId,
+        Map<Long, Team> teamsById,
+        Map<Long, User> instructorsById
+    ) {
+        if (assignments == null || assignments.isEmpty()) {
+            throw new InvalidTeamInstructorAssignmentException("Assignments are required.");
+        }
+
+        Set<Long> seenTeamIds = new LinkedHashSet<>();
+        Map<Long, List<Long>> assignmentsByTeam = new LinkedHashMap<>();
+
+        for (TeamInstructorAssignmentInput assignment : assignments) {
+            if (assignment == null || assignment.teamId() == null) {
+                throw new InvalidTeamInstructorAssignmentException("Each assignment must include a team.");
+            }
+            if (!seenTeamIds.add(assignment.teamId())) {
+                throw new InvalidTeamInstructorAssignmentException("Each team may only appear once in the assignment payload.");
+            }
+
+            Team team = teamsById.get(assignment.teamId());
+            if (team == null) {
+                throw new InvalidTeamInstructorAssignmentException(
+                    "Team " + assignment.teamId() + " does not belong to section " + sectionId + "."
+                );
+            }
+
+            List<Long> instructorIds = assignment.instructorIds() == null ? List.of() : assignment.instructorIds();
+            Set<Long> seenInstructorsInTeam = new LinkedHashSet<>();
+            List<Long> normalizedInstructorIds = new ArrayList<>();
+
+            for (Long instructorId : instructorIds) {
+                if (instructorId == null) {
+                    throw new InvalidTeamInstructorAssignmentException("Assigned instructor ids must not contain null values.");
+                }
+                if (!seenInstructorsInTeam.add(instructorId)) {
+                    throw new InvalidTeamInstructorAssignmentException("An instructor may only appear once per team assignment.");
+                }
+
+                User instructor = instructorsById.get(instructorId);
+                if (instructor == null || !isInstructor(instructor)) {
+                    throw new InvalidTeamInstructorAssignmentException("Instructor " + instructorId + " is not an enabled instructor.");
+                }
+
+                normalizedInstructorIds.add(instructorId);
+            }
+
+            if (normalizedInstructorIds.isEmpty()) {
+                throw new InvalidTeamInstructorAssignmentException(
+                    "Each team in the selected section must be assigned at least one instructor."
+                );
+            }
+
+            assignmentsByTeam.put(assignment.teamId(), normalizedInstructorIds);
+        }
+
+        if (!seenTeamIds.equals(teamsById.keySet())) {
+            throw new InvalidTeamInstructorAssignmentException(
+                "Assignments must be provided for every team in the selected section."
+            );
+        }
+
+        return assignmentsByTeam;
+    }
+
+    private TeamInstructorAssignmentWorkspace toWorkspace(Section section, List<Team> teams, List<User> instructors) {
+        Map<Long, List<String>> assignedTeamNamesByInstructorId = new LinkedHashMap<>();
+        for (User instructor : instructors) {
+            assignedTeamNamesByInstructorId.put(instructor.getId(), new ArrayList<>());
+        }
+
+        List<TeamInstructorAssignmentTeam> teamDtos = teams.stream()
+            .sorted(Comparator.comparing(Team::getTeamName, String.CASE_INSENSITIVE_ORDER))
+            .map(team -> {
+                List<TeamInstructorAssignmentInstructor> assignedInstructors = team.getInstructors().stream()
+                    .sorted(USER_COMPARATOR)
+                    .map(instructor -> {
+                        assignedTeamNamesByInstructorId
+                            .computeIfAbsent(instructor.getId(), ignored -> new ArrayList<>())
+                            .add(team.getTeamName());
+
+                        return new TeamInstructorAssignmentInstructor(
+                            instructor.getId(),
+                            toDisplayName(instructor),
+                            instructor.getEmail()
+                        );
+                    })
+                    .toList();
+
+                return new TeamInstructorAssignmentTeam(
+                    team.getTeamId(),
+                    team.getTeamName(),
+                    assignedInstructors
+                );
+            })
+            .toList();
+
+        List<InstructorAssignmentCandidate> instructorCandidates = instructors.stream()
+            .sorted(USER_COMPARATOR)
+            .map(instructor -> new InstructorAssignmentCandidate(
+                instructor.getId(),
+                toDisplayName(instructor),
+                instructor.getEmail(),
+                assignedTeamNamesByInstructorId.getOrDefault(instructor.getId(), List.of()).stream()
+                    .sorted(String.CASE_INSENSITIVE_ORDER)
+                    .toList()
+            ))
+            .toList();
+
+        return new TeamInstructorAssignmentWorkspace(
+            section.getSectionId(),
+            section.getSectionName(),
+            teamDtos,
+            instructorCandidates
+        );
+    }
+
+    private String toDisplayName(User user) {
+        return (user.getFirstName() + " " + user.getLastName()).trim();
+    }
+
+    private boolean isInstructor(User user) {
+        String roles = user.getRoles() == null ? "" : user.getRoles().toLowerCase();
+        return List.of(roles.split("\\s+")).contains("instructor");
+    }
+}

--- a/src/backend/src/main/java/team/projectpulse/user/repository/UserRepository.java
+++ b/src/backend/src/main/java/team/projectpulse/user/repository/UserRepository.java
@@ -21,4 +21,12 @@ public interface UserRepository extends JpaRepository<User, Long> {
         order by lower(u.lastName), lower(u.firstName), lower(u.email)
         """)
     List<User> findEnabledStudentsBySectionId(@Param("sectionId") Long sectionId);
+
+    @Query("""
+        select u from User u
+        where u.enabled = true
+          and lower(concat(' ', coalesce(u.roles, ''), ' ')) like '% instructor %'
+        order by lower(u.lastName), lower(u.firstName), lower(u.email)
+        """)
+    List<User> findEnabledInstructorsOrdered();
 }

--- a/src/backend/src/test/java/team/projectpulse/team/controller/TeamInstructorAssignmentControllerIntegrationTest.java
+++ b/src/backend/src/test/java/team/projectpulse/team/controller/TeamInstructorAssignmentControllerIntegrationTest.java
@@ -1,0 +1,146 @@
+package team.projectpulse.team.controller;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import team.projectpulse.section.domain.SectionNotFoundException;
+import team.projectpulse.team.domain.InvalidTeamInstructorAssignmentException;
+import team.projectpulse.team.dto.InstructorAssignmentCandidate;
+import team.projectpulse.team.dto.TeamInstructorAssignmentInstructor;
+import team.projectpulse.team.dto.TeamInstructorAssignmentTeam;
+import team.projectpulse.team.dto.TeamInstructorAssignmentWorkspace;
+import team.projectpulse.team.service.TeamInstructorAssignmentService;
+
+import java.util.List;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class TeamInstructorAssignmentControllerIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private TeamInstructorAssignmentService teamInstructorAssignmentService;
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void should_LoadWorkspace_When_AdminRequestsAssignments() throws Exception {
+        when(teamInstructorAssignmentService.loadWorkspace(1L)).thenReturn(buildWorkspace());
+
+        mockMvc.perform(get("/api/v1/team-instructor-assignments").param("sectionId", "1"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.flag").value(true))
+            .andExpect(jsonPath("$.data.sectionName").value("Spring 2026 - Section A"))
+            .andExpect(jsonPath("$.data.teams[0].teamName").value("Pulse Analytics"))
+            .andExpect(jsonPath("$.data.instructors[0].fullName").value("Ivy Stone"));
+
+        verify(teamInstructorAssignmentService).loadWorkspace(1L);
+    }
+
+    @Test
+    @WithMockUser(roles = "INSTRUCTOR")
+    void should_ReturnForbidden_When_InstructorRequestsAssignments() throws Exception {
+        mockMvc.perform(get("/api/v1/team-instructor-assignments").param("sectionId", "1"))
+            .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @WithMockUser(roles = "STUDENT")
+    void should_ReturnForbidden_When_StudentRequestsAssignments() throws Exception {
+        mockMvc.perform(get("/api/v1/team-instructor-assignments").param("sectionId", "1"))
+            .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void should_ReturnUnauthorized_When_UnauthenticatedUserRequestsAssignments() throws Exception {
+        mockMvc.perform(get("/api/v1/team-instructor-assignments").param("sectionId", "1"))
+            .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void should_SaveAssignments_When_AdminConfirmsAssignments() throws Exception {
+        when(teamInstructorAssignmentService.updateAssignments(org.mockito.ArgumentMatchers.any())).thenReturn(buildWorkspace());
+
+        mockMvc.perform(put("/api/v1/team-instructor-assignments")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                    {
+                      "sectionId": 1,
+                      "assignments": [
+                        { "teamId": 2001, "instructorIds": [100] }
+                      ]
+                    }
+                    """))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.flag").value(true))
+            .andExpect(jsonPath("$.message").value("Instructor team assignments saved successfully."))
+            .andExpect(jsonPath("$.data.teams[0].assignedInstructors[0].instructorId").value(100));
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void should_ReturnBadRequest_When_AssignmentPayloadIsInvalid() throws Exception {
+        when(teamInstructorAssignmentService.updateAssignments(org.mockito.ArgumentMatchers.any()))
+            .thenThrow(new InvalidTeamInstructorAssignmentException(
+                "Each team in the selected section must be assigned at least one instructor."
+            ));
+
+        mockMvc.perform(put("/api/v1/team-instructor-assignments")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                    {
+                      "sectionId": 1,
+                      "assignments": [
+                        { "teamId": 2001, "instructorIds": [] }
+                      ]
+                    }
+                    """))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.flag").value(false))
+            .andExpect(jsonPath("$.code").value(400))
+            .andExpect(jsonPath("$.message").value("Each team in the selected section must be assigned at least one instructor."));
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void should_ReturnNotFound_When_SectionDoesNotExist() throws Exception {
+        when(teamInstructorAssignmentService.loadWorkspace(999L)).thenThrow(new SectionNotFoundException(999L));
+
+        mockMvc.perform(get("/api/v1/team-instructor-assignments").param("sectionId", "999"))
+            .andExpect(status().isNotFound())
+            .andExpect(jsonPath("$.flag").value(false))
+            .andExpect(jsonPath("$.code").value(404))
+            .andExpect(jsonPath("$.message").value("No section found with id: 999"));
+    }
+
+    private TeamInstructorAssignmentWorkspace buildWorkspace() {
+        return new TeamInstructorAssignmentWorkspace(
+            1L,
+            "Spring 2026 - Section A",
+            List.of(
+                new TeamInstructorAssignmentTeam(
+                    2001L,
+                    "Pulse Analytics",
+                    List.of(new TeamInstructorAssignmentInstructor(100L, "Ivy Stone", "ivy@tcu.edu"))
+                )
+            ),
+            List.of(new InstructorAssignmentCandidate(100L, "Ivy Stone", "ivy@tcu.edu", List.of("Pulse Analytics")))
+        );
+    }
+}

--- a/src/backend/src/test/java/team/projectpulse/team/repository/TeamRepositoryIntegrationTest.java
+++ b/src/backend/src/test/java/team/projectpulse/team/repository/TeamRepositoryIntegrationTest.java
@@ -134,6 +134,17 @@ class TeamRepositoryIntegrationTest {
         assertEquals(List.of("Mia"), teams.get(1).getStudents().stream().map(User::getFirstName).toList());
     }
 
+    @Test
+    void should_FetchAllTeamsBySectionWithInstructorsOrderedByTeamName() {
+        SeededData data = seedTeams();
+
+        List<Team> teams = teamRepository.findAllBySectionIdWithInstructorsOrdered(data.sectionAId());
+
+        assertEquals(List.of("Pulse Analytics", "Review Board"), teams.stream().map(Team::getTeamName).toList());
+        assertEquals(List.of("Ivy"), teams.getFirst().getInstructors().stream().map(User::getFirstName).toList());
+        assertEquals(List.of("Noah"), teams.get(1).getInstructors().stream().map(User::getFirstName).toList());
+    }
+
     private SeededData seedTeams() {
         Section sectionA = new Section();
         sectionA.setSectionName("Spring 2026 - Section A");

--- a/src/backend/src/test/java/team/projectpulse/team/service/TeamInstructorAssignmentServiceTest.java
+++ b/src/backend/src/test/java/team/projectpulse/team/service/TeamInstructorAssignmentServiceTest.java
@@ -1,0 +1,388 @@
+package team.projectpulse.team.service;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import team.projectpulse.section.domain.Section;
+import team.projectpulse.section.domain.SectionNotFoundException;
+import team.projectpulse.section.repository.SectionRepository;
+import team.projectpulse.team.domain.InvalidTeamInstructorAssignmentException;
+import team.projectpulse.team.domain.Team;
+import team.projectpulse.team.dto.TeamInstructorAssignmentInput;
+import team.projectpulse.team.dto.TeamInstructorAssignmentWorkspace;
+import team.projectpulse.team.dto.UpdateTeamInstructorAssignmentsRequest;
+import team.projectpulse.team.repository.TeamRepository;
+import team.projectpulse.user.domain.User;
+import team.projectpulse.user.repository.UserRepository;
+
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class TeamInstructorAssignmentServiceTest {
+
+    @Mock
+    private SectionRepository sectionRepository;
+
+    @Mock
+    private TeamRepository teamRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @InjectMocks
+    private TeamInstructorAssignmentService service;
+
+    @Test
+    void should_ReturnWorkspace_When_SectionExists() {
+        Section section = buildSection(1L, "Spring 2026 - Section A");
+        User ivy = buildInstructor(100L, "Ivy", "Stone", "ivy@tcu.edu", true);
+        User noah = buildInstructor(101L, "Noah", "Bennett", "noah@tcu.edu", true);
+        Team pulseAnalytics = buildTeam(2001L, "Pulse Analytics", section, List.of(ivy));
+        Team requirementsHub = buildTeam(2002L, "Requirements Hub", section, List.of(noah));
+
+        when(sectionRepository.findById(1L)).thenReturn(Optional.of(section));
+        when(teamRepository.findAllBySectionIdWithInstructorsOrdered(1L))
+            .thenReturn(List.of(pulseAnalytics, requirementsHub));
+        when(userRepository.findEnabledInstructorsOrdered()).thenReturn(List.of(ivy, noah));
+
+        TeamInstructorAssignmentWorkspace workspace = service.loadWorkspace(1L);
+
+        assertEquals(1L, workspace.sectionId());
+        assertEquals("Spring 2026 - Section A", workspace.sectionName());
+        assertEquals(List.of("Pulse Analytics", "Requirements Hub"), workspace.teams().stream().map(team -> team.teamName()).toList());
+        assertEquals(List.of("Noah Bennett", "Ivy Stone"), workspace.instructors().stream().map(instructor -> instructor.fullName()).toList());
+    }
+
+    @Test
+    void should_ReturnAssignedTeamNamesPerSelectedSection_When_LoadingWorkspace() {
+        Section section = buildSection(1L, "Spring 2026 - Section A");
+        User ivy = buildInstructor(100L, "Ivy", "Stone", "ivy@tcu.edu", true);
+        User noah = buildInstructor(101L, "Noah", "Bennett", "noah@tcu.edu", true);
+        Team pulseAnalytics = buildTeam(2001L, "Pulse Analytics", section, List.of(ivy));
+        Team requirementsHub = buildTeam(2002L, "Requirements Hub", section, List.of(ivy, noah));
+
+        when(sectionRepository.findById(1L)).thenReturn(Optional.of(section));
+        when(teamRepository.findAllBySectionIdWithInstructorsOrdered(1L))
+            .thenReturn(List.of(pulseAnalytics, requirementsHub));
+        when(userRepository.findEnabledInstructorsOrdered()).thenReturn(List.of(ivy, noah));
+
+        TeamInstructorAssignmentWorkspace workspace = service.loadWorkspace(1L);
+
+        assertEquals(
+            List.of("Pulse Analytics", "Requirements Hub"),
+            workspace.instructors().get(1).assignedTeamNames()
+        );
+        assertEquals(List.of("Requirements Hub"), workspace.instructors().getFirst().assignedTeamNames());
+    }
+
+    @Test
+    void should_ThrowNotFound_When_SectionDoesNotExist() {
+        when(sectionRepository.findById(55L)).thenReturn(Optional.empty());
+
+        SectionNotFoundException ex = assertThrows(
+            SectionNotFoundException.class,
+            () -> service.loadWorkspace(55L)
+        );
+
+        assertEquals("No section found with id: 55", ex.getMessage());
+    }
+
+    @Test
+    void should_SaveAssignments_When_RequestIsValid() {
+        Section section = buildSection(1L, "Spring 2026 - Section A");
+        User ivy = buildInstructor(100L, "Ivy", "Stone", "ivy@tcu.edu", true);
+        User noah = buildInstructor(101L, "Noah", "Bennett", "noah@tcu.edu", true);
+        Team pulseAnalytics = buildTeam(2001L, "Pulse Analytics", section, List.of(ivy));
+        Team requirementsHub = buildTeam(2002L, "Requirements Hub", section, List.of(noah));
+        List<Team> teams = List.of(pulseAnalytics, requirementsHub);
+        List<User> instructors = List.of(ivy, noah);
+
+        when(sectionRepository.findById(1L)).thenReturn(Optional.of(section));
+        when(teamRepository.findAllBySectionIdWithInstructorsOrdered(1L)).thenReturn(teams, teams);
+        when(userRepository.findEnabledInstructorsOrdered()).thenReturn(instructors);
+
+        TeamInstructorAssignmentWorkspace workspace = service.updateAssignments(
+            new UpdateTeamInstructorAssignmentsRequest(
+                1L,
+                List.of(
+                    new TeamInstructorAssignmentInput(2001L, List.of(100L, 101L)),
+                    new TeamInstructorAssignmentInput(2002L, List.of(101L))
+                )
+            )
+        );
+
+        assertEquals(List.of("Noah Bennett", "Ivy Stone"), workspace.teams().getFirst().assignedInstructors().stream()
+            .map(instructor -> instructor.fullName()).toList());
+        assertEquals(List.of("Noah"), requirementsHub.getInstructors().stream().map(User::getFirstName).toList());
+        assertEquals(List.of("Ivy", "Noah"), pulseAnalytics.getInstructors().stream().map(User::getFirstName).toList());
+        verify(teamRepository).saveAll(teams);
+    }
+
+    @Test
+    void should_AllowInstructorToBeAssignedToMultipleTeams_When_RequestIsValid() {
+        Section section = buildSection(1L, "Spring 2026 - Section A");
+        User ivy = buildInstructor(100L, "Ivy", "Stone", "ivy@tcu.edu", true);
+        Team pulseAnalytics = buildTeam(2001L, "Pulse Analytics", section, List.of());
+        Team requirementsHub = buildTeam(2002L, "Requirements Hub", section, List.of());
+        List<Team> teams = List.of(pulseAnalytics, requirementsHub);
+
+        when(sectionRepository.findById(1L)).thenReturn(Optional.of(section));
+        when(teamRepository.findAllBySectionIdWithInstructorsOrdered(1L)).thenReturn(teams, teams);
+        when(userRepository.findEnabledInstructorsOrdered()).thenReturn(List.of(ivy));
+
+        TeamInstructorAssignmentWorkspace workspace = service.updateAssignments(
+            new UpdateTeamInstructorAssignmentsRequest(
+                1L,
+                List.of(
+                    new TeamInstructorAssignmentInput(2001L, List.of(100L)),
+                    new TeamInstructorAssignmentInput(2002L, List.of(100L))
+                )
+            )
+        );
+
+        assertEquals(List.of("Ivy Stone"), workspace.teams().getFirst().assignedInstructors().stream()
+            .map(instructor -> instructor.fullName()).toList());
+        assertEquals(List.of("Ivy Stone"), workspace.teams().get(1).assignedInstructors().stream()
+            .map(instructor -> instructor.fullName()).toList());
+    }
+
+    @Test
+    void should_ThrowInvalidArgument_When_NoTeamsExistInSection() {
+        Section section = buildSection(1L, "Spring 2026 - Section A");
+        User ivy = buildInstructor(100L, "Ivy", "Stone", "ivy@tcu.edu", true);
+
+        when(sectionRepository.findById(1L)).thenReturn(Optional.of(section));
+        when(teamRepository.findAllBySectionIdWithInstructorsOrdered(1L)).thenReturn(List.of());
+        when(userRepository.findEnabledInstructorsOrdered()).thenReturn(List.of(ivy));
+
+        InvalidTeamInstructorAssignmentException ex = assertThrows(
+            InvalidTeamInstructorAssignmentException.class,
+            () -> service.updateAssignments(new UpdateTeamInstructorAssignmentsRequest(1L, List.of()))
+        );
+
+        assertEquals("At least one team must exist in the selected section.", ex.getMessage());
+    }
+
+    @Test
+    void should_ThrowInvalidArgument_When_NoEnabledInstructorsExist() {
+        Section section = buildSection(1L, "Spring 2026 - Section A");
+        Team pulseAnalytics = buildTeam(2001L, "Pulse Analytics", section, List.of());
+
+        when(sectionRepository.findById(1L)).thenReturn(Optional.of(section));
+        when(teamRepository.findAllBySectionIdWithInstructorsOrdered(1L)).thenReturn(List.of(pulseAnalytics));
+        when(userRepository.findEnabledInstructorsOrdered()).thenReturn(List.of());
+
+        InvalidTeamInstructorAssignmentException ex = assertThrows(
+            InvalidTeamInstructorAssignmentException.class,
+            () -> service.updateAssignments(new UpdateTeamInstructorAssignmentsRequest(1L, List.of()))
+        );
+
+        assertEquals("At least one enabled instructor must exist before assignments can be saved.", ex.getMessage());
+    }
+
+    @Test
+    void should_ThrowInvalidArgument_When_AssignmentContainsDuplicateTeamIds() {
+        Section section = buildSection(1L, "Spring 2026 - Section A");
+        User ivy = buildInstructor(100L, "Ivy", "Stone", "ivy@tcu.edu", true);
+        Team pulseAnalytics = buildTeam(2001L, "Pulse Analytics", section, List.of());
+        Team requirementsHub = buildTeam(2002L, "Requirements Hub", section, List.of());
+
+        when(sectionRepository.findById(1L)).thenReturn(Optional.of(section));
+        when(teamRepository.findAllBySectionIdWithInstructorsOrdered(1L)).thenReturn(List.of(pulseAnalytics, requirementsHub));
+        when(userRepository.findEnabledInstructorsOrdered()).thenReturn(List.of(ivy));
+
+        InvalidTeamInstructorAssignmentException ex = assertThrows(
+            InvalidTeamInstructorAssignmentException.class,
+            () -> service.updateAssignments(
+                new UpdateTeamInstructorAssignmentsRequest(
+                    1L,
+                    List.of(
+                        new TeamInstructorAssignmentInput(2001L, List.of(100L)),
+                        new TeamInstructorAssignmentInput(2001L, List.of(100L))
+                    )
+                )
+            )
+        );
+
+        assertEquals("Each team may only appear once in the assignment payload.", ex.getMessage());
+    }
+
+    @Test
+    void should_ThrowInvalidArgument_When_AssignmentPayloadOmitsTeam() {
+        Section section = buildSection(1L, "Spring 2026 - Section A");
+        User ivy = buildInstructor(100L, "Ivy", "Stone", "ivy@tcu.edu", true);
+        Team pulseAnalytics = buildTeam(2001L, "Pulse Analytics", section, List.of());
+        Team requirementsHub = buildTeam(2002L, "Requirements Hub", section, List.of());
+
+        when(sectionRepository.findById(1L)).thenReturn(Optional.of(section));
+        when(teamRepository.findAllBySectionIdWithInstructorsOrdered(1L)).thenReturn(List.of(pulseAnalytics, requirementsHub));
+        when(userRepository.findEnabledInstructorsOrdered()).thenReturn(List.of(ivy));
+
+        InvalidTeamInstructorAssignmentException ex = assertThrows(
+            InvalidTeamInstructorAssignmentException.class,
+            () -> service.updateAssignments(
+                new UpdateTeamInstructorAssignmentsRequest(
+                    1L,
+                    List.of(new TeamInstructorAssignmentInput(2001L, List.of(100L)))
+                )
+            )
+        );
+
+        assertEquals("Assignments must be provided for every team in the selected section.", ex.getMessage());
+    }
+
+    @Test
+    void should_ThrowInvalidArgument_When_AssignmentContainsNullInstructorId() {
+        Section section = buildSection(1L, "Spring 2026 - Section A");
+        User ivy = buildInstructor(100L, "Ivy", "Stone", "ivy@tcu.edu", true);
+        Team pulseAnalytics = buildTeam(2001L, "Pulse Analytics", section, List.of());
+
+        when(sectionRepository.findById(1L)).thenReturn(Optional.of(section));
+        when(teamRepository.findAllBySectionIdWithInstructorsOrdered(1L)).thenReturn(List.of(pulseAnalytics));
+        when(userRepository.findEnabledInstructorsOrdered()).thenReturn(List.of(ivy));
+
+        InvalidTeamInstructorAssignmentException ex = assertThrows(
+            InvalidTeamInstructorAssignmentException.class,
+            () -> service.updateAssignments(
+                new UpdateTeamInstructorAssignmentsRequest(
+                    1L,
+                    List.of(new TeamInstructorAssignmentInput(2001L, java.util.Collections.singletonList(null)))
+                )
+            )
+        );
+
+        assertEquals("Assigned instructor ids must not contain null values.", ex.getMessage());
+    }
+
+    @Test
+    void should_ThrowInvalidArgument_When_AssignmentContainsDuplicateInstructorIds() {
+        Section section = buildSection(1L, "Spring 2026 - Section A");
+        User ivy = buildInstructor(100L, "Ivy", "Stone", "ivy@tcu.edu", true);
+        Team pulseAnalytics = buildTeam(2001L, "Pulse Analytics", section, List.of());
+
+        when(sectionRepository.findById(1L)).thenReturn(Optional.of(section));
+        when(teamRepository.findAllBySectionIdWithInstructorsOrdered(1L)).thenReturn(List.of(pulseAnalytics));
+        when(userRepository.findEnabledInstructorsOrdered()).thenReturn(List.of(ivy));
+
+        InvalidTeamInstructorAssignmentException ex = assertThrows(
+            InvalidTeamInstructorAssignmentException.class,
+            () -> service.updateAssignments(
+                new UpdateTeamInstructorAssignmentsRequest(
+                    1L,
+                    List.of(new TeamInstructorAssignmentInput(2001L, List.of(100L, 100L)))
+                )
+            )
+        );
+
+        assertEquals("An instructor may only appear once per team assignment.", ex.getMessage());
+    }
+
+    @Test
+    void should_ThrowInvalidArgument_When_AssignedUserIsNotAnEnabledInstructor() {
+        Section section = buildSection(1L, "Spring 2026 - Section A");
+        User ivy = buildInstructor(100L, "Ivy", "Stone", "ivy@tcu.edu", true);
+        Team pulseAnalytics = buildTeam(2001L, "Pulse Analytics", section, List.of());
+
+        when(sectionRepository.findById(1L)).thenReturn(Optional.of(section));
+        when(teamRepository.findAllBySectionIdWithInstructorsOrdered(1L)).thenReturn(List.of(pulseAnalytics));
+        when(userRepository.findEnabledInstructorsOrdered()).thenReturn(List.of(ivy));
+
+        InvalidTeamInstructorAssignmentException ex = assertThrows(
+            InvalidTeamInstructorAssignmentException.class,
+            () -> service.updateAssignments(
+                new UpdateTeamInstructorAssignmentsRequest(
+                    1L,
+                    List.of(new TeamInstructorAssignmentInput(2001L, List.of(999L)))
+                )
+            )
+        );
+
+        assertEquals("Instructor 999 is not an enabled instructor.", ex.getMessage());
+    }
+
+    @Test
+    void should_ThrowInvalidArgument_When_TeamDoesNotBelongToSection() {
+        Section section = buildSection(1L, "Spring 2026 - Section A");
+        User ivy = buildInstructor(100L, "Ivy", "Stone", "ivy@tcu.edu", true);
+        Team pulseAnalytics = buildTeam(2001L, "Pulse Analytics", section, List.of());
+
+        when(sectionRepository.findById(1L)).thenReturn(Optional.of(section));
+        when(teamRepository.findAllBySectionIdWithInstructorsOrdered(1L)).thenReturn(List.of(pulseAnalytics));
+        when(userRepository.findEnabledInstructorsOrdered()).thenReturn(List.of(ivy));
+
+        InvalidTeamInstructorAssignmentException ex = assertThrows(
+            InvalidTeamInstructorAssignmentException.class,
+            () -> service.updateAssignments(
+                new UpdateTeamInstructorAssignmentsRequest(
+                    1L,
+                    List.of(new TeamInstructorAssignmentInput(9999L, List.of(100L)))
+                )
+            )
+        );
+
+        assertEquals("Team 9999 does not belong to section 1.", ex.getMessage());
+    }
+
+    @Test
+    void should_ThrowInvalidArgument_When_TeamWouldHaveNoInstructors() {
+        Section section = buildSection(1L, "Spring 2026 - Section A");
+        User ivy = buildInstructor(100L, "Ivy", "Stone", "ivy@tcu.edu", true);
+        Team pulseAnalytics = buildTeam(2001L, "Pulse Analytics", section, List.of());
+
+        when(sectionRepository.findById(1L)).thenReturn(Optional.of(section));
+        when(teamRepository.findAllBySectionIdWithInstructorsOrdered(1L)).thenReturn(List.of(pulseAnalytics));
+        when(userRepository.findEnabledInstructorsOrdered()).thenReturn(List.of(ivy));
+
+        InvalidTeamInstructorAssignmentException ex = assertThrows(
+            InvalidTeamInstructorAssignmentException.class,
+            () -> service.updateAssignments(
+                new UpdateTeamInstructorAssignmentsRequest(
+                    1L,
+                    List.of(new TeamInstructorAssignmentInput(2001L, List.of()))
+                )
+            )
+        );
+
+        assertEquals("Each team in the selected section must be assigned at least one instructor.", ex.getMessage());
+    }
+
+    private Section buildSection(Long sectionId, String sectionName) {
+        Section section = new Section();
+        section.setSectionId(sectionId);
+        section.setSectionName(sectionName);
+        return section;
+    }
+
+    private Team buildTeam(Long teamId, String teamName, Section section, List<User> instructors) {
+        Team team = new Team();
+        team.setTeamId(teamId);
+        team.setTeamName(teamName);
+        team.setSection(section);
+        team.setInstructors(new LinkedHashSet<>(instructors));
+        return team;
+    }
+
+    private User buildInstructor(Long id, String firstName, String lastName, String email, boolean enabled) {
+        return buildUser(id, firstName, lastName, email, "instructor", enabled);
+    }
+
+    private User buildUser(Long id, String firstName, String lastName, String email, String roles, boolean enabled) {
+        User user = new User();
+        user.setId(id);
+        user.setFirstName(firstName);
+        user.setLastName(lastName);
+        user.setEmail(email);
+        user.setRoles(roles);
+        user.setEnabled(enabled);
+        return user;
+    }
+}

--- a/src/backend/src/test/java/team/projectpulse/user/repository/UserRepositoryIntegrationTest.java
+++ b/src/backend/src/test/java/team/projectpulse/user/repository/UserRepositoryIntegrationTest.java
@@ -42,6 +42,24 @@ class UserRepositoryIntegrationTest {
         assertEquals(List.of("amy@tcu.edu", "zoe@tcu.edu"), students.stream().map(User::getEmail).toList());
     }
 
+    @Test
+    void should_ReturnOnlyEnabledInstructorsOrderedByName() {
+        Section section = persistSection("Spring 2026 - Section A");
+
+        persistUser("Zoe", "Zimmer", "zoe@tcu.edu", "student", true, section);
+        persistUser("Ivy", "Stone", "ivy@tcu.edu", "instructor", true, section);
+        persistUser("Noah", "Bennett", "noah@tcu.edu", "admin instructor", true, section);
+        persistUser("Avery", "Mills", "avery@tcu.edu", "instructor", false, section);
+
+        entityManager.flush();
+        entityManager.clear();
+
+        List<User> instructors = userRepository.findEnabledInstructorsOrdered();
+
+        assertEquals(List.of("Noah", "Ivy"), instructors.stream().map(User::getFirstName).toList());
+        assertEquals(List.of("noah@tcu.edu", "ivy@tcu.edu"), instructors.stream().map(User::getEmail).toList());
+    }
+
     private Section persistSection(String sectionName) {
         Section section = new Section();
         section.setSectionName(sectionName);

--- a/src/frontend/src/features/team/pages/TeamInstructorAssignments.vue
+++ b/src/frontend/src/features/team/pages/TeamInstructorAssignments.vue
@@ -1,0 +1,690 @@
+<template>
+  <v-container>
+    <v-btn variant="text" prepend-icon="mdi-arrow-left" class="mb-4" @click="router.push({ name: 'teams' })">
+      Back to Teams
+    </v-btn>
+
+    <v-row class="mb-4" align="center">
+      <v-col>
+        <h2 class="text-h5 font-weight-bold">Assign Instructors to Senior Design Teams</h2>
+        <div class="text-body-2 text-medium-emphasis">
+          Select a section, stage instructor assignments, review them, then confirm the final roster.
+        </div>
+      </v-col>
+    </v-row>
+
+    <v-card variant="outlined" class="mb-4">
+      <v-card-text class="pa-4">
+        <v-row align="center">
+          <v-col cols="12" md="6">
+            <v-select
+              v-model="selectedSectionId"
+              :items="sections"
+              item-title="sectionName"
+              item-value="sectionId"
+              label="Section"
+              :loading="sectionsLoading"
+              :disabled="sectionsLoading || saving"
+              clearable
+              @update:model-value="loadWorkspace"
+            />
+          </v-col>
+          <v-col cols="12" md="6" class="text-md-right">
+            <v-chip v-if="workspace" color="primary" variant="tonal" class="mr-2">
+              {{ workspace.teams.length }} teams
+            </v-chip>
+            <v-chip v-if="workspace" color="secondary" variant="tonal">
+              {{ workspace.instructors.length }} enabled instructors
+            </v-chip>
+          </v-col>
+        </v-row>
+
+        <v-alert v-if="validationMessage" type="warning" variant="tonal" class="mt-2">
+          {{ validationMessage }}
+        </v-alert>
+      </v-card-text>
+    </v-card>
+
+    <v-row v-if="workspaceLoading">
+      <v-col class="text-center">
+        <v-progress-circular indeterminate />
+      </v-col>
+    </v-row>
+
+    <v-alert v-else-if="!selectedSectionId" type="info" variant="tonal">
+      Select a section to load its teams and instructor roster.
+    </v-alert>
+
+    <template v-else-if="workspace">
+      <template v-if="step === 1">
+        <v-row>
+          <v-col cols="12" lg="8">
+            <v-card variant="outlined" class="mb-4">
+              <v-card-title class="pa-4 pb-2 d-flex align-center">
+                <span>Teams in {{ workspace.sectionName }}</span>
+                <v-spacer />
+                <v-chip color="primary" variant="tonal">
+                  {{ teamsWithInstructorsCount }}/{{ workspace.teams.length }} staffed
+                </v-chip>
+              </v-card-title>
+              <v-card-text>
+                <v-alert v-if="workspace.teams.length === 0" type="warning" variant="tonal">
+                  At least one team must exist in the selected section.
+                </v-alert>
+                <v-row v-else>
+                  <v-col v-for="team in stagedTeams" :key="team.teamId" cols="12">
+                    <v-card
+                      variant="outlined"
+                      :class="['team-card', { 'team-card--selected': team.teamId === selectedTeamId }]"
+                    >
+                      <v-card-title class="pa-4 pb-2 d-flex align-center">
+                        <span>{{ team.teamName }}</span>
+                        <v-spacer />
+                        <v-chip size="small" variant="tonal" color="primary" class="mr-2">
+                          {{ team.assignedInstructors.length }} instructors
+                        </v-chip>
+                        <v-btn
+                          size="small"
+                          color="primary"
+                          variant="text"
+                          @click="selectedTeamId = team.teamId"
+                        >
+                          {{ team.teamId === selectedTeamId ? 'Selected' : 'Select Team' }}
+                        </v-btn>
+                      </v-card-title>
+                      <v-card-text>
+                        <div v-if="team.assignedInstructors.length === 0" class="text-medium-emphasis">
+                          No instructors assigned yet.
+                        </div>
+                        <div v-else class="assigned-list">
+                          <v-chip
+                            v-for="instructor in team.assignedInstructors"
+                            :key="instructor.instructorId"
+                            class="mr-2 mb-2"
+                            color="primary"
+                            variant="tonal"
+                          >
+                            {{ instructor.fullName }}
+                            <template #append>
+                              <v-btn
+                                icon="mdi-close"
+                                size="x-small"
+                                variant="text"
+                                class="ml-1"
+                                @click.stop="removeInstructor(team.teamId, instructor.instructorId)"
+                              />
+                            </template>
+                          </v-chip>
+                        </div>
+                      </v-card-text>
+                    </v-card>
+                  </v-col>
+                </v-row>
+              </v-card-text>
+            </v-card>
+          </v-col>
+
+          <v-col cols="12" lg="4">
+            <v-card variant="outlined" class="mb-4">
+              <v-card-title class="pa-4 pb-2">Instructor Pool</v-card-title>
+              <v-card-text>
+                <v-alert type="info" variant="tonal" density="compact" class="mb-4">
+                  Select one team, then choose instructors to assign. Instructors can supervise multiple teams.
+                </v-alert>
+
+                <v-alert v-if="workspace.instructors.length === 0" type="warning" variant="tonal">
+                  At least one enabled instructor must exist before assignments can be saved.
+                </v-alert>
+
+                <v-list v-else lines="two" density="compact">
+                  <v-list-item
+                    v-for="instructor in workspace.instructors"
+                    :key="instructor.instructorId"
+                    :active="selectedInstructorIds.includes(instructor.instructorId)"
+                    @click="toggleInstructorSelection(instructor.instructorId)"
+                  >
+                    <template #prepend>
+                      <v-checkbox-btn
+                        :model-value="selectedInstructorIds.includes(instructor.instructorId)"
+                        @click.stop
+                        @update:model-value="toggleInstructorSelection(instructor.instructorId)"
+                      />
+                    </template>
+
+                    <v-list-item-title>{{ instructor.fullName }}</v-list-item-title>
+                    <v-list-item-subtitle>{{ instructor.email }}</v-list-item-subtitle>
+
+                    <template #append>
+                      <div class="chip-group text-right">
+                        <v-chip
+                          v-for="teamName in assignedTeamNamesByInstructorId(instructor.instructorId)"
+                          :key="`${instructor.instructorId}-${teamName}`"
+                          size="small"
+                          color="primary"
+                          variant="tonal"
+                          class="mr-1 mb-1"
+                        >
+                          {{ teamName }}
+                        </v-chip>
+                        <v-chip
+                          v-if="assignedTeamNamesByInstructorId(instructor.instructorId).length === 0"
+                          size="small"
+                          color="warning"
+                          variant="tonal"
+                        >
+                          Unassigned
+                        </v-chip>
+                      </div>
+                    </template>
+                  </v-list-item>
+                </v-list>
+
+                <v-divider class="my-4" />
+
+                <v-btn
+                  block
+                  color="primary"
+                  prepend-icon="mdi-account-arrow-right"
+                  :disabled="!canAssignSelectedInstructors"
+                  @click="assignSelectedInstructors"
+                >
+                  Assign to Selected Team
+                </v-btn>
+              </v-card-text>
+            </v-card>
+
+            <v-card variant="outlined">
+              <v-card-title class="pa-4 pb-2">Current Status</v-card-title>
+              <v-card-text>
+                <div class="text-body-2 mb-2">
+                  Selected team:
+                  <strong>{{ selectedTeamName }}</strong>
+                </div>
+                <div class="text-body-2 mb-2">
+                  Teams with zero instructors:
+                  <strong>{{ teamsWithoutInstructorsCount }}</strong>
+                </div>
+                <div class="text-body-2">
+                  Selected instructors:
+                  <strong>{{ selectedInstructorIds.length }}</strong>
+                </div>
+              </v-card-text>
+              <v-card-actions class="pa-4 pt-0">
+                <v-btn variant="text" @click="resetStagedAssignments">Reset</v-btn>
+                <v-spacer />
+                <v-btn color="primary" @click="goToPreview">Preview</v-btn>
+              </v-card-actions>
+            </v-card>
+          </v-col>
+        </v-row>
+      </template>
+
+      <template v-else>
+        <v-card variant="outlined" class="mb-4">
+          <v-card-title class="pa-4 pb-2">Confirm Instructor Assignments</v-card-title>
+          <v-card-text>
+            <v-alert type="info" variant="tonal" class="mb-4">
+              Please review the instructor assignments before confirming. The save will replace the current team instructor roster for this section.
+            </v-alert>
+
+            <v-table density="compact" class="mb-4">
+              <tbody>
+                <tr>
+                  <th class="text-left">Section</th>
+                  <td>{{ workspace.sectionName }}</td>
+                </tr>
+                <tr>
+                  <th class="text-left">Teams</th>
+                  <td>{{ stagedTeams.length }}</td>
+                </tr>
+                <tr>
+                  <th class="text-left">Unique Instructors Used</th>
+                  <td>{{ uniqueAssignedInstructorCount }}</td>
+                </tr>
+                <tr>
+                  <th class="text-left">Total Team Assignments</th>
+                  <td>{{ totalInstructorAssignments }}</td>
+                </tr>
+              </tbody>
+            </v-table>
+
+            <v-row>
+              <v-col v-for="team in stagedTeams" :key="team.teamId" cols="12" md="6">
+                <v-card variant="outlined" class="h-100">
+                  <v-card-title class="text-subtitle-1 font-weight-bold">{{ team.teamName }}</v-card-title>
+                  <v-card-text>
+                    <div v-if="team.assignedInstructors.length === 0" class="text-medium-emphasis">No instructors assigned.</div>
+                    <v-chip
+                      v-for="instructor in team.assignedInstructors"
+                      :key="instructor.instructorId"
+                      size="small"
+                      variant="tonal"
+                      color="primary"
+                      class="mr-1 mb-1"
+                    >
+                      {{ instructor.fullName }}
+                    </v-chip>
+                  </v-card-text>
+                </v-card>
+              </v-col>
+            </v-row>
+          </v-card-text>
+          <v-divider />
+          <v-card-actions class="pa-4">
+            <v-btn variant="text" @click="cancelPreview">Cancel</v-btn>
+            <v-spacer />
+            <v-btn variant="outlined" @click="step = 1">Modify</v-btn>
+            <v-btn color="primary" :loading="saving" @click="confirmAssignments">Confirm</v-btn>
+          </v-card-actions>
+        </v-card>
+
+        <v-card variant="outlined">
+          <v-card-title class="pa-4 pb-2">Manual Notification Preview</v-card-title>
+          <v-card-text>
+            <div class="text-body-2 mb-3">
+              After saving, use this list to notify instructors of their assigned teams.
+            </div>
+            <v-table density="compact">
+              <thead>
+                <tr>
+                  <th>Instructor</th>
+                  <th>Email</th>
+                  <th>Assigned Teams</th>
+                  <th>Section</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr v-for="item in previewNotificationSummary" :key="item.instructorId">
+                  <td>{{ item.fullName }}</td>
+                  <td>{{ item.email }}</td>
+                  <td>{{ item.teamNames.join(', ') }}</td>
+                  <td>{{ item.sectionName }}</td>
+                </tr>
+              </tbody>
+            </v-table>
+          </v-card-text>
+        </v-card>
+      </template>
+
+      <v-card v-if="savedNotificationSummary.length" variant="outlined" class="mt-4">
+        <v-card-title class="pa-4 pb-2">Notify Instructors</v-card-title>
+        <v-card-text>
+          <div class="text-body-2 mb-3">
+            Assignments were saved successfully. Use this summary to notify instructors manually.
+          </div>
+          <v-table density="compact">
+            <thead>
+              <tr>
+                <th>Instructor</th>
+                <th>Email</th>
+                <th>Assigned Teams</th>
+                <th>Section</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr v-for="item in savedNotificationSummary" :key="item.instructorId">
+                <td>{{ item.fullName }}</td>
+                <td>{{ item.email }}</td>
+                <td>{{ item.teamNames.join(', ') }}</td>
+                <td>{{ item.sectionName }}</td>
+              </tr>
+            </tbody>
+          </v-table>
+        </v-card-text>
+      </v-card>
+    </template>
+
+    <v-snackbar v-model="snackbar.show" :color="snackbar.color" timeout="3500">
+      {{ snackbar.message }}
+    </v-snackbar>
+  </v-container>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted, ref } from 'vue'
+import { useRouter } from 'vue-router'
+import { findSections } from '@/features/section/services/sectionService'
+import type { SectionSummary } from '@/features/section/services/sectionTypes'
+import {
+  getTeamInstructorAssignmentWorkspace,
+  updateTeamInstructorAssignments
+} from '../services/teamService'
+import type {
+  InstructorAssignmentCandidate,
+  TeamInstructorAssignmentInstructor,
+  TeamInstructorAssignmentTeam,
+  TeamInstructorAssignmentWorkspace,
+  UpdateTeamInstructorAssignmentsRequest
+} from '../services/teamTypes'
+
+interface NotificationSummaryItem {
+  instructorId: number
+  fullName: string
+  email: string
+  teamNames: string[]
+  sectionName: string
+}
+
+const router = useRouter()
+
+const sections = ref<SectionSummary[]>([])
+const selectedSectionId = ref<number | null>(null)
+const workspace = ref<TeamInstructorAssignmentWorkspace | null>(null)
+const stagedTeams = ref<TeamInstructorAssignmentTeam[]>([])
+const selectedTeamId = ref<number | null>(null)
+const selectedInstructorIds = ref<number[]>([])
+const sectionsLoading = ref(false)
+const workspaceLoading = ref(false)
+const saving = ref(false)
+const step = ref(1)
+const validationMessage = ref('')
+const savedNotificationSummary = ref<NotificationSummaryItem[]>([])
+const snackbar = ref({ show: false, message: '', color: 'success' })
+
+const teamsWithInstructorsCount = computed(() =>
+  stagedTeams.value.filter((team) => team.assignedInstructors.length > 0).length
+)
+
+const teamsWithoutInstructorsCount = computed(() =>
+  stagedTeams.value.filter((team) => team.assignedInstructors.length === 0).length
+)
+
+const totalInstructorAssignments = computed(() =>
+  stagedTeams.value.reduce((total, team) => total + team.assignedInstructors.length, 0)
+)
+
+const uniqueAssignedInstructorCount = computed(() => {
+  const uniqueInstructorIds = new Set(
+    stagedTeams.value.flatMap((team) => team.assignedInstructors.map((instructor) => instructor.instructorId))
+  )
+  return uniqueInstructorIds.size
+})
+
+const selectedTeamName = computed(() =>
+  stagedTeams.value.find((team) => team.teamId === selectedTeamId.value)?.teamName ?? 'None selected'
+)
+
+const canAssignSelectedInstructors = computed(() =>
+  selectedTeamId.value !== null && selectedInstructorIds.value.length > 0
+)
+
+const previewNotificationSummary = computed(() =>
+  buildNotificationSummary(stagedTeams.value, workspace.value?.sectionName ?? '')
+)
+
+onMounted(async () => {
+  await loadSections()
+})
+
+async function loadSections() {
+  sectionsLoading.value = true
+  try {
+    const res = await findSections() as any
+    sections.value = res.flag ? (res.data ?? []) : []
+
+    const onlySection = sections.value[0]
+    if (sections.value.length === 1 && onlySection) {
+      selectedSectionId.value = onlySection.sectionId
+      await loadWorkspace()
+    }
+  } catch {
+    sections.value = []
+    snackbar.value = { show: true, message: 'Failed to load sections.', color: 'error' }
+  } finally {
+    sectionsLoading.value = false
+  }
+}
+
+async function loadWorkspace() {
+  validationMessage.value = ''
+  savedNotificationSummary.value = []
+  step.value = 1
+  selectedInstructorIds.value = []
+
+  if (!selectedSectionId.value) {
+    workspace.value = null
+    stagedTeams.value = []
+    selectedTeamId.value = null
+    return
+  }
+
+  workspaceLoading.value = true
+  try {
+    const res = await getTeamInstructorAssignmentWorkspace(selectedSectionId.value) as any
+    if (res.flag && res.data) {
+      workspace.value = res.data
+      stagedTeams.value = cloneTeams(res.data.teams)
+      selectedTeamId.value = stagedTeams.value[0]?.teamId ?? null
+      return
+    }
+
+    workspace.value = null
+    stagedTeams.value = []
+    selectedTeamId.value = null
+    snackbar.value = { show: true, message: res.message || 'Failed to load assignments.', color: 'error' }
+  } catch (error: any) {
+    workspace.value = null
+    stagedTeams.value = []
+    selectedTeamId.value = null
+    const message = error?.response?.data?.message || 'Failed to load assignments.'
+    snackbar.value = { show: true, message, color: 'error' }
+  } finally {
+    workspaceLoading.value = false
+  }
+}
+
+function toggleInstructorSelection(instructorId: number) {
+  if (selectedInstructorIds.value.includes(instructorId)) {
+    selectedInstructorIds.value = selectedInstructorIds.value.filter((id) => id !== instructorId)
+    return
+  }
+  selectedInstructorIds.value = [...selectedInstructorIds.value, instructorId]
+}
+
+function assignSelectedInstructors() {
+  if (!selectedTeamId.value || !workspace.value) {
+    return
+  }
+
+  const selectedInstructors = workspace.value.instructors
+    .filter((instructor) => selectedInstructorIds.value.includes(instructor.instructorId))
+    .map(toAssignedInstructor)
+
+  const teamIndex = stagedTeams.value.findIndex((team) => team.teamId === selectedTeamId.value)
+  if (teamIndex >= 0) {
+    const currentTeam = stagedTeams.value[teamIndex]
+    if (!currentTeam) {
+      return
+    }
+
+    const mergedInstructors = [
+      ...currentTeam.assignedInstructors,
+      ...selectedInstructors.filter((instructor) =>
+        !currentTeam.assignedInstructors.some(
+          (assignedInstructor) => assignedInstructor.instructorId === instructor.instructorId
+        )
+      )
+    ].sort(compareInstructors)
+
+    stagedTeams.value[teamIndex] = {
+      ...currentTeam,
+      assignedInstructors: mergedInstructors
+    }
+  }
+
+  selectedInstructorIds.value = []
+  validationMessage.value = ''
+}
+
+function removeInstructor(teamId: number, instructorId: number) {
+  stagedTeams.value = stagedTeams.value.map((team) => {
+    if (team.teamId !== teamId) {
+      return team
+    }
+    return {
+      ...team,
+      assignedInstructors: team.assignedInstructors.filter((instructor) => instructor.instructorId !== instructorId)
+    }
+  })
+}
+
+function resetStagedAssignments() {
+  if (!workspace.value) {
+    return
+  }
+
+  stagedTeams.value = cloneTeams(workspace.value.teams)
+  selectedTeamId.value = stagedTeams.value[0]?.teamId ?? null
+  selectedInstructorIds.value = []
+  validationMessage.value = ''
+}
+
+function goToPreview() {
+  const message = validateBeforePreview()
+  if (message) {
+    validationMessage.value = message
+    return
+  }
+
+  validationMessage.value = ''
+  step.value = 2
+}
+
+function cancelPreview() {
+  resetStagedAssignments()
+  step.value = 1
+}
+
+async function confirmAssignments() {
+  if (!workspace.value) {
+    return
+  }
+
+  saving.value = true
+  try {
+    const payload: UpdateTeamInstructorAssignmentsRequest = {
+      sectionId: workspace.value.sectionId,
+      assignments: stagedTeams.value.map((team) => ({
+        teamId: team.teamId,
+        instructorIds: team.assignedInstructors.map((instructor) => instructor.instructorId)
+      }))
+    }
+
+    const res = await updateTeamInstructorAssignments(payload) as any
+    if (res.flag && res.data) {
+      workspace.value = res.data
+      stagedTeams.value = cloneTeams(res.data.teams)
+      selectedTeamId.value = stagedTeams.value[0]?.teamId ?? null
+      selectedInstructorIds.value = []
+      savedNotificationSummary.value = buildNotificationSummary(res.data.teams, res.data.sectionName)
+      validationMessage.value = ''
+      step.value = 1
+      snackbar.value = { show: true, message: 'Instructor team assignments saved successfully.', color: 'success' }
+      return
+    }
+
+    snackbar.value = {
+      show: true,
+      message: res.message || 'Failed to save instructor assignments.',
+      color: 'error'
+    }
+  } catch (error: any) {
+    const message = error?.response?.data?.message || 'Failed to save instructor assignments.'
+    snackbar.value = { show: true, message, color: 'error' }
+  } finally {
+    saving.value = false
+  }
+}
+
+function assignedTeamNamesByInstructorId(instructorId: number) {
+  return stagedTeams.value
+    .filter((team) => team.assignedInstructors.some((instructor) => instructor.instructorId === instructorId))
+    .map((team) => team.teamName)
+    .sort((left, right) => left.localeCompare(right, undefined, { sensitivity: 'base' }))
+}
+
+function validateBeforePreview() {
+  if (!selectedSectionId.value || !workspace.value) {
+    return 'Section is required.'
+  }
+  if (workspace.value.teams.length === 0) {
+    return 'At least one team must exist in the selected section.'
+  }
+  if (workspace.value.instructors.length === 0) {
+    return 'At least one enabled instructor must exist before assignments can be saved.'
+  }
+  if (stagedTeams.value.some((team) => team.assignedInstructors.length === 0)) {
+    return 'Each team in the selected section must be assigned at least one instructor.'
+  }
+
+  return ''
+}
+
+function cloneTeams(teams: TeamInstructorAssignmentTeam[]) {
+  return teams.map((team) => ({
+    ...team,
+    assignedInstructors: [...team.assignedInstructors].sort(compareInstructors)
+  }))
+}
+
+function compareInstructors(left: TeamInstructorAssignmentInstructor, right: TeamInstructorAssignmentInstructor) {
+  return left.fullName.localeCompare(right.fullName, undefined, { sensitivity: 'base' })
+    || left.email.localeCompare(right.email, undefined, { sensitivity: 'base' })
+}
+
+function toAssignedInstructor(instructor: InstructorAssignmentCandidate): TeamInstructorAssignmentInstructor {
+  return {
+    instructorId: instructor.instructorId,
+    fullName: instructor.fullName,
+    email: instructor.email
+  }
+}
+
+function buildNotificationSummary(teams: TeamInstructorAssignmentTeam[], sectionName: string) {
+  const itemsByInstructorId = new Map<number, NotificationSummaryItem>()
+
+  for (const team of teams) {
+    for (const instructor of team.assignedInstructors) {
+      const existingItem = itemsByInstructorId.get(instructor.instructorId)
+      if (existingItem) {
+        existingItem.teamNames.push(team.teamName)
+        existingItem.teamNames.sort((left, right) => left.localeCompare(right, undefined, { sensitivity: 'base' }))
+        continue
+      }
+
+      itemsByInstructorId.set(instructor.instructorId, {
+        instructorId: instructor.instructorId,
+        fullName: instructor.fullName,
+        email: instructor.email,
+        teamNames: [team.teamName],
+        sectionName
+      })
+    }
+  }
+
+  return [...itemsByInstructorId.values()].sort((left, right) =>
+    left.fullName.localeCompare(right.fullName, undefined, { sensitivity: 'base' })
+    || left.email.localeCompare(right.email, undefined, { sensitivity: 'base' })
+  )
+}
+</script>
+
+<style scoped lang="scss">
+.team-card {
+  border-color: rgba(var(--v-theme-outline), 0.5);
+}
+
+.team-card--selected {
+  border-color: rgb(var(--v-theme-primary));
+  box-shadow: 0 0 0 1px rgba(var(--v-theme-primary), 0.2);
+}
+
+.assigned-list {
+  display: flex;
+  flex-wrap: wrap;
+}
+
+.chip-group {
+  max-width: 260px;
+}
+</style>

--- a/src/frontend/src/features/team/pages/Teams.vue
+++ b/src/frontend/src/features/team/pages/Teams.vue
@@ -7,6 +7,9 @@
           <v-btn variant="outlined" prepend-icon="mdi-account-switch" @click="openAssignmentsPage">
             Assign Students
           </v-btn>
+          <v-btn variant="outlined" prepend-icon="mdi-account-tie" @click="openInstructorAssignmentsPage">
+            Assign Instructors
+          </v-btn>
           <v-btn color="primary" prepend-icon="mdi-plus" @click="openCreateDialog">Create Team</v-btn>
         </div>
       </v-col>
@@ -402,6 +405,10 @@ function dismissDeletedTeamNotification() {
 
 function openAssignmentsPage() {
   router.push({ name: 'team-student-assignments' })
+}
+
+function openInstructorAssignmentsPage() {
+  router.push({ name: 'team-instructor-assignments' })
 }
 
 async function openCreateDialog() {

--- a/src/frontend/src/features/team/services/teamService.ts
+++ b/src/frontend/src/features/team/services/teamService.ts
@@ -3,15 +3,18 @@ import type { ApiResponse } from '@/shared/types/api'
 import type {
   CreateTeamRequest,
   FindTeamsParams,
+  TeamInstructorAssignmentWorkspace,
   TeamDetail,
   TeamStudentAssignmentWorkspace,
   TeamSummary,
+  UpdateTeamInstructorAssignmentsRequest,
   UpdateTeamRequest,
   UpdateTeamStudentAssignmentsRequest
 } from './teamTypes'
 
 const BASE = '/teams'
 const ASSIGNMENT_BASE = '/team-student-assignments'
+const INSTRUCTOR_ASSIGNMENT_BASE = '/team-instructor-assignments'
 
 export const findTeams = (params?: FindTeamsParams) =>
   request.get<ApiResponse<TeamSummary[]>>(BASE, { params: params ?? {} })
@@ -36,3 +39,9 @@ export const getTeamStudentAssignmentWorkspace = (sectionId: number) =>
 
 export const updateTeamStudentAssignments = (payload: UpdateTeamStudentAssignmentsRequest) =>
   request.put<ApiResponse<TeamStudentAssignmentWorkspace>>(ASSIGNMENT_BASE, payload)
+
+export const getTeamInstructorAssignmentWorkspace = (sectionId: number) =>
+  request.get<ApiResponse<TeamInstructorAssignmentWorkspace>>(INSTRUCTOR_ASSIGNMENT_BASE, { params: { sectionId } })
+
+export const updateTeamInstructorAssignments = (payload: UpdateTeamInstructorAssignmentsRequest) =>
+  request.put<ApiResponse<TeamInstructorAssignmentWorkspace>>(INSTRUCTOR_ASSIGNMENT_BASE, payload)

--- a/src/frontend/src/features/team/services/teamTypes.ts
+++ b/src/frontend/src/features/team/services/teamTypes.ts
@@ -73,14 +73,50 @@ export interface TeamStudentAssignmentWorkspace {
   students: StudentAssignmentCandidate[]
 }
 
+export interface InstructorAssignmentCandidate {
+  instructorId: number
+  fullName: string
+  email: string
+  assignedTeamNames: string[]
+}
+
+export interface TeamInstructorAssignmentInstructor {
+  instructorId: number
+  fullName: string
+  email: string
+}
+
+export interface TeamInstructorAssignmentTeam {
+  teamId: number
+  teamName: string
+  assignedInstructors: TeamInstructorAssignmentInstructor[]
+}
+
+export interface TeamInstructorAssignmentWorkspace {
+  sectionId: number
+  sectionName: string
+  teams: TeamInstructorAssignmentTeam[]
+  instructors: InstructorAssignmentCandidate[]
+}
+
 export interface TeamStudentAssignmentInput {
   teamId: number
   studentIds: number[]
 }
 
+export interface TeamInstructorAssignmentInput {
+  teamId: number
+  instructorIds: number[]
+}
+
 export interface UpdateTeamStudentAssignmentsRequest {
   sectionId: number
   assignments: TeamStudentAssignmentInput[]
+}
+
+export interface UpdateTeamInstructorAssignmentsRequest {
+  sectionId: number
+  assignments: TeamInstructorAssignmentInput[]
 }
 
 export interface FindTeamsParams {

--- a/src/frontend/src/router/routes.ts
+++ b/src/frontend/src/router/routes.ts
@@ -76,6 +76,12 @@ export const routes = [
         meta: { requiresAuth: true, roles: ['admin'] }
       },
       {
+        path: '/teams/assign-instructors',
+        component: () => import('@/features/team/pages/TeamInstructorAssignments.vue'),
+        name: 'team-instructor-assignments',
+        meta: { requiresAuth: true, roles: ['admin'] }
+      },
+      {
         path: '/teams/:id',
         component: () => import('@/features/team/pages/TeamDetail.vue'),
         name: 'team-detail',


### PR DESCRIPTION
Implements UC-19 by adding an admin-only instructor assignment workflow for senior design teams. This includes new backend GET/PUT /api/v1/team-instructor-assignments endpoints, validation/service logic for section-scoped team instructor rosters, a dedicated Assign Instructors page in the frontend with preview/confirm flow, and a manual notification summary after save. Frontend checks passed, and the UC-19 service test issues found during backend validation were fixed.

