### PR TITLE
feat(uc-20): implement instructor removal from team

### DIFF
--- a/src/backend/src/main/java/team/projectpulse/team/controller/TeamController.java
+++ b/src/backend/src/main/java/team/projectpulse/team/controller/TeamController.java
@@ -73,4 +73,13 @@ public class TeamController {
             teamService.removeStudentFromTeam(teamId, studentId)
         );
     }
+
+    @DeleteMapping("/{teamId}/instructors/{instructorId}")
+    @PreAuthorize("hasRole('ADMIN')")
+    public Result<TeamDetail> removeInstructorFromTeam(@PathVariable Long teamId, @PathVariable Long instructorId) {
+        return Result.success(
+            "Instructor removed from team successfully.",
+            teamService.removeInstructorFromTeam(teamId, instructorId)
+        );
+    }
 }

--- a/src/backend/src/main/java/team/projectpulse/team/controller/TeamExceptionHandler.java
+++ b/src/backend/src/main/java/team/projectpulse/team/controller/TeamExceptionHandler.java
@@ -6,6 +6,7 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import team.projectpulse.system.Result;
 import team.projectpulse.system.StatusCode;
+import team.projectpulse.team.domain.InstructorNotFoundException;
 import team.projectpulse.team.domain.InvalidTeamException;
 import team.projectpulse.team.domain.InvalidTeamInstructorAssignmentException;
 import team.projectpulse.team.domain.InvalidTeamStudentAssignmentException;
@@ -49,6 +50,12 @@ public class TeamExceptionHandler {
     @ExceptionHandler(StudentNotFoundException.class)
     @ResponseStatus(HttpStatus.NOT_FOUND)
     public Result<Void> handleStudentNotFound(StudentNotFoundException ex) {
+        return Result.notFound(ex.getMessage());
+    }
+
+    @ExceptionHandler(InstructorNotFoundException.class)
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    public Result<Void> handleInstructorNotFound(InstructorNotFoundException ex) {
         return Result.notFound(ex.getMessage());
     }
 }

--- a/src/backend/src/main/java/team/projectpulse/team/domain/InstructorNotFoundException.java
+++ b/src/backend/src/main/java/team/projectpulse/team/domain/InstructorNotFoundException.java
@@ -1,0 +1,8 @@
+package team.projectpulse.team.domain;
+
+public class InstructorNotFoundException extends RuntimeException {
+
+    public InstructorNotFoundException(Long instructorId) {
+        super("No instructor found with id: " + instructorId);
+    }
+}

--- a/src/backend/src/main/java/team/projectpulse/team/dto/TeamDetail.java
+++ b/src/backend/src/main/java/team/projectpulse/team/dto/TeamDetail.java
@@ -11,6 +11,7 @@ public record TeamDetail(
     String teamWebsiteUrl,
     List<TeamMemberDetail> teamMembers,
     List<String> teamMemberNames,
+    List<TeamInstructorDetail> teamInstructors,
     List<String> instructorNames
 ) {
 }

--- a/src/backend/src/main/java/team/projectpulse/team/dto/TeamInstructorDetail.java
+++ b/src/backend/src/main/java/team/projectpulse/team/dto/TeamInstructorDetail.java
@@ -1,0 +1,8 @@
+package team.projectpulse.team.dto;
+
+public record TeamInstructorDetail(
+    Long instructorId,
+    String fullName,
+    String email
+) {
+}

--- a/src/backend/src/main/java/team/projectpulse/team/service/TeamService.java
+++ b/src/backend/src/main/java/team/projectpulse/team/service/TeamService.java
@@ -3,14 +3,17 @@ package team.projectpulse.team.service;
 import org.springframework.stereotype.Service;
 import team.projectpulse.section.domain.Section;
 import team.projectpulse.section.repository.SectionRepository;
+import team.projectpulse.team.domain.InstructorNotFoundException;
 import team.projectpulse.team.domain.Team;
 import team.projectpulse.team.domain.InvalidTeamException;
+import team.projectpulse.team.domain.InvalidTeamInstructorAssignmentException;
 import team.projectpulse.team.domain.InvalidTeamStudentAssignmentException;
 import team.projectpulse.team.domain.StudentNotFoundException;
 import team.projectpulse.team.domain.TeamAlreadyExistsException;
 import team.projectpulse.team.domain.TeamNotFoundException;
 import team.projectpulse.team.dto.CreateTeamRequest;
 import team.projectpulse.team.dto.TeamDetail;
+import team.projectpulse.team.dto.TeamInstructorDetail;
 import team.projectpulse.team.dto.TeamMemberDetail;
 import team.projectpulse.team.dto.TeamSummary;
 import team.projectpulse.team.dto.UpdateTeamRequest;
@@ -141,6 +144,28 @@ public class TeamService {
         return toDetail(teamRepository.save(team));
     }
 
+    public TeamDetail removeInstructorFromTeam(Long teamId, Long instructorId) {
+        Team team = teamRepository.findDetailById(teamId)
+            .orElseThrow(() -> new TeamNotFoundException(teamId));
+
+        User instructor = userRepository.findById(instructorId)
+            .filter(this::isInstructor)
+            .orElseThrow(() -> new InstructorNotFoundException(instructorId));
+
+        boolean assignedToTeam = team.getInstructors().stream()
+            .anyMatch(teamInstructor -> teamInstructor.getId().equals(instructor.getId()));
+
+        if (!assignedToTeam) {
+            throw new InvalidTeamInstructorAssignmentException(
+                "Instructor " + instructorId + " is not assigned to team " + teamId + "."
+            );
+        }
+
+        team.getInstructors().removeIf(teamInstructor -> teamInstructor.getId().equals(instructor.getId()));
+
+        return toDetail(teamRepository.save(team));
+    }
+
     private TeamSummary toSummary(Team team) {
         return new TeamSummary(
             team.getTeamId(),
@@ -164,6 +189,7 @@ public class TeamService {
             team.getTeamWebsiteUrl(),
             toSortedTeamMembers(team.getStudents()),
             toSortedNames(team.getStudents()),
+            toSortedTeamInstructors(team.getInstructors()),
             toSortedNames(team.getInstructors())
         );
     }
@@ -177,6 +203,15 @@ public class TeamService {
             .toList();
     }
 
+    private List<TeamInstructorDetail> toSortedTeamInstructors(Iterable<User> users) {
+        return StreamSupport.stream(users.spliterator(), false)
+            .sorted(Comparator
+                .comparing(this::toDisplayName, String.CASE_INSENSITIVE_ORDER)
+                .thenComparing(User::getEmail, String.CASE_INSENSITIVE_ORDER))
+            .map(user -> new TeamInstructorDetail(user.getId(), toDisplayName(user), user.getEmail()))
+            .toList();
+    }
+
     private String toDisplayName(User user) {
         return (user.getFirstName() + " " + user.getLastName()).trim();
     }
@@ -186,6 +221,11 @@ public class TeamService {
             .map(this::toDisplayName)
             .sorted(String.CASE_INSENSITIVE_ORDER)
             .toList();
+    }
+
+    private boolean isInstructor(User user) {
+        String roles = user.getRoles() == null ? "" : user.getRoles().toLowerCase();
+        return List.of(roles.split("\\s+")).contains("instructor");
     }
 
     private String normalize(String value) {

--- a/src/backend/src/test/java/team/projectpulse/team/controller/TeamControllerIntegrationTest.java
+++ b/src/backend/src/test/java/team/projectpulse/team/controller/TeamControllerIntegrationTest.java
@@ -10,12 +10,15 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import team.projectpulse.section.domain.SectionNotFoundException;
+import team.projectpulse.team.domain.InstructorNotFoundException;
 import team.projectpulse.team.domain.InvalidTeamException;
+import team.projectpulse.team.domain.InvalidTeamInstructorAssignmentException;
 import team.projectpulse.team.domain.InvalidTeamStudentAssignmentException;
 import team.projectpulse.team.domain.StudentNotFoundException;
 import team.projectpulse.team.domain.TeamAlreadyExistsException;
 import team.projectpulse.team.domain.TeamNotFoundException;
 import team.projectpulse.team.dto.TeamDetail;
+import team.projectpulse.team.dto.TeamInstructorDetail;
 import team.projectpulse.team.dto.TeamMemberDetail;
 import team.projectpulse.team.dto.TeamSummary;
 import team.projectpulse.team.service.TeamService;
@@ -90,7 +93,7 @@ class TeamControllerIntegrationTest {
     @WithMockUser(roles = "ADMIN")
     void should_ReturnTeamDetailWrappedInResult_When_AdminRequestsTeam() throws Exception {
         when(teamService.findTeamDetail(1L))
-            .thenReturn(new TeamDetail(
+            .thenReturn(buildTeamDetail(
                 1L,
                 1L,
                 "Spring 2026 - Section A",
@@ -99,6 +102,7 @@ class TeamControllerIntegrationTest {
                 "https://pulse.example.com",
                 List.of(new TeamMemberDetail(100L, "Ava Johnson", "ava@tcu.edu")),
                 List.of("Ava Johnson"),
+                List.of(new TeamInstructorDetail(200L, "Ivy Stone", "ivy@tcu.edu")),
                 List.of("Ivy Stone")
             ));
 
@@ -107,7 +111,8 @@ class TeamControllerIntegrationTest {
             .andExpect(jsonPath("$.flag").value(true))
             .andExpect(jsonPath("$.code").value(200))
             .andExpect(jsonPath("$.data.teamName").value("Pulse Analytics"))
-            .andExpect(jsonPath("$.data.sectionName").value("Spring 2026 - Section A"));
+            .andExpect(jsonPath("$.data.sectionName").value("Spring 2026 - Section A"))
+            .andExpect(jsonPath("$.data.teamInstructors[0].fullName").value("Ivy Stone"));
 
         verify(teamService).findTeamDetail(1L);
     }
@@ -116,17 +121,7 @@ class TeamControllerIntegrationTest {
     @WithMockUser(roles = "INSTRUCTOR")
     void should_AllowInstructor_When_RequestingTeamDetail() throws Exception {
         when(teamService.findTeamDetail(2L))
-            .thenReturn(new TeamDetail(
-                2L,
-                1L,
-                "Spring 2026 - Section A",
-                "Review Board",
-                null,
-                null,
-                List.of(),
-                List.of(),
-                List.of()
-            ));
+            .thenReturn(buildTeamDetail(2L, 1L, "Spring 2026 - Section A", "Review Board", null, null, List.of(), List.of(), List.of(), List.of()));
 
         mockMvc.perform(get("/api/v1/teams/2"))
             .andExpect(status().isOk())
@@ -166,13 +161,14 @@ class TeamControllerIntegrationTest {
     @WithMockUser(roles = "ADMIN")
     void should_CreateTeamWrappedInResult_When_AdminRequestsCreate() throws Exception {
         when(teamService.createTeam(org.mockito.ArgumentMatchers.any()))
-            .thenReturn(new TeamDetail(
+            .thenReturn(buildTeamDetail(
                 10L,
                 2L,
                 "Spring 2026 - Section A",
                 "Requirements Hub",
                 "desc",
                 "https://requirements-hub.example.com",
+                List.of(),
                 List.of(),
                 List.of(),
                 List.of()
@@ -194,6 +190,7 @@ class TeamControllerIntegrationTest {
             .andExpect(jsonPath("$.data.teamId").value(10))
             .andExpect(jsonPath("$.data.teamName").value("Requirements Hub"))
             .andExpect(jsonPath("$.data.teamMemberNames").isArray())
+            .andExpect(jsonPath("$.data.teamInstructors").isArray())
             .andExpect(jsonPath("$.data.instructorNames").isArray());
     }
 
@@ -272,7 +269,7 @@ class TeamControllerIntegrationTest {
     @WithMockUser(roles = "ADMIN")
     void should_UpdateTeamWrappedInResult_When_AdminRequestsUpdate() throws Exception {
         when(teamService.updateTeam(eq(10L), org.mockito.ArgumentMatchers.any()))
-            .thenReturn(new TeamDetail(
+            .thenReturn(buildTeamDetail(
                 10L,
                 2L,
                 "Spring 2026 - Section A",
@@ -281,6 +278,7 @@ class TeamControllerIntegrationTest {
                 "https://requirements-hub.example.com",
                 List.of(),
                 List.of(),
+                List.of(new TeamInstructorDetail(200L, "Ivy Stone", "ivy@tcu.edu")),
                 List.of("Ivy Stone")
             ));
 
@@ -424,7 +422,7 @@ class TeamControllerIntegrationTest {
     @WithMockUser(roles = "ADMIN")
     void should_RemoveStudentFromTeam_When_AdminRequestsRemoval() throws Exception {
         when(teamService.removeStudentFromTeam(10L, 100L))
-            .thenReturn(new TeamDetail(
+            .thenReturn(buildTeamDetail(
                 10L,
                 2L,
                 "Spring 2026 - Section A",
@@ -433,6 +431,7 @@ class TeamControllerIntegrationTest {
                 "https://requirements-hub.example.com",
                 List.of(),
                 List.of(),
+                List.of(new TeamInstructorDetail(200L, "Ivy Stone", "ivy@tcu.edu")),
                 List.of("Ivy Stone")
             ));
 
@@ -442,7 +441,8 @@ class TeamControllerIntegrationTest {
             .andExpect(jsonPath("$.message").value("Student removed from team successfully."))
             .andExpect(jsonPath("$.data.teamId").value(10))
             .andExpect(jsonPath("$.data.teamMembers").isArray())
-            .andExpect(jsonPath("$.data.teamMemberNames").isArray());
+            .andExpect(jsonPath("$.data.teamMemberNames").isArray())
+            .andExpect(jsonPath("$.data.teamInstructors[0].fullName").value("Ivy Stone"));
 
         verify(teamService).removeStudentFromTeam(10L, 100L);
     }
@@ -504,5 +504,119 @@ class TeamControllerIntegrationTest {
             .andExpect(jsonPath("$.flag").value(false))
             .andExpect(jsonPath("$.code").value(400))
             .andExpect(jsonPath("$.message").value("Student 100 is not assigned to team 10."));
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void should_RemoveInstructorFromTeam_When_AdminRequestsRemoval() throws Exception {
+        when(teamService.removeInstructorFromTeam(10L, 200L))
+            .thenReturn(buildTeamDetail(
+                10L,
+                2L,
+                "Spring 2026 - Section A",
+                "Requirements Hub",
+                "Centralized workspace",
+                "https://requirements-hub.example.com",
+                List.of(),
+                List.of(),
+                List.of(new TeamInstructorDetail(201L, "Noah Bennett", "noah@tcu.edu")),
+                List.of("Noah Bennett")
+            ));
+
+        mockMvc.perform(delete("/api/v1/teams/10/instructors/200"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.flag").value(true))
+            .andExpect(jsonPath("$.code").value(200))
+            .andExpect(jsonPath("$.message").value("Instructor removed from team successfully."))
+            .andExpect(jsonPath("$.data.teamId").value(10))
+            .andExpect(jsonPath("$.data.teamInstructors[0].fullName").value("Noah Bennett"))
+            .andExpect(jsonPath("$.data.instructorNames[0]").value("Noah Bennett"));
+
+        verify(teamService).removeInstructorFromTeam(10L, 200L);
+    }
+
+    @Test
+    @WithMockUser(roles = "INSTRUCTOR")
+    void should_ReturnForbidden_When_InstructorRequestsInstructorRemoval() throws Exception {
+        mockMvc.perform(delete("/api/v1/teams/10/instructors/200"))
+            .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @WithMockUser(roles = "STUDENT")
+    void should_ReturnForbidden_When_StudentRequestsInstructorRemoval() throws Exception {
+        mockMvc.perform(delete("/api/v1/teams/10/instructors/200"))
+            .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void should_ReturnUnauthorized_When_UnauthenticatedRequestRemovesInstructor() throws Exception {
+        mockMvc.perform(delete("/api/v1/teams/10/instructors/200"))
+            .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void should_ReturnNotFound_When_RemovingInstructorFromMissingTeam() throws Exception {
+        when(teamService.removeInstructorFromTeam(999L, 200L))
+            .thenThrow(new TeamNotFoundException(999L));
+
+        mockMvc.perform(delete("/api/v1/teams/999/instructors/200"))
+            .andExpect(status().isNotFound())
+            .andExpect(jsonPath("$.flag").value(false))
+            .andExpect(jsonPath("$.code").value(404))
+            .andExpect(jsonPath("$.message").value("No team found with id: 999"));
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void should_ReturnNotFound_When_RemovedInstructorDoesNotExist() throws Exception {
+        when(teamService.removeInstructorFromTeam(10L, 404L))
+            .thenThrow(new InstructorNotFoundException(404L));
+
+        mockMvc.perform(delete("/api/v1/teams/10/instructors/404"))
+            .andExpect(status().isNotFound())
+            .andExpect(jsonPath("$.flag").value(false))
+            .andExpect(jsonPath("$.code").value(404))
+            .andExpect(jsonPath("$.message").value("No instructor found with id: 404"));
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void should_ReturnBadRequest_When_InstructorIsNotAssignedToTeam() throws Exception {
+        when(teamService.removeInstructorFromTeam(10L, 200L))
+            .thenThrow(new InvalidTeamInstructorAssignmentException("Instructor 200 is not assigned to team 10."));
+
+        mockMvc.perform(delete("/api/v1/teams/10/instructors/200"))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.flag").value(false))
+            .andExpect(jsonPath("$.code").value(400))
+            .andExpect(jsonPath("$.message").value("Instructor 200 is not assigned to team 10."));
+    }
+
+    private TeamDetail buildTeamDetail(
+        Long teamId,
+        Long sectionId,
+        String sectionName,
+        String teamName,
+        String teamDescription,
+        String teamWebsiteUrl,
+        List<TeamMemberDetail> teamMembers,
+        List<String> teamMemberNames,
+        List<TeamInstructorDetail> teamInstructors,
+        List<String> instructorNames
+    ) {
+        return new TeamDetail(
+            teamId,
+            sectionId,
+            sectionName,
+            teamName,
+            teamDescription,
+            teamWebsiteUrl,
+            teamMembers,
+            teamMemberNames,
+            teamInstructors,
+            instructorNames
+        );
     }
 }

--- a/src/backend/src/test/java/team/projectpulse/team/service/TeamServiceTest.java
+++ b/src/backend/src/test/java/team/projectpulse/team/service/TeamServiceTest.java
@@ -7,8 +7,10 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import team.projectpulse.section.domain.Section;
 import team.projectpulse.section.domain.SectionNotFoundException;
+import team.projectpulse.team.domain.InstructorNotFoundException;
 import team.projectpulse.section.repository.SectionRepository;
 import team.projectpulse.team.domain.InvalidTeamException;
+import team.projectpulse.team.domain.InvalidTeamInstructorAssignmentException;
 import team.projectpulse.team.domain.InvalidTeamStudentAssignmentException;
 import team.projectpulse.team.domain.StudentNotFoundException;
 import team.projectpulse.team.domain.Team;
@@ -16,6 +18,7 @@ import team.projectpulse.team.domain.TeamAlreadyExistsException;
 import team.projectpulse.team.domain.TeamNotFoundException;
 import team.projectpulse.team.dto.CreateTeamRequest;
 import team.projectpulse.team.dto.TeamDetail;
+import team.projectpulse.team.dto.TeamInstructorDetail;
 import team.projectpulse.team.dto.TeamMemberDetail;
 import team.projectpulse.team.dto.TeamSummary;
 import team.projectpulse.team.dto.UpdateTeamRequest;
@@ -107,6 +110,10 @@ class TeamServiceTest {
             new TeamMemberDetail(1L, "Zoe Zeta", "zoe@tcu.edu")
         ), detail.teamMembers());
         assertEquals(List.of("Amy Adams", "Zoe Zeta"), detail.teamMemberNames());
+        assertEquals(List.of(
+            new TeamInstructorDetail(4L, "Ivy Stone", "ivy@tcu.edu"),
+            new TeamInstructorDetail(3L, "Noah Bennett", "noah@tcu.edu")
+        ), detail.teamInstructors());
         assertEquals(List.of("Ivy Stone", "Noah Bennett"), detail.instructorNames());
         verify(teamRepository).findDetailById(10L);
     }
@@ -119,6 +126,10 @@ class TeamServiceTest {
         TeamDetail detail = teamService.findTeamDetail(10L);
 
         assertEquals(List.of("Amy Adams", "Zoe Zeta"), detail.teamMemberNames());
+        assertEquals(List.of(
+            new TeamInstructorDetail(4L, "Ivy Stone", "ivy@tcu.edu"),
+            new TeamInstructorDetail(3L, "Noah Bennett", "noah@tcu.edu")
+        ), detail.teamInstructors());
         assertEquals(List.of("Ivy Stone", "Noah Bennett"), detail.instructorNames());
         assertEquals("Amy Adams", detail.teamMembers().getFirst().fullName());
         assertEquals("amy@tcu.edu", detail.teamMembers().getFirst().email());
@@ -162,6 +173,7 @@ class TeamServiceTest {
         assertEquals("https://requirements-hub.example.com", detail.teamWebsiteUrl());
         assertEquals(List.of(), detail.teamMembers());
         assertEquals(List.of(), detail.teamMemberNames());
+        assertEquals(List.of(), detail.teamInstructors());
         assertEquals(List.of(), detail.instructorNames());
         verify(sectionRepository).findById(2L);
         verify(teamRepository).existsByTeamNameIgnoreCase("Requirements Hub");
@@ -249,6 +261,7 @@ class TeamServiceTest {
         TeamDetail detail = teamService.createTeam(new CreateTeamRequest(2L, "New Team", null, null));
 
         assertEquals(List.of(), detail.teamMemberNames());
+        assertEquals(List.of(), detail.teamInstructors());
         assertEquals(List.of(), detail.instructorNames());
         assertEquals(List.of(), detail.teamMembers());
     }
@@ -274,6 +287,10 @@ class TeamServiceTest {
             new TeamMemberDetail(1L, "Zoe Zeta", "zoe@tcu.edu")
         ), detail.teamMembers());
         assertEquals(List.of("Amy Adams", "Zoe Zeta"), detail.teamMemberNames());
+        assertEquals(List.of(
+            new TeamInstructorDetail(4L, "Ivy Stone", "ivy@tcu.edu"),
+            new TeamInstructorDetail(3L, "Noah Bennett", "noah@tcu.edu")
+        ), detail.teamInstructors());
         assertEquals(List.of("Ivy Stone", "Noah Bennett"), detail.instructorNames());
         verify(teamRepository).findDetailById(10L);
         verify(teamRepository).existsByTeamNameIgnoreCaseAndTeamIdNot("Requirements Hub", 10L);
@@ -412,6 +429,10 @@ class TeamServiceTest {
 
         assertEquals(List.of(new TeamMemberDetail(2L, "Amy Adams", "amy@tcu.edu")), detail.teamMembers());
         assertEquals(List.of("Amy Adams"), detail.teamMemberNames());
+        assertEquals(List.of(
+            new TeamInstructorDetail(4L, "Ivy Stone", "ivy@tcu.edu"),
+            new TeamInstructorDetail(3L, "Noah Bennett", "noah@tcu.edu")
+        ), detail.teamInstructors());
         assertEquals(List.of("Ivy Stone", "Noah Bennett"), detail.instructorNames());
         verify(teamRepository).findDetailById(10L);
         verify(userRepository).findById(1L);
@@ -436,6 +457,10 @@ class TeamServiceTest {
 
         assertEquals(List.of(), detail.teamMembers());
         assertEquals(List.of(), detail.teamMemberNames());
+        assertEquals(List.of(
+            new TeamInstructorDetail(4L, "Ivy Stone", "ivy@tcu.edu"),
+            new TeamInstructorDetail(3L, "Noah Bennett", "noah@tcu.edu")
+        ), detail.teamInstructors());
     }
 
     @Test
@@ -498,6 +523,10 @@ class TeamServiceTest {
 
         assertEquals(2L, detail.sectionId());
         assertEquals("Spring 2026 - Section A", detail.sectionName());
+        assertEquals(List.of(
+            new TeamInstructorDetail(4L, "Ivy Stone", "ivy@tcu.edu"),
+            new TeamInstructorDetail(3L, "Noah Bennett", "noah@tcu.edu")
+        ), detail.teamInstructors());
         assertEquals(List.of("Ivy Stone", "Noah Bennett"), detail.instructorNames());
     }
 
@@ -516,6 +545,133 @@ class TeamServiceTest {
 
         assertEquals(List.of(new TeamMemberDetail(1L, "Zoe Zeta", "zoe@tcu.edu")), detail.teamMembers());
         assertEquals(List.of("Zoe Zeta"), detail.teamMemberNames());
+        assertEquals(List.of(
+            new TeamInstructorDetail(4L, "Ivy Stone", "ivy@tcu.edu"),
+            new TeamInstructorDetail(3L, "Noah Bennett", "noah@tcu.edu")
+        ), detail.teamInstructors());
+    }
+
+    @Test
+    void should_RemoveInstructorFromTeam_When_InstructorIsAssigned() {
+        Team existingTeam = buildTeam();
+        User instructor = existingTeam.getInstructors().stream()
+            .filter(teamInstructor -> teamInstructor.getId().equals(3L))
+            .findFirst()
+            .orElseThrow();
+        when(teamRepository.findDetailById(10L)).thenReturn(Optional.of(existingTeam));
+        when(userRepository.findById(3L)).thenReturn(Optional.of(instructor));
+        when(teamRepository.save(existingTeam)).thenReturn(existingTeam);
+
+        TeamDetail detail = teamService.removeInstructorFromTeam(10L, 3L);
+
+        assertEquals(List.of(new TeamInstructorDetail(4L, "Ivy Stone", "ivy@tcu.edu")), detail.teamInstructors());
+        assertEquals(List.of("Ivy Stone"), detail.instructorNames());
+        assertEquals(List.of("Amy Adams", "Zoe Zeta"), detail.teamMemberNames());
+        verify(teamRepository).findDetailById(10L);
+        verify(userRepository).findById(3L);
+        verify(teamRepository).save(existingTeam);
+    }
+
+    @Test
+    void should_ReturnUpdatedDetail_When_RemovingInstructor() {
+        Team existingTeam = buildTeam();
+        User instructor = existingTeam.getInstructors().stream()
+            .filter(teamInstructor -> teamInstructor.getId().equals(4L))
+            .findFirst()
+            .orElseThrow();
+        when(teamRepository.findDetailById(10L)).thenReturn(Optional.of(existingTeam));
+        when(userRepository.findById(4L)).thenReturn(Optional.of(instructor));
+        when(teamRepository.save(existingTeam)).thenReturn(existingTeam);
+
+        TeamDetail detail = teamService.removeInstructorFromTeam(10L, 4L);
+
+        assertEquals(10L, detail.teamId());
+        assertEquals("Pulse Analytics", detail.teamName());
+        assertEquals(List.of(new TeamInstructorDetail(3L, "Noah Bennett", "noah@tcu.edu")), detail.teamInstructors());
+        assertEquals(List.of("Noah Bennett"), detail.instructorNames());
+    }
+
+    @Test
+    void should_AllowRemovingLastInstructor_When_NoOtherInstructorsRemain() {
+        Team existingTeam = buildTeam();
+        User onlyInstructor = existingTeam.getInstructors().stream()
+            .filter(teamInstructor -> teamInstructor.getId().equals(4L))
+            .findFirst()
+            .orElseThrow();
+        existingTeam.setInstructors(new LinkedHashSet<>(List.of(onlyInstructor)));
+
+        when(teamRepository.findDetailById(10L)).thenReturn(Optional.of(existingTeam));
+        when(userRepository.findById(4L)).thenReturn(Optional.of(onlyInstructor));
+        when(teamRepository.save(existingTeam)).thenReturn(existingTeam);
+
+        TeamDetail detail = teamService.removeInstructorFromTeam(10L, 4L);
+
+        assertEquals(List.of(), detail.teamInstructors());
+        assertEquals(List.of(), detail.instructorNames());
+    }
+
+    @Test
+    void should_ThrowTeamNotFoundException_When_RemovingInstructorFromMissingTeam() {
+        when(teamRepository.findDetailById(404L)).thenReturn(Optional.empty());
+
+        TeamNotFoundException ex = assertThrows(
+            TeamNotFoundException.class,
+            () -> teamService.removeInstructorFromTeam(404L, 3L)
+        );
+
+        assertEquals("No team found with id: 404", ex.getMessage());
+    }
+
+    @Test
+    void should_ThrowInstructorNotFoundException_When_InstructorDoesNotExist() {
+        Team existingTeam = buildTeam();
+        when(teamRepository.findDetailById(10L)).thenReturn(Optional.of(existingTeam));
+        when(userRepository.findById(404L)).thenReturn(Optional.empty());
+
+        InstructorNotFoundException ex = assertThrows(
+            InstructorNotFoundException.class,
+            () -> teamService.removeInstructorFromTeam(10L, 404L)
+        );
+
+        assertEquals("No instructor found with id: 404", ex.getMessage());
+    }
+
+    @Test
+    void should_ThrowInstructorNotFoundException_When_UserIsNotInstructor() {
+        Team existingTeam = buildTeam();
+        User student = existingTeam.getStudents().stream()
+            .filter(teamStudent -> teamStudent.getId().equals(1L))
+            .findFirst()
+            .orElseThrow();
+        when(teamRepository.findDetailById(10L)).thenReturn(Optional.of(existingTeam));
+        when(userRepository.findById(1L)).thenReturn(Optional.of(student));
+
+        InstructorNotFoundException ex = assertThrows(
+            InstructorNotFoundException.class,
+            () -> teamService.removeInstructorFromTeam(10L, 1L)
+        );
+
+        assertEquals("No instructor found with id: 1", ex.getMessage());
+    }
+
+    @Test
+    void should_ThrowInvalidTeamInstructorAssignmentException_When_InstructorIsNotAssignedToTeam() {
+        Team existingTeam = buildTeam();
+        User instructor = new User();
+        instructor.setId(55L);
+        instructor.setFirstName("Maya");
+        instructor.setLastName("Lee");
+        instructor.setEmail("maya@tcu.edu");
+        instructor.setRoles("instructor");
+        when(teamRepository.findDetailById(10L)).thenReturn(Optional.of(existingTeam));
+        when(userRepository.findById(55L)).thenReturn(Optional.of(instructor));
+
+        InvalidTeamInstructorAssignmentException ex = assertThrows(
+            InvalidTeamInstructorAssignmentException.class,
+            () -> teamService.removeInstructorFromTeam(10L, 55L)
+        );
+
+        assertEquals("Instructor 55 is not assigned to team 10.", ex.getMessage());
     }
 
     private Team buildTeam() {
@@ -534,12 +690,18 @@ class TeamServiceTest {
         student2.setEmail("amy@tcu.edu");
 
         User instructor1 = new User();
+        instructor1.setId(3L);
         instructor1.setFirstName("Noah");
         instructor1.setLastName("Bennett");
+        instructor1.setEmail("noah@tcu.edu");
+        instructor1.setRoles("instructor");
 
         User instructor2 = new User();
+        instructor2.setId(4L);
         instructor2.setFirstName("Ivy");
         instructor2.setLastName("Stone");
+        instructor2.setEmail("ivy@tcu.edu");
+        instructor2.setRoles("instructor");
 
         Team team = new Team();
         team.setTeamId(10L);

--- a/src/frontend/src/features/team/pages/TeamDetail.vue
+++ b/src/frontend/src/features/team/pages/TeamDetail.vue
@@ -88,21 +88,34 @@
         </v-col>
         <v-col cols="12" md="6">
           <v-card variant="outlined" class="fill-height">
-            <v-card-title class="text-subtitle-1 font-weight-bold pa-4 pb-2">Instructors</v-card-title>
+            <v-card-title class="text-subtitle-1 font-weight-bold pa-4 pb-2 d-flex align-center">
+              <span>Instructors</span>
+              <v-spacer />
+              <v-btn
+                v-if="isAdmin && team.teamInstructors.length > 0"
+                size="small"
+                color="error"
+                variant="outlined"
+                prepend-icon="mdi-account-remove"
+                @click="openRemoveInstructorDialog"
+              >
+                Remove Instructor
+              </v-btn>
+            </v-card-title>
             <v-card-text>
-              <v-alert v-if="team.instructorNames.length === 0" type="info" variant="tonal" density="compact">
+              <v-alert v-if="team.teamInstructors.length === 0" type="info" variant="tonal" density="compact">
                 No instructors assigned.
               </v-alert>
               <div v-else>
                 <v-chip
-                  v-for="instructor in team.instructorNames"
-                  :key="instructor"
+                  v-for="instructor in team.teamInstructors"
+                  :key="instructor.instructorId"
                   size="small"
                   color="primary"
                   variant="tonal"
                   class="mr-1 mb-1"
                 >
-                  {{ instructor }}
+                  {{ instructor.fullName }}
                 </v-chip>
               </div>
             </v-card-text>
@@ -137,6 +150,39 @@
               <tr>
                 <th class="text-left">Status</th>
                 <td>{{ removedStudentNotification.status }}</td>
+              </tr>
+            </tbody>
+          </v-table>
+        </v-card-text>
+      </v-card>
+
+      <v-card v-if="removedInstructorNotification" variant="outlined" class="mt-4">
+        <v-card-title class="text-subtitle-1 font-weight-bold pa-4 pb-2">Notify Instructor</v-card-title>
+        <v-card-text>
+          <div class="text-body-2 mb-3">
+            Use this summary to notify the instructor manually about the team removal.
+          </div>
+          <v-table density="compact">
+            <tbody>
+              <tr>
+                <th class="text-left">Instructor</th>
+                <td>{{ removedInstructorNotification.fullName }}</td>
+              </tr>
+              <tr>
+                <th class="text-left">Email</th>
+                <td>{{ removedInstructorNotification.email }}</td>
+              </tr>
+              <tr>
+                <th class="text-left">Previous Team</th>
+                <td>{{ removedInstructorNotification.teamName }}</td>
+              </tr>
+              <tr>
+                <th class="text-left">Section</th>
+                <td>{{ removedInstructorNotification.sectionName }}</td>
+              </tr>
+              <tr>
+                <th class="text-left">Status</th>
+                <td>{{ removedInstructorNotification.status }}</td>
               </tr>
             </tbody>
           </v-table>
@@ -332,6 +378,123 @@
       </v-card>
     </v-dialog>
 
+    <v-dialog v-model="removeInstructorDialog" max-width="720" persistent>
+      <v-card>
+        <v-card-title class="pa-4">
+          {{ removeInstructorStep === 1 ? 'Remove Instructor' : 'Confirm Instructor Removal' }}
+        </v-card-title>
+        <v-divider />
+
+        <v-card-text v-if="removeInstructorStep === 1" class="pa-4">
+          <v-select
+            v-model="selectedInstructorId"
+            :items="team?.teamInstructors ?? []"
+            item-title="fullName"
+            item-value="instructorId"
+            label="Instructor to Remove"
+            :error-messages="removeInstructorErrors.instructorId"
+          />
+
+          <v-card v-if="selectedTeamInstructor" variant="outlined" class="mt-4">
+            <v-card-text>
+              <div class="text-caption text-medium-emphasis">Selected Instructor Email</div>
+              <div>{{ selectedTeamInstructor.email }}</div>
+            </v-card-text>
+          </v-card>
+        </v-card-text>
+
+        <v-card-text v-else class="pa-4">
+          <v-alert type="warning" variant="tonal" class="mb-4">
+            Please review the instructor removal before confirming.
+          </v-alert>
+
+          <v-table density="compact" class="mb-4">
+            <tbody>
+              <tr>
+                <th class="text-left">Section</th>
+                <td>{{ team?.sectionName ?? '—' }}</td>
+              </tr>
+              <tr>
+                <th class="text-left">Team</th>
+                <td>{{ team?.teamName ?? '—' }}</td>
+              </tr>
+              <tr>
+                <th class="text-left">Instructor</th>
+                <td>{{ selectedTeamInstructor?.fullName ?? '—' }}</td>
+              </tr>
+              <tr>
+                <th class="text-left">Email</th>
+                <td>{{ selectedTeamInstructor?.email ?? '—' }}</td>
+              </tr>
+            </tbody>
+          </v-table>
+
+          <div class="text-subtitle-2 font-weight-bold mb-2">Remaining Instructors</div>
+          <v-alert
+            v-if="remainingTeamInstructors.length === 0"
+            type="info"
+            variant="tonal"
+            density="compact"
+            class="mb-4"
+          >
+            No instructors will remain after this removal.
+          </v-alert>
+          <div v-else class="mb-4">
+            <v-chip
+              v-for="instructor in remainingTeamInstructors"
+              :key="instructor.instructorId"
+              size="small"
+              color="primary"
+              variant="tonal"
+              class="mr-1 mb-1"
+            >
+              {{ instructor.fullName }}
+            </v-chip>
+          </div>
+
+          <div class="text-subtitle-2 font-weight-bold mb-2">Manual Notification Preview</div>
+          <v-table density="compact">
+            <tbody>
+              <tr>
+                <th class="text-left">Instructor</th>
+                <td>{{ selectedTeamInstructor?.fullName ?? '—' }}</td>
+              </tr>
+              <tr>
+                <th class="text-left">Email</th>
+                <td>{{ selectedTeamInstructor?.email ?? '—' }}</td>
+              </tr>
+              <tr>
+                <th class="text-left">Previous Team</th>
+                <td>{{ team?.teamName ?? '—' }}</td>
+              </tr>
+              <tr>
+                <th class="text-left">Section</th>
+                <td>{{ team?.sectionName ?? '—' }}</td>
+              </tr>
+              <tr>
+                <th class="text-left">Status</th>
+                <td>Removed from team</td>
+              </tr>
+            </tbody>
+          </v-table>
+        </v-card-text>
+
+        <v-divider />
+        <v-card-actions class="pa-4">
+          <v-btn variant="text" @click="cancelRemoveInstructor">Cancel</v-btn>
+          <v-spacer />
+          <v-btn v-if="removeInstructorStep === 2" variant="outlined" @click="removeInstructorStep = 1">Modify</v-btn>
+          <v-btn
+            color="error"
+            :loading="removeInstructorSaving"
+            @click="removeInstructorStep === 1 ? goToRemoveInstructorPreview() : confirmRemoveInstructor()"
+          >
+            {{ removeInstructorStep === 1 ? 'Preview' : 'Confirm' }}
+          </v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
+
     <v-dialog v-model="deleteDialog" max-width="760" persistent>
       <v-card>
         <v-card-title class="pa-4">
@@ -422,7 +585,7 @@
 
           <div class="text-subtitle-2 font-weight-bold mb-2">Instructors to Remove</div>
           <v-alert
-            v-if="!team?.instructorNames.length"
+            v-if="!team?.teamInstructors.length"
             type="info"
             variant="tonal"
             density="compact"
@@ -432,14 +595,14 @@
           </v-alert>
           <div v-else class="mb-4">
             <v-chip
-              v-for="instructor in team.instructorNames"
-              :key="instructor"
+              v-for="instructor in team.teamInstructors"
+              :key="instructor.instructorId"
               size="small"
               color="primary"
               variant="tonal"
               class="mr-1 mb-1"
             >
-              {{ instructor }}
+              {{ instructor.fullName }}
             </v-chip>
           </div>
 
@@ -474,11 +637,25 @@
 import { computed, onMounted, ref } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { useUserInfoStore } from '@/stores/userInfo'
-import { deleteTeam, getTeam, removeStudentFromTeam, updateTeam } from '../services/teamService'
+import { deleteTeam, getTeam, removeInstructorFromTeam, removeStudentFromTeam, updateTeam } from '../services/teamService'
 import { useTeamNotificationsStore } from '../stores/teamNotifications'
-import type { TeamDeletionNotification, TeamDetail, TeamMemberDetail, UpdateTeamRequest } from '../services/teamTypes'
+import type {
+  TeamDeletionNotification,
+  TeamDetail,
+  TeamInstructorDetail,
+  TeamMemberDetail,
+  UpdateTeamRequest
+} from '../services/teamTypes'
 
 interface RemovedStudentNotification {
+  fullName: string
+  email: string
+  teamName: string
+  sectionName: string
+  status: string
+}
+
+interface RemovedInstructorNotification {
   fullName: string
   email: string
   teamName: string
@@ -502,10 +679,16 @@ const removeStep = ref(1)
 const removeSaving = ref(false)
 const removeErrors = ref<{ studentId?: string }>({})
 const selectedStudentId = ref<number | null>(null)
+const removeInstructorDialog = ref(false)
+const removeInstructorStep = ref(1)
+const removeInstructorSaving = ref(false)
+const removeInstructorErrors = ref<{ instructorId?: string }>({})
+const selectedInstructorId = ref<number | null>(null)
 const deleteDialog = ref(false)
 const deleteStep = ref(1)
 const deleteSaving = ref(false)
 const removedStudentNotification = ref<RemovedStudentNotification | null>(null)
+const removedInstructorNotification = ref<RemovedInstructorNotification | null>(null)
 const snackbar = ref({ show: false, message: '', color: 'success' })
 
 const emptyForm = () => ({
@@ -528,8 +711,16 @@ const selectedTeamMember = computed<TeamMemberDetail | null>(() =>
   team.value?.teamMembers.find((member) => member.studentId === selectedStudentId.value) ?? null
 )
 
+const selectedTeamInstructor = computed<TeamInstructorDetail | null>(() =>
+  team.value?.teamInstructors.find((instructor) => instructor.instructorId === selectedInstructorId.value) ?? null
+)
+
 const remainingTeamMembers = computed(() =>
   team.value?.teamMembers.filter((member) => member.studentId !== selectedStudentId.value) ?? []
+)
+
+const remainingTeamInstructors = computed(() =>
+  team.value?.teamInstructors.filter((instructor) => instructor.instructorId !== selectedInstructorId.value) ?? []
 )
 
 onMounted(async () => {
@@ -580,6 +771,20 @@ function cancelRemove() {
   removeStep.value = 1
 }
 
+function openRemoveInstructorDialog() {
+  selectedInstructorId.value = null
+  removeInstructorErrors.value = {}
+  removeInstructorStep.value = 1
+  removeInstructorDialog.value = true
+}
+
+function cancelRemoveInstructor() {
+  removeInstructorDialog.value = false
+  removeInstructorErrors.value = {}
+  selectedInstructorId.value = null
+  removeInstructorStep.value = 1
+}
+
 function openDeleteDialog() {
   deleteStep.value = 1
   deleteDialog.value = true
@@ -624,6 +829,15 @@ function validateRemove(): boolean {
   return true
 }
 
+function validateRemoveInstructor(): boolean {
+  removeInstructorErrors.value = {}
+  if (!selectedInstructorId.value) {
+    removeInstructorErrors.value.instructorId = 'Instructor is required.'
+    return false
+  }
+  return true
+}
+
 function goToEditPreview() {
   if (!validateEdit()) return
   editStep.value = 2
@@ -632,6 +846,11 @@ function goToEditPreview() {
 function goToRemovePreview() {
   if (!validateRemove()) return
   removeStep.value = 2
+}
+
+function goToRemoveInstructorPreview() {
+  if (!validateRemoveInstructor()) return
+  removeInstructorStep.value = 2
 }
 
 function goToDeletePreview() {
@@ -700,6 +919,41 @@ async function confirmRemove() {
   }
 }
 
+async function confirmRemoveInstructor() {
+  if (!team.value || !selectedTeamInstructor.value) return
+
+  removeInstructorSaving.value = true
+  const removedInstructor = selectedTeamInstructor.value
+
+  try {
+    const res = await removeInstructorFromTeam(team.value.teamId, removedInstructor.instructorId) as any
+    if (res.flag && res.data) {
+      const updatedTeam = res.data as TeamDetail
+      team.value = updatedTeam
+      removedInstructorNotification.value = {
+        fullName: removedInstructor.fullName,
+        email: removedInstructor.email,
+        teamName: updatedTeam.teamName,
+        sectionName: updatedTeam.sectionName,
+        status: 'Removed from team'
+      }
+      removeInstructorDialog.value = false
+      removeInstructorErrors.value = {}
+      selectedInstructorId.value = null
+      removeInstructorStep.value = 1
+      snackbar.value = { show: true, message: 'Instructor removed from team successfully.', color: 'success' }
+      return
+    }
+
+    snackbar.value = { show: true, message: res.message || 'Failed to remove instructor from team.', color: 'error' }
+  } catch (error: any) {
+    const message = error?.response?.data?.message || 'Failed to remove instructor from team.'
+    snackbar.value = { show: true, message, color: 'error' }
+  } finally {
+    removeInstructorSaving.value = false
+  }
+}
+
 async function confirmDelete() {
   if (!team.value) return
 
@@ -732,7 +986,10 @@ function buildDeletedTeamNotification(currentTeam: TeamDetail): TeamDeletionNoti
       fullName: member.fullName,
       email: member.email
     })),
-    instructorNotifications: currentTeam.instructorNames.map((fullName) => ({ fullName })),
+    instructorNotifications: currentTeam.teamInstructors.map((instructor) => ({
+      fullName: instructor.fullName,
+      email: instructor.email
+    })),
     status: 'Team deleted'
   }
 }

--- a/src/frontend/src/features/team/services/teamService.ts
+++ b/src/frontend/src/features/team/services/teamService.ts
@@ -34,6 +34,9 @@ export const deleteTeam = (id: number) =>
 export const removeStudentFromTeam = (teamId: number, studentId: number) =>
   request.delete<ApiResponse<TeamDetail>>(`${BASE}/${teamId}/students/${studentId}`)
 
+export const removeInstructorFromTeam = (teamId: number, instructorId: number) =>
+  request.delete<ApiResponse<TeamDetail>>(`${BASE}/${teamId}/instructors/${instructorId}`)
+
 export const getTeamStudentAssignmentWorkspace = (sectionId: number) =>
   request.get<ApiResponse<TeamStudentAssignmentWorkspace>>(ASSIGNMENT_BASE, { params: { sectionId } })
 

--- a/src/frontend/src/features/team/services/teamTypes.ts
+++ b/src/frontend/src/features/team/services/teamTypes.ts
@@ -18,11 +18,18 @@ export interface TeamDetail {
   teamWebsiteUrl: string | null
   teamMembers: TeamMemberDetail[]
   teamMemberNames: string[]
+  teamInstructors: TeamInstructorDetail[]
   instructorNames: string[]
 }
 
 export interface TeamMemberDetail {
   studentId: number
+  fullName: string
+  email: string
+}
+
+export interface TeamInstructorDetail {
+  instructorId: number
   fullName: string
   email: string
 }


### PR DESCRIPTION
Implements UC-20 by allowing admins to remove an instructor from a senior design team directly on the team detail page. This adds a new backend DELETE /api/v1/teams/{teamId}/instructors/{instructorId} endpoint, extends team detail responses with structured instructor data for selection and notification, and adds a preview/confirm removal flow with a manual instructor notification summary in the frontend. Frontend npm run type-check and npm exec vite build passed; backend compile passed, while runtime mock-based tests may still be affected by the existing Mockito/JDK 25 environment issue.