### PR TITLE
feat(uc-27): implement WAR activity management

### DIFF
--- a/src/backend/src/main/java/team/projectpulse/activity/controller/ActivityController.java
+++ b/src/backend/src/main/java/team/projectpulse/activity/controller/ActivityController.java
@@ -1,0 +1,65 @@
+package team.projectpulse.activity.controller;
+
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import team.projectpulse.activity.dto.ActivityDetail;
+import team.projectpulse.activity.dto.ActivityWorkspace;
+import team.projectpulse.activity.dto.CreateActivityRequest;
+import team.projectpulse.activity.dto.UpdateActivityRequest;
+import team.projectpulse.activity.service.ActivityService;
+import team.projectpulse.system.Result;
+
+@RestController
+@RequestMapping("${api.endpoint.base-url}/activities")
+public class ActivityController {
+
+    private final ActivityService activityService;
+
+    public ActivityController(ActivityService activityService) {
+        this.activityService = activityService;
+    }
+
+    @GetMapping("/workspace")
+    @PreAuthorize("hasRole('STUDENT')")
+    public Result<ActivityWorkspace> getWorkspace(
+        Authentication authentication,
+        @RequestParam(required = false) String week
+    ) {
+        return Result.success(activityService.loadWorkspace(authentication.getName(), week));
+    }
+
+    @PostMapping
+    @PreAuthorize("hasRole('STUDENT')")
+    public Result<ActivityDetail> createActivity(
+        Authentication authentication,
+        @RequestBody CreateActivityRequest request
+    ) {
+        return Result.success("WAR has been updated.", activityService.createActivity(authentication.getName(), request));
+    }
+
+    @PutMapping("/{activityId}")
+    @PreAuthorize("hasRole('STUDENT')")
+    public Result<ActivityDetail> updateActivity(
+        Authentication authentication,
+        @PathVariable Long activityId,
+        @RequestBody UpdateActivityRequest request
+    ) {
+        return Result.success("WAR has been updated.", activityService.updateActivity(authentication.getName(), activityId, request));
+    }
+
+    @DeleteMapping("/{activityId}")
+    @PreAuthorize("hasRole('STUDENT')")
+    public Result<Void> deleteActivity(Authentication authentication, @PathVariable Long activityId) {
+        activityService.deleteActivity(authentication.getName(), activityId);
+        return Result.success("WAR has been updated.", null);
+    }
+}

--- a/src/backend/src/main/java/team/projectpulse/activity/controller/ActivityExceptionHandler.java
+++ b/src/backend/src/main/java/team/projectpulse/activity/controller/ActivityExceptionHandler.java
@@ -1,0 +1,26 @@
+package team.projectpulse.activity.controller;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import team.projectpulse.activity.domain.ActivityNotFoundException;
+import team.projectpulse.activity.domain.InvalidActivityException;
+import team.projectpulse.system.Result;
+import team.projectpulse.system.StatusCode;
+
+@RestControllerAdvice
+public class ActivityExceptionHandler {
+
+    @ExceptionHandler(ActivityNotFoundException.class)
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    public Result<Void> handleActivityNotFound(ActivityNotFoundException ex) {
+        return Result.notFound(ex.getMessage());
+    }
+
+    @ExceptionHandler(InvalidActivityException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public Result<Void> handleInvalidActivity(InvalidActivityException ex) {
+        return Result.error(StatusCode.INVALID_ARGUMENT, ex.getMessage());
+    }
+}

--- a/src/backend/src/main/java/team/projectpulse/activity/domain/Activity.java
+++ b/src/backend/src/main/java/team/projectpulse/activity/domain/Activity.java
@@ -1,0 +1,175 @@
+package team.projectpulse.activity.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import jakarta.persistence.Table;
+import team.projectpulse.team.domain.Team;
+import team.projectpulse.user.domain.User;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "activities")
+public class Activity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "activity_id")
+    private Long activityId;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "team_id", nullable = false)
+    private Team team;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "student_id", nullable = false)
+    private User student;
+
+    @Column(name = "week", nullable = false, length = 20)
+    private String week;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "category", nullable = false, length = 50)
+    private ActivityCategory category;
+
+    @Column(name = "planned_activity", nullable = false, length = 255)
+    private String plannedActivity;
+
+    @Column(name = "description", nullable = false, columnDefinition = "TEXT")
+    private String description;
+
+    @Column(name = "planned_hours", nullable = false, precision = 6, scale = 2)
+    private BigDecimal plannedHours;
+
+    @Column(name = "actual_hours", nullable = false, precision = 6, scale = 2)
+    private BigDecimal actualHours;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 30)
+    private ActivityStatus status;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    @PrePersist
+    void onCreate() {
+        LocalDateTime now = LocalDateTime.now();
+        createdAt = now;
+        updatedAt = now;
+    }
+
+    @PreUpdate
+    void onUpdate() {
+        updatedAt = LocalDateTime.now();
+    }
+
+    public Long getActivityId() {
+        return activityId;
+    }
+
+    public void setActivityId(Long activityId) {
+        this.activityId = activityId;
+    }
+
+    public Team getTeam() {
+        return team;
+    }
+
+    public void setTeam(Team team) {
+        this.team = team;
+    }
+
+    public User getStudent() {
+        return student;
+    }
+
+    public void setStudent(User student) {
+        this.student = student;
+    }
+
+    public String getWeek() {
+        return week;
+    }
+
+    public void setWeek(String week) {
+        this.week = week;
+    }
+
+    public ActivityCategory getCategory() {
+        return category;
+    }
+
+    public void setCategory(ActivityCategory category) {
+        this.category = category;
+    }
+
+    public String getPlannedActivity() {
+        return plannedActivity;
+    }
+
+    public void setPlannedActivity(String plannedActivity) {
+        this.plannedActivity = plannedActivity;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public BigDecimal getPlannedHours() {
+        return plannedHours;
+    }
+
+    public void setPlannedHours(BigDecimal plannedHours) {
+        this.plannedHours = plannedHours;
+    }
+
+    public BigDecimal getActualHours() {
+        return actualHours;
+    }
+
+    public void setActualHours(BigDecimal actualHours) {
+        this.actualHours = actualHours;
+    }
+
+    public ActivityStatus getStatus() {
+        return status;
+    }
+
+    public void setStatus(ActivityStatus status) {
+        this.status = status;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(LocalDateTime createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public LocalDateTime getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public void setUpdatedAt(LocalDateTime updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+}

--- a/src/backend/src/main/java/team/projectpulse/activity/domain/ActivityCategory.java
+++ b/src/backend/src/main/java/team/projectpulse/activity/domain/ActivityCategory.java
@@ -1,0 +1,15 @@
+package team.projectpulse.activity.domain;
+
+public enum ActivityCategory {
+    DEVELOPMENT,
+    TESTING,
+    BUGFIX,
+    COMMUNICATION,
+    DOCUMENTATION,
+    DESIGN,
+    PLANNING,
+    LEARNING,
+    DEPLOYMENT,
+    SUPPORT,
+    MISCELLANEOUS
+}

--- a/src/backend/src/main/java/team/projectpulse/activity/domain/ActivityNotFoundException.java
+++ b/src/backend/src/main/java/team/projectpulse/activity/domain/ActivityNotFoundException.java
@@ -1,0 +1,7 @@
+package team.projectpulse.activity.domain;
+
+public class ActivityNotFoundException extends RuntimeException {
+    public ActivityNotFoundException(Long activityId) {
+        super("No activity found with id: " + activityId);
+    }
+}

--- a/src/backend/src/main/java/team/projectpulse/activity/domain/ActivityStatus.java
+++ b/src/backend/src/main/java/team/projectpulse/activity/domain/ActivityStatus.java
@@ -1,0 +1,7 @@
+package team.projectpulse.activity.domain;
+
+public enum ActivityStatus {
+    IN_PROGRESS,
+    UNDER_TESTING,
+    DONE
+}

--- a/src/backend/src/main/java/team/projectpulse/activity/domain/InvalidActivityException.java
+++ b/src/backend/src/main/java/team/projectpulse/activity/domain/InvalidActivityException.java
@@ -1,0 +1,7 @@
+package team.projectpulse.activity.domain;
+
+public class InvalidActivityException extends RuntimeException {
+    public InvalidActivityException(String message) {
+        super(message);
+    }
+}

--- a/src/backend/src/main/java/team/projectpulse/activity/dto/ActivityDetail.java
+++ b/src/backend/src/main/java/team/projectpulse/activity/dto/ActivityDetail.java
@@ -1,0 +1,18 @@
+package team.projectpulse.activity.dto;
+
+import team.projectpulse.activity.domain.ActivityCategory;
+import team.projectpulse.activity.domain.ActivityStatus;
+
+import java.math.BigDecimal;
+
+public record ActivityDetail(
+    Long activityId,
+    String week,
+    ActivityCategory category,
+    String plannedActivity,
+    String description,
+    BigDecimal plannedHours,
+    BigDecimal actualHours,
+    ActivityStatus status
+) {
+}

--- a/src/backend/src/main/java/team/projectpulse/activity/dto/ActivityWeekOption.java
+++ b/src/backend/src/main/java/team/projectpulse/activity/dto/ActivityWeekOption.java
@@ -1,0 +1,8 @@
+package team.projectpulse.activity.dto;
+
+public record ActivityWeekOption(
+    String week,
+    String label,
+    boolean activeWeek
+) {
+}

--- a/src/backend/src/main/java/team/projectpulse/activity/dto/ActivityWorkspace.java
+++ b/src/backend/src/main/java/team/projectpulse/activity/dto/ActivityWorkspace.java
@@ -1,0 +1,16 @@
+package team.projectpulse.activity.dto;
+
+import java.util.List;
+
+public record ActivityWorkspace(
+    Long sectionId,
+    String sectionName,
+    Long teamId,
+    String teamName,
+    String selectedWeek,
+    List<ActivityWeekOption> availableWeeks,
+    List<ActivityDetail> activities,
+    boolean canManageActivities,
+    String availabilityMessage
+) {
+}

--- a/src/backend/src/main/java/team/projectpulse/activity/dto/CreateActivityRequest.java
+++ b/src/backend/src/main/java/team/projectpulse/activity/dto/CreateActivityRequest.java
@@ -1,0 +1,17 @@
+package team.projectpulse.activity.dto;
+
+import team.projectpulse.activity.domain.ActivityCategory;
+import team.projectpulse.activity.domain.ActivityStatus;
+
+import java.math.BigDecimal;
+
+public record CreateActivityRequest(
+    String week,
+    ActivityCategory category,
+    String plannedActivity,
+    String description,
+    BigDecimal plannedHours,
+    BigDecimal actualHours,
+    ActivityStatus status
+) {
+}

--- a/src/backend/src/main/java/team/projectpulse/activity/dto/UpdateActivityRequest.java
+++ b/src/backend/src/main/java/team/projectpulse/activity/dto/UpdateActivityRequest.java
@@ -1,0 +1,16 @@
+package team.projectpulse.activity.dto;
+
+import team.projectpulse.activity.domain.ActivityCategory;
+import team.projectpulse.activity.domain.ActivityStatus;
+
+import java.math.BigDecimal;
+
+public record UpdateActivityRequest(
+    ActivityCategory category,
+    String plannedActivity,
+    String description,
+    BigDecimal plannedHours,
+    BigDecimal actualHours,
+    ActivityStatus status
+) {
+}

--- a/src/backend/src/main/java/team/projectpulse/activity/repository/ActivityRepository.java
+++ b/src/backend/src/main/java/team/projectpulse/activity/repository/ActivityRepository.java
@@ -1,0 +1,37 @@
+package team.projectpulse.activity.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import team.projectpulse.activity.domain.Activity;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface ActivityRepository extends JpaRepository<Activity, Long> {
+
+    @Query("""
+        select a from Activity a
+        join fetch a.team t
+        join fetch a.student s
+        where s.id = :studentId
+          and a.week = :week
+        order by a.activityId asc
+        """)
+    List<Activity> findAllByStudentIdAndWeekOrderByActivityIdAsc(
+        @Param("studentId") Long studentId,
+        @Param("week") String week
+    );
+
+    @Query("""
+        select a from Activity a
+        join fetch a.team t
+        join fetch a.student s
+        where a.activityId = :activityId
+          and s.id = :studentId
+        """)
+    Optional<Activity> findByActivityIdAndStudentId(
+        @Param("activityId") Long activityId,
+        @Param("studentId") Long studentId
+    );
+}

--- a/src/backend/src/main/java/team/projectpulse/activity/service/ActivityService.java
+++ b/src/backend/src/main/java/team/projectpulse/activity/service/ActivityService.java
@@ -1,0 +1,416 @@
+package team.projectpulse.activity.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import team.projectpulse.activity.domain.Activity;
+import team.projectpulse.activity.domain.ActivityCategory;
+import team.projectpulse.activity.domain.ActivityNotFoundException;
+import team.projectpulse.activity.domain.ActivityStatus;
+import team.projectpulse.activity.domain.InvalidActivityException;
+import team.projectpulse.activity.dto.ActivityDetail;
+import team.projectpulse.activity.dto.ActivityWeekOption;
+import team.projectpulse.activity.dto.ActivityWorkspace;
+import team.projectpulse.activity.dto.CreateActivityRequest;
+import team.projectpulse.activity.dto.UpdateActivityRequest;
+import team.projectpulse.activity.repository.ActivityRepository;
+import team.projectpulse.section.domain.Section;
+import team.projectpulse.team.domain.Team;
+import team.projectpulse.team.repository.TeamRepository;
+import team.projectpulse.user.domain.User;
+import team.projectpulse.user.repository.UserRepository;
+
+import java.math.BigDecimal;
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.temporal.WeekFields;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+import java.util.Set;
+
+@Service
+public class ActivityService {
+
+    private static final BigDecimal MAX_HOURS = new BigDecimal("999.99");
+    private static final int MAX_PLANNED_ACTIVITY_LENGTH = 255;
+    private static final int MAX_DESCRIPTION_LENGTH = 2000;
+    private static final WeekFields ISO = WeekFields.ISO;
+
+    private final ActivityRepository activityRepository;
+    private final UserRepository userRepository;
+    private final TeamRepository teamRepository;
+
+    public ActivityService(
+        ActivityRepository activityRepository,
+        UserRepository userRepository,
+        TeamRepository teamRepository
+    ) {
+        this.activityRepository = activityRepository;
+        this.userRepository = userRepository;
+        this.teamRepository = teamRepository;
+    }
+
+    @Transactional(readOnly = true)
+    public ActivityWorkspace loadWorkspace(String studentEmail, String requestedWeek) {
+        User student = requireStudent(studentEmail);
+        Section section = student.getSection();
+
+        if (section == null) {
+            return new ActivityWorkspace(
+                null,
+                null,
+                null,
+                null,
+                null,
+                List.of(),
+                List.of(),
+                false,
+                "You must belong to a senior design section before managing WAR activities."
+            );
+        }
+
+        Optional<Team> teamOptional = teamRepository.findByStudentIdWithSection(student.getId());
+        if (teamOptional.isEmpty()) {
+            return new ActivityWorkspace(
+                section.getSectionId(),
+                section.getSectionName(),
+                null,
+                null,
+                null,
+                buildWeekOptions(section),
+                List.of(),
+                false,
+                "You must be assigned to a senior design team before managing WAR activities."
+            );
+        }
+
+        Team team = teamOptional.get();
+        List<ActivityWeekOption> availableWeeks = buildWeekOptions(section);
+        String selectedWeek = determineSelectedWeek(availableWeeks, requestedWeek);
+
+        if (selectedWeek == null) {
+            return new ActivityWorkspace(
+                section.getSectionId(),
+                section.getSectionName(),
+                team.getTeamId(),
+                team.getTeamName(),
+                null,
+                availableWeeks,
+                List.of(),
+                false,
+                "No eligible weeks are available yet."
+            );
+        }
+
+        List<ActivityDetail> activities = activityRepository
+            .findAllByStudentIdAndWeekOrderByActivityIdAsc(student.getId(), selectedWeek)
+            .stream()
+            .map(this::toDetail)
+            .toList();
+
+        return new ActivityWorkspace(
+            section.getSectionId(),
+            section.getSectionName(),
+            team.getTeamId(),
+            team.getTeamName(),
+            selectedWeek,
+            availableWeeks,
+            activities,
+            true,
+            null
+        );
+    }
+
+    @Transactional
+    public ActivityDetail createActivity(String studentEmail, CreateActivityRequest request) {
+        StudentContext context = requireStudentContext(studentEmail);
+        validateCreateRequest(request, context.section());
+
+        Activity activity = new Activity();
+        activity.setTeam(context.team());
+        activity.setStudent(context.student());
+        activity.setWeek(normalizeWeek(request.week(), context.section()));
+        activity.setCategory(requireCategory(request.category()));
+        activity.setPlannedActivity(requirePlannedActivity(request.plannedActivity()));
+        activity.setDescription(requireDescription(request.description()));
+        activity.setPlannedHours(requireHours(request.plannedHours(), "Planned hours are required."));
+        activity.setActualHours(requireHours(request.actualHours(), "Actual hours are required."));
+        activity.setStatus(requireStatus(request.status()));
+
+        return toDetail(activityRepository.save(activity));
+    }
+
+    @Transactional
+    public ActivityDetail updateActivity(String studentEmail, Long activityId, UpdateActivityRequest request) {
+        StudentContext context = requireStudentContext(studentEmail);
+        Activity activity = activityRepository.findByActivityIdAndStudentId(activityId, context.student().getId())
+            .orElseThrow(() -> new ActivityNotFoundException(activityId));
+
+        validateUpdateRequest(request);
+
+        activity.setCategory(requireCategory(request.category()));
+        activity.setPlannedActivity(requirePlannedActivity(request.plannedActivity()));
+        activity.setDescription(requireDescription(request.description()));
+        activity.setPlannedHours(requireHours(request.plannedHours(), "Planned hours are required."));
+        activity.setActualHours(requireHours(request.actualHours(), "Actual hours are required."));
+        activity.setStatus(requireStatus(request.status()));
+
+        return toDetail(activityRepository.save(activity));
+    }
+
+    @Transactional
+    public void deleteActivity(String studentEmail, Long activityId) {
+        StudentContext context = requireStudentContext(studentEmail);
+        Activity activity = activityRepository.findByActivityIdAndStudentId(activityId, context.student().getId())
+            .orElseThrow(() -> new ActivityNotFoundException(activityId));
+
+        activityRepository.delete(activity);
+    }
+
+    private User requireStudent(String studentEmail) {
+        User student = userRepository.findByEmail(studentEmail)
+            .orElseThrow(() -> new InvalidActivityException("No student account found for the current user."));
+
+        if (!isStudent(student)) {
+            throw new InvalidActivityException("Only students can manage WAR activities.");
+        }
+
+        return student;
+    }
+
+    private StudentContext requireStudentContext(String studentEmail) {
+        User student = requireStudent(studentEmail);
+        Section section = student.getSection();
+        if (section == null) {
+            throw new InvalidActivityException("You must belong to a senior design section before managing WAR activities.");
+        }
+
+        Team team = teamRepository.findByStudentIdWithSection(student.getId())
+            .orElseThrow(() -> new InvalidActivityException("You must be assigned to a senior design team before managing WAR activities."));
+
+        List<ActivityWeekOption> availableWeeks = buildWeekOptions(section);
+        if (availableWeeks.isEmpty()) {
+            throw new InvalidActivityException("No eligible week is available for WAR activity management.");
+        }
+
+        return new StudentContext(student, section, team, availableWeeks);
+    }
+
+    private void validateCreateRequest(CreateActivityRequest request, Section section) {
+        if (request == null) {
+            throw new InvalidActivityException("Activity request is required.");
+        }
+        normalizeWeek(request.week(), section);
+        requireCategory(request.category());
+        requirePlannedActivity(request.plannedActivity());
+        requireDescription(request.description());
+        requireHours(request.plannedHours(), "Planned hours are required.");
+        requireHours(request.actualHours(), "Actual hours are required.");
+        requireStatus(request.status());
+    }
+
+    private void validateUpdateRequest(UpdateActivityRequest request) {
+        if (request == null) {
+            throw new InvalidActivityException("Activity request is required.");
+        }
+        requireCategory(request.category());
+        requirePlannedActivity(request.plannedActivity());
+        requireDescription(request.description());
+        requireHours(request.plannedHours(), "Planned hours are required.");
+        requireHours(request.actualHours(), "Actual hours are required.");
+        requireStatus(request.status());
+    }
+
+    private String normalizeWeek(String week, Section section) {
+        if (week == null || week.isBlank()) {
+            throw new InvalidActivityException("Week is required.");
+        }
+
+        String trimmedWeek = week.trim();
+        if (isFutureWeek(trimmedWeek)) {
+            throw new InvalidActivityException("Future weeks cannot be selected.");
+        }
+
+        Set<String> allowedWeeks = buildWeekOptions(section).stream()
+            .map(ActivityWeekOption::week)
+            .collect(java.util.stream.Collectors.toCollection(LinkedHashSet::new));
+
+        if (!allowedWeeks.contains(trimmedWeek)) {
+            throw new InvalidActivityException("Selected week is not eligible for WAR activity management.");
+        }
+
+        return trimmedWeek;
+    }
+
+    private ActivityCategory requireCategory(ActivityCategory category) {
+        if (category == null) {
+            throw new InvalidActivityException("Activity category is required.");
+        }
+        return category;
+    }
+
+    private ActivityStatus requireStatus(ActivityStatus status) {
+        if (status == null) {
+            throw new InvalidActivityException("Status is required.");
+        }
+        return status;
+    }
+
+    private String requirePlannedActivity(String plannedActivity) {
+        String normalized = normalizeText(plannedActivity);
+        if (normalized == null) {
+            throw new InvalidActivityException("Planned activity is required.");
+        }
+        if (normalized.length() > MAX_PLANNED_ACTIVITY_LENGTH) {
+            throw new InvalidActivityException("Planned activity must be 255 characters or fewer.");
+        }
+        return normalized;
+    }
+
+    private String requireDescription(String description) {
+        String normalized = normalizeText(description);
+        if (normalized == null) {
+            throw new InvalidActivityException("Activity description is required.");
+        }
+        if (normalized.length() > MAX_DESCRIPTION_LENGTH) {
+            throw new InvalidActivityException("Activity description must be 2000 characters or fewer.");
+        }
+        return normalized;
+    }
+
+    private BigDecimal requireHours(BigDecimal hours, String requiredMessage) {
+        if (hours == null) {
+            throw new InvalidActivityException(requiredMessage);
+        }
+        if (hours.compareTo(BigDecimal.ZERO) < 0) {
+            if ("Planned hours are required.".equals(requiredMessage)) {
+                throw new InvalidActivityException("Planned hours must be zero or greater.");
+            }
+            throw new InvalidActivityException("Actual hours must be zero or greater.");
+        }
+        if (hours.compareTo(MAX_HOURS) > 0) {
+            if ("Planned hours are required.".equals(requiredMessage)) {
+                throw new InvalidActivityException("Planned hours must be 999.99 or fewer.");
+            }
+            throw new InvalidActivityException("Actual hours must be 999.99 or fewer.");
+        }
+        return hours.stripTrailingZeros();
+    }
+
+    private String normalizeText(String value) {
+        if (value == null) {
+            return null;
+        }
+        String trimmed = value.trim();
+        return trimmed.isEmpty() ? null : trimmed;
+    }
+
+    private String determineSelectedWeek(List<ActivityWeekOption> availableWeeks, String requestedWeek) {
+        if (availableWeeks.isEmpty()) {
+            return null;
+        }
+        if (requestedWeek != null && availableWeeks.stream().anyMatch(option -> option.week().equals(requestedWeek))) {
+            return requestedWeek;
+        }
+        return availableWeeks.stream()
+            .map(ActivityWeekOption::week)
+            .max(String.CASE_INSENSITIVE_ORDER)
+            .orElse(null);
+    }
+
+    private List<ActivityWeekOption> buildWeekOptions(Section section) {
+        Set<String> activeWeeks = new LinkedHashSet<>(section.getActiveWeeks() == null ? List.of() : section.getActiveWeeks());
+        List<String> eligibleWeeks = deriveEligibleWeeks(section);
+
+        return eligibleWeeks.stream()
+            .sorted(Comparator.naturalOrder())
+            .map(week -> new ActivityWeekOption(week, formatWeekLabel(week), activeWeeks.contains(week)))
+            .toList();
+    }
+
+    private List<String> deriveEligibleWeeks(Section section) {
+        if (section.getStartDate() != null && section.getEndDate() != null) {
+            LocalDate currentDate = LocalDate.now();
+            LocalDate cappedEndDate = section.getEndDate().isBefore(currentDate) ? section.getEndDate() : currentDate;
+
+            if (cappedEndDate.isBefore(section.getStartDate())) {
+                return List.of();
+            }
+
+            LocalDate cursor = toMonday(section.getStartDate());
+            LocalDate endCursor = toMonday(cappedEndDate);
+            List<String> weeks = new ArrayList<>();
+
+            while (!cursor.isAfter(endCursor)) {
+                weeks.add(toIsoWeek(cursor));
+                cursor = cursor.plusWeeks(1);
+            }
+            return weeks;
+        }
+
+        return (section.getActiveWeeks() == null ? List.<String>of() : section.getActiveWeeks()).stream()
+            .filter(week -> !isFutureWeek(week))
+            .sorted()
+            .toList();
+    }
+
+    private boolean isFutureWeek(String isoWeek) {
+        try {
+            LocalDate weekStart = parseIsoWeekStart(isoWeek);
+            return weekStart.isAfter(toMonday(LocalDate.now()));
+        } catch (RuntimeException ex) {
+            return true;
+        }
+    }
+
+    private LocalDate parseIsoWeekStart(String isoWeek) {
+        if (isoWeek == null || !isoWeek.matches("\\d{4}-W\\d{2}")) {
+            throw new IllegalArgumentException("Invalid ISO week.");
+        }
+        String[] parts = isoWeek.split("-W");
+        int year = Integer.parseInt(parts[0]);
+        int week = Integer.parseInt(parts[1]);
+        return LocalDate.of(year, 1, 4)
+            .with(ISO.weekOfWeekBasedYear(), week)
+            .with(ISO.dayOfWeek(), 1);
+    }
+
+    private LocalDate toMonday(LocalDate date) {
+        return date.with(DayOfWeek.MONDAY);
+    }
+
+    private String toIsoWeek(LocalDate date) {
+        int weekYear = date.get(ISO.weekBasedYear());
+        int weekNumber = date.get(ISO.weekOfWeekBasedYear());
+        return "%d-W%02d".formatted(weekYear, weekNumber);
+    }
+
+    private String formatWeekLabel(String isoWeek) {
+        String[] parts = isoWeek.split("-W");
+        return "Week " + Integer.parseInt(parts[1]) + " (" + parts[0] + ")";
+    }
+
+    private ActivityDetail toDetail(Activity activity) {
+        return new ActivityDetail(
+            activity.getActivityId(),
+            activity.getWeek(),
+            activity.getCategory(),
+            activity.getPlannedActivity(),
+            activity.getDescription(),
+            activity.getPlannedHours(),
+            activity.getActualHours(),
+            activity.getStatus()
+        );
+    }
+
+    private boolean isStudent(User user) {
+        String roles = user.getRoles() == null ? "" : user.getRoles().toLowerCase(Locale.ROOT);
+        return List.of(roles.split("\\s+")).contains("student");
+    }
+
+    private record StudentContext(User student, Section section, Team team, List<ActivityWeekOption> availableWeeks) {
+    }
+}

--- a/src/backend/src/main/java/team/projectpulse/team/repository/TeamRepository.java
+++ b/src/backend/src/main/java/team/projectpulse/team/repository/TeamRepository.java
@@ -63,4 +63,12 @@ public interface TeamRepository extends JpaRepository<Team, Long> {
         order by lower(t.teamName)
         """)
     List<Team> findAllBySectionIdWithInstructorsOrdered(@Param("sectionId") Long sectionId);
+
+    @Query("""
+        select distinct t from Team t
+        join fetch t.section s
+        join t.students st
+        where st.id = :studentId
+        """)
+    Optional<Team> findByStudentIdWithSection(@Param("studentId") Long studentId);
 }

--- a/src/backend/src/main/resources/db/migration/V7__activities.sql
+++ b/src/backend/src/main/resources/db/migration/V7__activities.sql
@@ -1,0 +1,24 @@
+-- V7: Weekly activity report activities
+
+CREATE TABLE IF NOT EXISTS activities (
+    activity_id       BIGINT AUTO_INCREMENT PRIMARY KEY,
+    team_id           BIGINT         NOT NULL,
+    student_id        BIGINT         NOT NULL,
+    week              VARCHAR(20)    NOT NULL,
+    category          VARCHAR(50)    NOT NULL,
+    planned_activity  VARCHAR(255)   NOT NULL,
+    description       TEXT           NOT NULL,
+    planned_hours     DECIMAL(6,2)   NOT NULL,
+    actual_hours      DECIMAL(6,2)   NOT NULL,
+    status            VARCHAR(30)    NOT NULL,
+    created_at        TIMESTAMP      NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at        TIMESTAMP      NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    CONSTRAINT fk_activities_team
+        FOREIGN KEY (team_id) REFERENCES teams(team_id) ON DELETE CASCADE,
+    CONSTRAINT fk_activities_student
+        FOREIGN KEY (student_id) REFERENCES users(id) ON DELETE CASCADE
+);
+
+CREATE INDEX idx_activities_student_week ON activities (student_id, week);
+CREATE INDEX idx_activities_team_week ON activities (team_id, week);
+CREATE INDEX idx_activities_team_week_student ON activities (team_id, week, student_id);

--- a/src/backend/src/test/java/team/projectpulse/activity/controller/ActivityControllerIntegrationTest.java
+++ b/src/backend/src/test/java/team/projectpulse/activity/controller/ActivityControllerIntegrationTest.java
@@ -1,0 +1,210 @@
+package team.projectpulse.activity.controller;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import team.projectpulse.activity.domain.ActivityCategory;
+import team.projectpulse.activity.domain.ActivityNotFoundException;
+import team.projectpulse.activity.domain.ActivityStatus;
+import team.projectpulse.activity.domain.InvalidActivityException;
+import team.projectpulse.activity.dto.ActivityDetail;
+import team.projectpulse.activity.dto.ActivityWeekOption;
+import team.projectpulse.activity.dto.ActivityWorkspace;
+import team.projectpulse.activity.service.ActivityService;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class ActivityControllerIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private ActivityService activityService;
+
+    @Test
+    @WithMockUser(username = "ava@tcu.edu", roles = "STUDENT")
+    void should_LoadWorkspace_When_StudentRequestsIt() throws Exception {
+        when(activityService.loadWorkspace("ava@tcu.edu", "2026-W16")).thenReturn(buildWorkspace());
+
+        mockMvc.perform(get("/api/v1/activities/workspace").param("week", "2026-W16"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.flag").value(true))
+            .andExpect(jsonPath("$.data.sectionName").value("Spring 2026 - Section A"))
+            .andExpect(jsonPath("$.data.teamName").value("Pulse Analytics"))
+            .andExpect(jsonPath("$.data.activities[0].plannedActivity").value("Implement endpoint"));
+
+        verify(activityService).loadWorkspace("ava@tcu.edu", "2026-W16");
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void should_ReturnForbidden_When_AdminLoadsWorkspace() throws Exception {
+        mockMvc.perform(get("/api/v1/activities/workspace"))
+            .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @WithMockUser(roles = "INSTRUCTOR")
+    void should_ReturnForbidden_When_InstructorLoadsWorkspace() throws Exception {
+        mockMvc.perform(get("/api/v1/activities/workspace"))
+            .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void should_ReturnUnauthorized_When_UnauthenticatedUserLoadsWorkspace() throws Exception {
+        mockMvc.perform(get("/api/v1/activities/workspace"))
+            .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @WithMockUser(username = "ava@tcu.edu", roles = "STUDENT")
+    void should_CreateActivity_When_StudentSubmitsValidPayload() throws Exception {
+        when(activityService.createActivity(any(), any())).thenReturn(buildActivityDetail());
+
+        mockMvc.perform(post("/api/v1/activities")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                    {
+                      "week": "2026-W16",
+                      "category": "DEVELOPMENT",
+                      "plannedActivity": "Implement endpoint",
+                      "description": "Built the WAR workspace endpoint",
+                      "plannedHours": 4.5,
+                      "actualHours": 5.0,
+                      "status": "DONE"
+                    }
+                    """))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.flag").value(true))
+            .andExpect(jsonPath("$.message").value("WAR has been updated."))
+            .andExpect(jsonPath("$.data.activityId").value(1));
+    }
+
+    @Test
+    @WithMockUser(username = "ava@tcu.edu", roles = "STUDENT")
+    void should_UpdateActivity_When_StudentConfirmsChanges() throws Exception {
+        when(activityService.updateActivity(any(), any(), any())).thenReturn(buildActivityDetail());
+
+        mockMvc.perform(put("/api/v1/activities/1")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                    {
+                      "category": "TESTING",
+                      "plannedActivity": "Validate forms",
+                      "description": "Updated frontend validation rules",
+                      "plannedHours": 2.0,
+                      "actualHours": 2.5,
+                      "status": "UNDER_TESTING"
+                    }
+                    """))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.flag").value(true))
+            .andExpect(jsonPath("$.message").value("WAR has been updated."));
+    }
+
+    @Test
+    @WithMockUser(username = "ava@tcu.edu", roles = "STUDENT")
+    void should_DeleteActivity_When_StudentConfirmsDeletion() throws Exception {
+        mockMvc.perform(delete("/api/v1/activities/1"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.flag").value(true))
+            .andExpect(jsonPath("$.message").value("WAR has been updated."));
+    }
+
+    @Test
+    @WithMockUser(username = "ava@tcu.edu", roles = "STUDENT")
+    void should_ReturnBadRequest_When_ActivityPayloadIsInvalid() throws Exception {
+        when(activityService.createActivity(any(), any()))
+            .thenThrow(new InvalidActivityException("Future weeks cannot be selected."));
+
+        mockMvc.perform(post("/api/v1/activities")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                    {
+                      "week": "2026-W99",
+                      "category": "DEVELOPMENT",
+                      "plannedActivity": "Implement endpoint",
+                      "description": "Built the WAR workspace endpoint",
+                      "plannedHours": 4.5,
+                      "actualHours": 5.0,
+                      "status": "DONE"
+                    }
+                    """))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.flag").value(false))
+            .andExpect(jsonPath("$.code").value(400))
+            .andExpect(jsonPath("$.message").value("Future weeks cannot be selected."));
+    }
+
+    @Test
+    @WithMockUser(username = "ava@tcu.edu", roles = "STUDENT")
+    void should_ReturnNotFound_When_ActivityDoesNotExist() throws Exception {
+        when(activityService.updateActivity(any(), any(), any()))
+            .thenThrow(new ActivityNotFoundException(99L));
+
+        mockMvc.perform(put("/api/v1/activities/99")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                    {
+                      "category": "TESTING",
+                      "plannedActivity": "Validate forms",
+                      "description": "Updated frontend validation rules",
+                      "plannedHours": 2.0,
+                      "actualHours": 2.5,
+                      "status": "UNDER_TESTING"
+                    }
+                    """))
+            .andExpect(status().isNotFound())
+            .andExpect(jsonPath("$.flag").value(false))
+            .andExpect(jsonPath("$.code").value(404))
+            .andExpect(jsonPath("$.message").value("No activity found with id: 99"));
+    }
+
+    private ActivityWorkspace buildWorkspace() {
+        return new ActivityWorkspace(
+            1L,
+            "Spring 2026 - Section A",
+            2001L,
+            "Pulse Analytics",
+            "2026-W16",
+            List.of(new ActivityWeekOption("2026-W16", "Week 16 (2026)", true)),
+            List.of(buildActivityDetail()),
+            true,
+            null
+        );
+    }
+
+    private ActivityDetail buildActivityDetail() {
+        return new ActivityDetail(
+            1L,
+            "2026-W16",
+            ActivityCategory.DEVELOPMENT,
+            "Implement endpoint",
+            "Built the WAR workspace endpoint",
+            new BigDecimal("4.50"),
+            new BigDecimal("5.00"),
+            ActivityStatus.DONE
+        );
+    }
+}

--- a/src/backend/src/test/java/team/projectpulse/activity/repository/ActivityRepositoryIntegrationTest.java
+++ b/src/backend/src/test/java/team/projectpulse/activity/repository/ActivityRepositoryIntegrationTest.java
@@ -1,0 +1,119 @@
+package team.projectpulse.activity.repository;
+
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import org.springframework.test.context.ActiveProfiles;
+import team.projectpulse.activity.domain.Activity;
+import team.projectpulse.activity.domain.ActivityCategory;
+import team.projectpulse.activity.domain.ActivityStatus;
+import team.projectpulse.section.domain.Section;
+import team.projectpulse.team.domain.Team;
+import team.projectpulse.user.domain.User;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@DataJpaTest
+@ActiveProfiles("test")
+class ActivityRepositoryIntegrationTest {
+
+    @Autowired
+    private EntityManager entityManager;
+
+    @Autowired
+    private ActivityRepository activityRepository;
+
+    @Test
+    void should_ReturnOnlyCurrentStudentsActivitiesForWeek_When_QueryingByStudentAndWeek() {
+        SeededData data = seedActivities();
+
+        List<Activity> activities = activityRepository.findAllByStudentIdAndWeekOrderByActivityIdAsc(
+            data.ava().getId(),
+            "2026-W16"
+        );
+
+        assertEquals(List.of("Implement endpoint", "Write tests"), activities.stream()
+            .map(Activity::getPlannedActivity)
+            .toList());
+    }
+
+    @Test
+    void should_EnforceOwnership_When_FindingActivityByIdAndStudentId() {
+        SeededData data = seedActivities();
+
+        Optional<Activity> ownedActivity = activityRepository.findByActivityIdAndStudentId(
+            data.firstAvaActivity().getActivityId(),
+            data.ava().getId()
+        );
+        Optional<Activity> foreignActivity = activityRepository.findByActivityIdAndStudentId(
+            data.ethanActivity().getActivityId(),
+            data.ava().getId()
+        );
+
+        assertTrue(ownedActivity.isPresent());
+        assertTrue(foreignActivity.isEmpty());
+    }
+
+    private SeededData seedActivities() {
+        Section section = new Section();
+        section.setSectionName("Spring 2026 - Section A");
+        section.setStartDate(LocalDate.of(2026, 1, 12));
+        section.setEndDate(LocalDate.of(2026, 5, 8));
+        entityManager.persist(section);
+
+        User ava = persistUser("Ava", "Johnson", "ava.activity@tcu.edu");
+        User ethan = persistUser("Ethan", "Wright", "ethan.activity@tcu.edu");
+
+        Team team = new Team();
+        team.setSection(section);
+        team.setTeamName("Pulse Analytics");
+        entityManager.persist(team);
+
+        Activity firstAva = persistActivity(team, ava, "2026-W16", "Implement endpoint");
+        Activity secondAva = persistActivity(team, ava, "2026-W16", "Write tests");
+        Activity ethanActivity = persistActivity(team, ethan, "2026-W16", "Review PR");
+        persistActivity(team, ava, "2026-W15", "Older week");
+
+        entityManager.flush();
+        entityManager.clear();
+
+        return new SeededData(ava, firstAva, ethanActivity);
+    }
+
+    private User persistUser(String firstName, String lastName, String email) {
+        User user = new User();
+        user.setFirstName(firstName);
+        user.setLastName(lastName);
+        user.setEmail(email);
+        user.setPassword("encoded");
+        user.setRoles("student");
+        user.setEnabled(true);
+        entityManager.persist(user);
+        return user;
+    }
+
+    private Activity persistActivity(Team team, User student, String week, String plannedActivity) {
+        Activity activity = new Activity();
+        activity.setTeam(team);
+        activity.setStudent(student);
+        activity.setWeek(week);
+        activity.setCategory(ActivityCategory.DEVELOPMENT);
+        activity.setPlannedActivity(plannedActivity);
+        activity.setDescription(plannedActivity + " description");
+        activity.setPlannedHours(new BigDecimal("2.00"));
+        activity.setActualHours(new BigDecimal("3.00"));
+        activity.setStatus(ActivityStatus.DONE);
+        entityManager.persist(activity);
+        return activity;
+    }
+
+    private record SeededData(User ava, Activity firstAvaActivity, Activity ethanActivity) {
+    }
+}

--- a/src/backend/src/test/java/team/projectpulse/activity/service/ActivityServiceTest.java
+++ b/src/backend/src/test/java/team/projectpulse/activity/service/ActivityServiceTest.java
@@ -1,0 +1,381 @@
+package team.projectpulse.activity.service;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import team.projectpulse.activity.domain.Activity;
+import team.projectpulse.activity.domain.ActivityCategory;
+import team.projectpulse.activity.domain.ActivityNotFoundException;
+import team.projectpulse.activity.domain.ActivityStatus;
+import team.projectpulse.activity.domain.InvalidActivityException;
+import team.projectpulse.activity.dto.ActivityWorkspace;
+import team.projectpulse.activity.dto.CreateActivityRequest;
+import team.projectpulse.activity.dto.UpdateActivityRequest;
+import team.projectpulse.activity.repository.ActivityRepository;
+import team.projectpulse.section.domain.Section;
+import team.projectpulse.team.domain.Team;
+import team.projectpulse.team.repository.TeamRepository;
+import team.projectpulse.user.domain.User;
+import team.projectpulse.user.repository.UserRepository;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.temporal.WeekFields;
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ActivityServiceTest {
+
+    @Mock
+    private ActivityRepository activityRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private TeamRepository teamRepository;
+
+    @InjectMocks
+    private ActivityService service;
+
+    @Test
+    void should_LoadWorkspaceForStudent_When_ContextExists() {
+        Section section = buildSection(LocalDate.now().minusWeeks(2), LocalDate.now().plusWeeks(2), List.of(currentIsoWeek()));
+        User student = buildStudent(100L, section);
+        Team team = buildTeam(2001L, "Pulse Analytics", section);
+        Activity activity = buildActivity(1L, team, student, currentIsoWeek());
+
+        when(userRepository.findByEmail("ava@tcu.edu")).thenReturn(Optional.of(student));
+        when(teamRepository.findByStudentIdWithSection(100L)).thenReturn(Optional.of(team));
+        when(activityRepository.findAllByStudentIdAndWeekOrderByActivityIdAsc(100L, currentIsoWeek()))
+            .thenReturn(List.of(activity));
+
+        ActivityWorkspace workspace = service.loadWorkspace("ava@tcu.edu", currentIsoWeek());
+
+        assertTrue(workspace.canManageActivities());
+        assertEquals("Spring 2026 - Section A", workspace.sectionName());
+        assertEquals("Pulse Analytics", workspace.teamName());
+        assertEquals(currentIsoWeek(), workspace.selectedWeek());
+        assertEquals(1, workspace.activities().size());
+        assertTrue(workspace.availableWeeks().stream().anyMatch(option -> option.activeWeek()));
+    }
+
+    @Test
+    void should_DefaultToLatestEligibleWeek_When_RequestWeekMissing() {
+        Section section = buildSection(LocalDate.now().minusWeeks(3), LocalDate.now().plusWeeks(2), List.of(previousIsoWeek()));
+        User student = buildStudent(100L, section);
+        Team team = buildTeam(2001L, "Pulse Analytics", section);
+
+        when(userRepository.findByEmail("ava@tcu.edu")).thenReturn(Optional.of(student));
+        when(teamRepository.findByStudentIdWithSection(100L)).thenReturn(Optional.of(team));
+        when(activityRepository.findAllByStudentIdAndWeekOrderByActivityIdAsc(100L, currentIsoWeek()))
+            .thenReturn(List.of());
+
+        ActivityWorkspace workspace = service.loadWorkspace("ava@tcu.edu", null);
+
+        assertEquals(currentIsoWeek(), workspace.selectedWeek());
+    }
+
+    @Test
+    void should_ReturnDisabledWorkspace_When_StudentHasNoSection() {
+        User student = buildStudent(100L, null);
+
+        when(userRepository.findByEmail("ava@tcu.edu")).thenReturn(Optional.of(student));
+
+        ActivityWorkspace workspace = service.loadWorkspace("ava@tcu.edu", null);
+
+        assertFalse(workspace.canManageActivities());
+        assertEquals("You must belong to a senior design section before managing WAR activities.", workspace.availabilityMessage());
+    }
+
+    @Test
+    void should_ReturnDisabledWorkspace_When_StudentHasNoTeam() {
+        Section section = buildSection(LocalDate.now().minusWeeks(1), LocalDate.now().plusWeeks(1), List.of(currentIsoWeek()));
+        User student = buildStudent(100L, section);
+
+        when(userRepository.findByEmail("ava@tcu.edu")).thenReturn(Optional.of(student));
+        when(teamRepository.findByStudentIdWithSection(100L)).thenReturn(Optional.empty());
+
+        ActivityWorkspace workspace = service.loadWorkspace("ava@tcu.edu", null);
+
+        assertFalse(workspace.canManageActivities());
+        assertEquals("You must be assigned to a senior design team before managing WAR activities.", workspace.availabilityMessage());
+    }
+
+    @Test
+    void should_ReturnDisabledWorkspace_When_NoEligibleWeeksExist() {
+        Section section = buildSection(LocalDate.now().plusWeeks(1), LocalDate.now().plusWeeks(2), List.of());
+        User student = buildStudent(100L, section);
+        Team team = buildTeam(2001L, "Pulse Analytics", section);
+
+        when(userRepository.findByEmail("ava@tcu.edu")).thenReturn(Optional.of(student));
+        when(teamRepository.findByStudentIdWithSection(100L)).thenReturn(Optional.of(team));
+
+        ActivityWorkspace workspace = service.loadWorkspace("ava@tcu.edu", null);
+
+        assertFalse(workspace.canManageActivities());
+        assertEquals("No eligible weeks are available yet.", workspace.availabilityMessage());
+    }
+
+    @Test
+    void should_CreateActivity_When_RequestIsValid() {
+        Section section = buildSection(LocalDate.now().minusWeeks(2), LocalDate.now().plusWeeks(1), List.of(currentIsoWeek()));
+        User student = buildStudent(100L, section);
+        Team team = buildTeam(2001L, "Pulse Analytics", section);
+        Activity saved = buildActivity(1L, team, student, currentIsoWeek());
+
+        when(userRepository.findByEmail("ava@tcu.edu")).thenReturn(Optional.of(student));
+        when(teamRepository.findByStudentIdWithSection(100L)).thenReturn(Optional.of(team));
+        when(activityRepository.save(any(Activity.class))).thenReturn(saved);
+
+        var result = service.createActivity("ava@tcu.edu", new CreateActivityRequest(
+            currentIsoWeek(),
+            ActivityCategory.DEVELOPMENT,
+            "Implement endpoint",
+            "Built the WAR workspace endpoint",
+            new BigDecimal("4.50"),
+            new BigDecimal("5.00"),
+            ActivityStatus.DONE
+        ));
+
+        assertEquals(1L, result.activityId());
+        assertEquals("Implement endpoint", result.plannedActivity());
+        verify(activityRepository).save(any(Activity.class));
+    }
+
+    @Test
+    void should_UpdateActivity_When_RequestIsValid() {
+        Section section = buildSection(LocalDate.now().minusWeeks(2), LocalDate.now().plusWeeks(1), List.of(currentIsoWeek()));
+        User student = buildStudent(100L, section);
+        Team team = buildTeam(2001L, "Pulse Analytics", section);
+        Activity existing = buildActivity(1L, team, student, currentIsoWeek());
+
+        when(userRepository.findByEmail("ava@tcu.edu")).thenReturn(Optional.of(student));
+        when(teamRepository.findByStudentIdWithSection(100L)).thenReturn(Optional.of(team));
+        when(activityRepository.findByActivityIdAndStudentId(1L, 100L)).thenReturn(Optional.of(existing));
+        when(activityRepository.save(existing)).thenReturn(existing);
+
+        var result = service.updateActivity("ava@tcu.edu", 1L, new UpdateActivityRequest(
+            ActivityCategory.TESTING,
+            "Validate forms",
+            "Updated frontend validation rules",
+            new BigDecimal("2.00"),
+            new BigDecimal("2.50"),
+            ActivityStatus.UNDER_TESTING
+        ));
+
+        assertEquals(ActivityCategory.TESTING, result.category());
+        assertEquals("Validate forms", existing.getPlannedActivity());
+    }
+
+    @Test
+    void should_DeleteActivity_When_StudentOwnsActivity() {
+        Section section = buildSection(LocalDate.now().minusWeeks(2), LocalDate.now().plusWeeks(1), List.of(currentIsoWeek()));
+        User student = buildStudent(100L, section);
+        Team team = buildTeam(2001L, "Pulse Analytics", section);
+        Activity existing = buildActivity(1L, team, student, currentIsoWeek());
+
+        when(userRepository.findByEmail("ava@tcu.edu")).thenReturn(Optional.of(student));
+        when(teamRepository.findByStudentIdWithSection(100L)).thenReturn(Optional.of(team));
+        when(activityRepository.findByActivityIdAndStudentId(1L, 100L)).thenReturn(Optional.of(existing));
+
+        service.deleteActivity("ava@tcu.edu", 1L);
+
+        verify(activityRepository).delete(existing);
+    }
+
+    @Test
+    void should_ThrowInvalidActivity_When_CreateWeekIsFuture() {
+        Section section = buildSection(LocalDate.now().minusWeeks(1), LocalDate.now().plusWeeks(3), List.of());
+        User student = buildStudent(100L, section);
+        Team team = buildTeam(2001L, "Pulse Analytics", section);
+
+        when(userRepository.findByEmail("ava@tcu.edu")).thenReturn(Optional.of(student));
+        when(teamRepository.findByStudentIdWithSection(100L)).thenReturn(Optional.of(team));
+
+        InvalidActivityException ex = assertThrows(
+            InvalidActivityException.class,
+            () -> service.createActivity("ava@tcu.edu", new CreateActivityRequest(
+                futureIsoWeek(),
+                ActivityCategory.DEVELOPMENT,
+                "Implement endpoint",
+                "Future work",
+                BigDecimal.ONE,
+                BigDecimal.ONE,
+                ActivityStatus.IN_PROGRESS
+            ))
+        );
+
+        assertEquals("Future weeks cannot be selected.", ex.getMessage());
+    }
+
+    @Test
+    void should_ThrowInvalidActivity_When_CreateWeekIsOutsideAllowedTimeline() {
+        Section section = buildSection(LocalDate.now().minusWeeks(1), LocalDate.now().plusWeeks(1), List.of());
+        User student = buildStudent(100L, section);
+        Team team = buildTeam(2001L, "Pulse Analytics", section);
+
+        when(userRepository.findByEmail("ava@tcu.edu")).thenReturn(Optional.of(student));
+        when(teamRepository.findByStudentIdWithSection(100L)).thenReturn(Optional.of(team));
+
+        InvalidActivityException ex = assertThrows(
+            InvalidActivityException.class,
+            () -> service.createActivity("ava@tcu.edu", new CreateActivityRequest(
+                "2020-W01",
+                ActivityCategory.DEVELOPMENT,
+                "Implement endpoint",
+                "Outside timeline",
+                BigDecimal.ONE,
+                BigDecimal.ONE,
+                ActivityStatus.IN_PROGRESS
+            ))
+        );
+
+        assertEquals("Selected week is not eligible for WAR activity management.", ex.getMessage());
+    }
+
+    @Test
+    void should_ThrowInvalidActivity_When_RequiredFieldsMissing() {
+        Section section = buildSection(LocalDate.now().minusWeeks(1), LocalDate.now().plusWeeks(1), List.of(currentIsoWeek()));
+        User student = buildStudent(100L, section);
+        Team team = buildTeam(2001L, "Pulse Analytics", section);
+
+        when(userRepository.findByEmail("ava@tcu.edu")).thenReturn(Optional.of(student));
+        when(teamRepository.findByStudentIdWithSection(100L)).thenReturn(Optional.of(team));
+
+        InvalidActivityException ex = assertThrows(
+            InvalidActivityException.class,
+            () -> service.createActivity("ava@tcu.edu", new CreateActivityRequest(
+                currentIsoWeek(),
+                null,
+                "",
+                "",
+                null,
+                null,
+                null
+            ))
+        );
+
+        assertEquals("Activity category is required.", ex.getMessage());
+    }
+
+    @Test
+    void should_ThrowInvalidActivity_When_HoursAreNegative() {
+        Section section = buildSection(LocalDate.now().minusWeeks(1), LocalDate.now().plusWeeks(1), List.of(currentIsoWeek()));
+        User student = buildStudent(100L, section);
+        Team team = buildTeam(2001L, "Pulse Analytics", section);
+
+        when(userRepository.findByEmail("ava@tcu.edu")).thenReturn(Optional.of(student));
+        when(teamRepository.findByStudentIdWithSection(100L)).thenReturn(Optional.of(team));
+
+        InvalidActivityException ex = assertThrows(
+            InvalidActivityException.class,
+            () -> service.createActivity("ava@tcu.edu", new CreateActivityRequest(
+                currentIsoWeek(),
+                ActivityCategory.DEVELOPMENT,
+                "Implement endpoint",
+                "Negative hours",
+                new BigDecimal("-1.00"),
+                BigDecimal.ONE,
+                ActivityStatus.IN_PROGRESS
+            ))
+        );
+
+        assertEquals("Planned hours must be zero or greater.", ex.getMessage());
+    }
+
+    @Test
+    void should_ThrowNotFound_When_UpdatingAnotherStudentsActivity() {
+        Section section = buildSection(LocalDate.now().minusWeeks(1), LocalDate.now().plusWeeks(1), List.of(currentIsoWeek()));
+        User student = buildStudent(100L, section);
+        Team team = buildTeam(2001L, "Pulse Analytics", section);
+
+        when(userRepository.findByEmail("ava@tcu.edu")).thenReturn(Optional.of(student));
+        when(teamRepository.findByStudentIdWithSection(100L)).thenReturn(Optional.of(team));
+        when(activityRepository.findByActivityIdAndStudentId(99L, 100L)).thenReturn(Optional.empty());
+
+        assertThrows(
+            ActivityNotFoundException.class,
+            () -> service.updateActivity("ava@tcu.edu", 99L, new UpdateActivityRequest(
+                ActivityCategory.DEVELOPMENT,
+                "Implement endpoint",
+                "No access",
+                BigDecimal.ONE,
+                BigDecimal.ONE,
+                ActivityStatus.IN_PROGRESS
+            ))
+        );
+    }
+
+    private Section buildSection(LocalDate startDate, LocalDate endDate, List<String> activeWeeks) {
+        Section section = new Section();
+        section.setSectionId(1L);
+        section.setSectionName("Spring 2026 - Section A");
+        section.setStartDate(startDate);
+        section.setEndDate(endDate);
+        section.setActiveWeeks(activeWeeks);
+        return section;
+    }
+
+    private User buildStudent(Long id, Section section) {
+        User user = new User();
+        user.setId(id);
+        user.setFirstName("Ava");
+        user.setLastName("Johnson");
+        user.setEmail("ava@tcu.edu");
+        user.setRoles("student");
+        user.setEnabled(true);
+        user.setSection(section);
+        return user;
+    }
+
+    private Team buildTeam(Long id, String name, Section section) {
+        Team team = new Team();
+        team.setTeamId(id);
+        team.setTeamName(name);
+        team.setSection(section);
+        return team;
+    }
+
+    private Activity buildActivity(Long id, Team team, User student, String week) {
+        Activity activity = new Activity();
+        activity.setActivityId(id);
+        activity.setTeam(team);
+        activity.setStudent(student);
+        activity.setWeek(week);
+        activity.setCategory(ActivityCategory.DEVELOPMENT);
+        activity.setPlannedActivity("Implement endpoint");
+        activity.setDescription("Built the WAR workspace endpoint");
+        activity.setPlannedHours(new BigDecimal("4.50"));
+        activity.setActualHours(new BigDecimal("5.00"));
+        activity.setStatus(ActivityStatus.DONE);
+        return activity;
+    }
+
+    private String currentIsoWeek() {
+        LocalDate now = LocalDate.now();
+        return "%d-W%02d".formatted(now.get(WeekFields.ISO.weekBasedYear()), now.get(WeekFields.ISO.weekOfWeekBasedYear()));
+    }
+
+    private String previousIsoWeek() {
+        LocalDate previous = LocalDate.now().minusWeeks(1);
+        return "%d-W%02d".formatted(previous.get(WeekFields.ISO.weekBasedYear()), previous.get(WeekFields.ISO.weekOfWeekBasedYear()));
+    }
+
+    private String futureIsoWeek() {
+        LocalDate future = LocalDate.now().plusWeeks(1);
+        return "%d-W%02d".formatted(future.get(WeekFields.ISO.weekBasedYear()), future.get(WeekFields.ISO.weekOfWeekBasedYear()));
+    }
+}

--- a/src/backend/src/test/java/team/projectpulse/team/repository/TeamRepositoryIntegrationTest.java
+++ b/src/backend/src/test/java/team/projectpulse/team/repository/TeamRepositoryIntegrationTest.java
@@ -145,6 +145,17 @@ class TeamRepositoryIntegrationTest {
         assertEquals(List.of("Noah"), teams.get(1).getInstructors().stream().map(User::getFirstName).toList());
     }
 
+    @Test
+    void should_ReturnAssignedTeamWithSection_When_FindingByStudentId() {
+        SeededData data = seedTeams();
+
+        Optional<Team> teamOptional = teamRepository.findByStudentIdWithSection(data.liamId());
+
+        assertTrue(teamOptional.isPresent());
+        assertEquals("Pulse Analytics", teamOptional.get().getTeamName());
+        assertEquals("Spring 2026 - Section A", teamOptional.get().getSection().getSectionName());
+    }
+
     private SeededData seedTeams() {
         Section sectionA = new Section();
         sectionA.setSectionName("Spring 2026 - Section A");
@@ -173,7 +184,7 @@ class TeamRepositoryIntegrationTest {
         entityManager.flush();
         entityManager.clear();
 
-        return new SeededData(sectionA.getSectionId(), "Review Board", "Pulse Analytics", "Gamma Studio", pulse.getTeamId(), review.getTeamId());
+        return new SeededData(sectionA.getSectionId(), "Review Board", "Pulse Analytics", "Gamma Studio", pulse.getTeamId(), review.getTeamId(), liam.getId());
     }
 
     private User persistUser(String firstName, String lastName, String email, String roles) {
@@ -200,5 +211,13 @@ class TeamRepositoryIntegrationTest {
         return team;
     }
 
-    private record SeededData(Long sectionAId, String teamBravo, String teamAlpha, String teamGamma, Long pulseAnalyticsId, Long reviewBoardId) {}
+    private record SeededData(
+        Long sectionAId,
+        String teamBravo,
+        String teamAlpha,
+        String teamGamma,
+        Long pulseAnalyticsId,
+        Long reviewBoardId,
+        Long liamId
+    ) {}
 }

--- a/src/frontend/src/features/activity/pages/WarActivities.vue
+++ b/src/frontend/src/features/activity/pages/WarActivities.vue
@@ -1,0 +1,623 @@
+<template>
+  <v-container>
+    <v-row class="mb-4" align="center">
+      <v-col>
+        <h2 class="text-h5 font-weight-bold">Weekly Activity Report</h2>
+        <div class="text-body-2 text-medium-emphasis">
+          Manage your weekly activities, review changes, then confirm updates to your WAR.
+        </div>
+      </v-col>
+      <v-col cols="auto">
+        <v-btn
+          color="primary"
+          prepend-icon="mdi-plus"
+          :disabled="!workspace?.canManageActivities || !workspace?.selectedWeek"
+          @click="openCreateDialog"
+        >
+          Add Activity
+        </v-btn>
+      </v-col>
+    </v-row>
+
+    <v-card variant="outlined" class="mb-4">
+      <v-card-text class="pa-4">
+        <v-row align="center">
+          <v-col cols="12" md="4">
+            <v-select
+              v-model="selectedWeek"
+              :items="workspace?.availableWeeks ?? []"
+              item-title="label"
+              item-value="week"
+              label="Week"
+              :loading="loading"
+              :disabled="loading || !(workspace?.availableWeeks.length)"
+              @update:model-value="handleWeekChange"
+            />
+          </v-col>
+          <v-col cols="12" md="8" class="d-flex flex-wrap justify-md-end ga-2">
+            <v-chip v-if="workspace?.sectionName" color="primary" variant="tonal">{{ workspace.sectionName }}</v-chip>
+            <v-chip v-if="workspace?.teamName" color="secondary" variant="tonal">{{ workspace.teamName }}</v-chip>
+            <v-chip v-if="selectedWeekOption" :color="selectedWeekOption.activeWeek ? 'success' : 'warning'" variant="tonal">
+              {{ selectedWeekOption.activeWeek ? 'Active Week' : 'Inactive Week' }}
+            </v-chip>
+            <v-chip v-if="selectedWeek" variant="outlined">{{ getIsoWeekRangeLabel(selectedWeek) }}</v-chip>
+          </v-col>
+        </v-row>
+
+        <v-alert v-if="workspace?.availabilityMessage" type="info" variant="tonal" class="mt-2">
+          {{ workspace.availabilityMessage }}
+        </v-alert>
+      </v-card-text>
+    </v-card>
+
+    <v-row v-if="loading">
+      <v-col class="text-center">
+        <v-progress-circular indeterminate />
+      </v-col>
+    </v-row>
+
+    <template v-else-if="workspace">
+      <v-card variant="outlined">
+        <v-card-title class="pa-4 pb-2 d-flex align-center">
+          <span>My Activities</span>
+          <v-spacer />
+          <v-chip v-if="selectedWeek" variant="tonal" color="primary">
+            {{ selectedWeekLabel }}
+          </v-chip>
+        </v-card-title>
+        <v-card-text>
+          <v-alert v-if="workspace.activities.length === 0" type="info" variant="tonal">
+            No activities added for this week yet.
+          </v-alert>
+
+          <v-table v-else density="compact">
+            <thead>
+              <tr>
+                <th>Category</th>
+                <th>Planned Activity</th>
+                <th>Description</th>
+                <th>Planned Hours</th>
+                <th>Actual Hours</th>
+                <th>Status</th>
+                <th class="text-right">Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr v-for="activity in workspace.activities" :key="activity.activityId">
+                <td>
+                  <v-chip
+                    size="small"
+                    variant="tonal"
+                    :color="categoryChipColor(activity.category)"
+                  >
+                    {{ formatCategory(activity.category) }}
+                  </v-chip>
+                </td>
+                <td>{{ activity.plannedActivity }}</td>
+                <td class="description-cell">{{ activity.description }}</td>
+                <td>{{ formatHours(activity.plannedHours) }}</td>
+                <td>{{ formatHours(activity.actualHours) }}</td>
+                <td>
+                  <v-chip
+                    size="small"
+                    variant="tonal"
+                    :color="statusChipColor(activity.status)"
+                  >
+                    {{ formatStatus(activity.status) }}
+                  </v-chip>
+                </td>
+                <td class="text-right">
+                  <v-btn size="small" variant="text" color="primary" @click="openEditDialog(activity)">Edit</v-btn>
+                  <v-btn size="small" variant="text" color="error" @click="openDeleteDialog(activity)">Delete</v-btn>
+                </td>
+              </tr>
+            </tbody>
+          </v-table>
+        </v-card-text>
+      </v-card>
+    </template>
+
+    <v-dialog v-model="formDialog" max-width="760" persistent>
+      <v-card>
+        <v-card-title class="pa-4">
+          {{ formMode === 'create' ? (formStep === 1 ? 'Add Activity' : 'Confirm Activity') : (formStep === 1 ? 'Edit Activity' : 'Confirm Activity Change') }}
+        </v-card-title>
+        <v-divider />
+
+        <v-card-text v-if="formStep === 1" class="pa-4">
+          <v-alert type="info" variant="tonal" class="mb-4">
+            {{ selectedWeek ? `Selected week: ${selectedWeekLabel}` : 'Select a week before managing activities.' }}
+          </v-alert>
+
+          <v-select
+            v-model="activityForm.category"
+            :items="categoryOptions"
+            item-title="label"
+            item-value="value"
+            label="Activity Category"
+            :error-messages="formErrors.category"
+            class="mb-4"
+          />
+
+          <v-text-field
+            v-model="activityForm.plannedActivity"
+            label="Planned Activity"
+            :error-messages="formErrors.plannedActivity"
+            class="mb-4"
+          />
+
+          <v-textarea
+            v-model="activityForm.description"
+            label="Activity Description"
+            rows="4"
+            :error-messages="formErrors.description"
+            class="mb-4"
+          />
+
+          <v-row>
+            <v-col cols="12" md="6">
+              <v-text-field
+                v-model="activityForm.plannedHours"
+                label="Planned Hours"
+                type="number"
+                min="0"
+                step="0.25"
+                :error-messages="formErrors.plannedHours"
+              />
+            </v-col>
+            <v-col cols="12" md="6">
+              <v-text-field
+                v-model="activityForm.actualHours"
+                label="Actual Hours"
+                type="number"
+                min="0"
+                step="0.25"
+                :error-messages="formErrors.actualHours"
+              />
+            </v-col>
+          </v-row>
+
+          <v-select
+            v-model="activityForm.status"
+            :items="statusOptions"
+            item-title="label"
+            item-value="value"
+            label="Status"
+            :error-messages="formErrors.status"
+          />
+        </v-card-text>
+
+        <v-card-text v-else class="pa-4">
+          <v-alert type="info" variant="tonal" class="mb-4">
+            Please review the activity details before confirming.
+          </v-alert>
+          <v-table density="compact">
+            <tbody>
+              <tr>
+                <th class="text-left">Week</th>
+                <td>{{ selectedWeekLabel }}</td>
+              </tr>
+              <tr>
+                <th class="text-left">Section</th>
+                <td>{{ workspace?.sectionName ?? '—' }}</td>
+              </tr>
+              <tr>
+                <th class="text-left">Team</th>
+                <td>{{ workspace?.teamName ?? '—' }}</td>
+              </tr>
+              <tr>
+                <th class="text-left">Category</th>
+                <td>{{ activityForm.category ? formatCategory(activityForm.category) : '—' }}</td>
+              </tr>
+              <tr>
+                <th class="text-left">Planned Activity</th>
+                <td>{{ activityForm.plannedActivity || '—' }}</td>
+              </tr>
+              <tr>
+                <th class="text-left">Description</th>
+                <td>{{ activityForm.description || '—' }}</td>
+              </tr>
+              <tr>
+                <th class="text-left">Planned Hours</th>
+                <td>{{ activityForm.plannedHours || '0' }}</td>
+              </tr>
+              <tr>
+                <th class="text-left">Actual Hours</th>
+                <td>{{ activityForm.actualHours || '0' }}</td>
+              </tr>
+              <tr>
+                <th class="text-left">Status</th>
+                <td>{{ activityForm.status ? formatStatus(activityForm.status) : '—' }}</td>
+              </tr>
+            </tbody>
+          </v-table>
+        </v-card-text>
+
+        <v-divider />
+        <v-card-actions class="pa-4">
+          <v-btn variant="text" @click="closeFormDialog">Cancel</v-btn>
+          <v-spacer />
+          <v-btn v-if="formStep === 2" variant="outlined" @click="formStep = 1">Modify</v-btn>
+          <v-btn color="primary" :loading="saving" @click="formStep === 1 ? goToFormPreview() : submitForm()">
+            {{ formStep === 1 ? 'Preview' : 'Confirm' }}
+          </v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
+
+    <v-dialog v-model="deleteDialog" max-width="680" persistent>
+      <v-card>
+        <v-card-title class="pa-4">Delete Activity</v-card-title>
+        <v-divider />
+        <v-card-text class="pa-4">
+          <v-alert type="warning" variant="tonal" class="mb-4">
+            This activity will be removed from your WAR for the selected week.
+          </v-alert>
+          <v-table density="compact">
+            <tbody>
+              <tr>
+                <th class="text-left">Week</th>
+                <td>{{ selectedWeekLabel }}</td>
+              </tr>
+              <tr>
+                <th class="text-left">Category</th>
+                <td>{{ deleteTarget ? formatCategory(deleteTarget.category) : '—' }}</td>
+              </tr>
+              <tr>
+                <th class="text-left">Planned Activity</th>
+                <td>{{ deleteTarget?.plannedActivity ?? '—' }}</td>
+              </tr>
+              <tr>
+                <th class="text-left">Status</th>
+                <td>{{ deleteTarget ? formatStatus(deleteTarget.status) : '—' }}</td>
+              </tr>
+            </tbody>
+          </v-table>
+        </v-card-text>
+        <v-divider />
+        <v-card-actions class="pa-4">
+          <v-btn variant="text" @click="closeDeleteDialog">Cancel</v-btn>
+          <v-spacer />
+          <v-btn color="error" :loading="saving" @click="confirmDelete">Confirm</v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
+
+    <v-snackbar v-model="snackbar.show" :color="snackbar.color" timeout="3000">
+      {{ snackbar.message }}
+    </v-snackbar>
+  </v-container>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted, ref } from 'vue'
+import { createActivity, deleteActivity, getActivityWorkspace, updateActivity } from '../services/activityService'
+import type {
+  ActivityCategory,
+  ActivityDetail,
+  ActivityStatus,
+  ActivityWeekOption,
+  ActivityWorkspace,
+  CreateActivityRequest,
+  UpdateActivityRequest
+} from '../services/activityTypes'
+import { formatIsoWeekLabel, getIsoWeekRangeLabel } from '@/shared/utils/week'
+
+type FormMode = 'create' | 'edit'
+
+interface ActivityFormState {
+  category: ActivityCategory | null
+  plannedActivity: string
+  description: string
+  plannedHours: string
+  actualHours: string
+  status: ActivityStatus | null
+}
+
+const loading = ref(false)
+const saving = ref(false)
+const workspace = ref<ActivityWorkspace | null>(null)
+const selectedWeek = ref<string | null>(null)
+
+const formDialog = ref(false)
+const formStep = ref(1)
+const formMode = ref<FormMode>('create')
+const editTarget = ref<ActivityDetail | null>(null)
+const deleteDialog = ref(false)
+const deleteTarget = ref<ActivityDetail | null>(null)
+
+const activityForm = ref<ActivityFormState>(defaultForm())
+const formErrors = ref<Record<string, string[]>>({})
+
+const snackbar = ref({ show: false, message: '', color: 'success' })
+
+const categoryOptions = [
+  { label: 'Development', value: 'DEVELOPMENT' },
+  { label: 'Testing', value: 'TESTING' },
+  { label: 'Bugfix', value: 'BUGFIX' },
+  { label: 'Communication', value: 'COMMUNICATION' },
+  { label: 'Documentation', value: 'DOCUMENTATION' },
+  { label: 'Design', value: 'DESIGN' },
+  { label: 'Planning', value: 'PLANNING' },
+  { label: 'Learning', value: 'LEARNING' },
+  { label: 'Deployment', value: 'DEPLOYMENT' },
+  { label: 'Support', value: 'SUPPORT' },
+  { label: 'Miscellaneous', value: 'MISCELLANEOUS' }
+] as const
+
+const statusOptions = [
+  { label: 'In progress', value: 'IN_PROGRESS' },
+  { label: 'Under testing', value: 'UNDER_TESTING' },
+  { label: 'Done', value: 'DONE' }
+] as const
+
+const selectedWeekOption = computed<ActivityWeekOption | null>(() =>
+  workspace.value?.availableWeeks.find((option) => option.week === selectedWeek.value) ?? null
+)
+
+const selectedWeekLabel = computed(() =>
+  selectedWeekOption.value?.label ?? (selectedWeek.value ? formatIsoWeekLabel(selectedWeek.value) : '—')
+)
+
+onMounted(() => {
+  loadWorkspace()
+})
+
+async function loadWorkspace(week?: string) {
+  loading.value = true
+  try {
+    const response = await getActivityWorkspace(week) as any
+    workspace.value = response.flag ? response.data : null
+    selectedWeek.value = response.flag ? response.data?.selectedWeek ?? null : null
+  } catch (err: any) {
+    snackbar.value = {
+      show: true,
+      message: err?.response?.data?.message || 'An error occurred.',
+      color: 'error'
+    }
+  } finally {
+    loading.value = false
+  }
+}
+
+async function handleWeekChange() {
+  await loadWorkspace(selectedWeek.value ?? undefined)
+}
+
+function openCreateDialog() {
+  formMode.value = 'create'
+  editTarget.value = null
+  activityForm.value = defaultForm()
+  formErrors.value = {}
+  formStep.value = 1
+  formDialog.value = true
+}
+
+function openEditDialog(activity: ActivityDetail) {
+  formMode.value = 'edit'
+  editTarget.value = activity
+  activityForm.value = {
+    category: activity.category,
+    plannedActivity: activity.plannedActivity,
+    description: activity.description,
+    plannedHours: String(activity.plannedHours),
+    actualHours: String(activity.actualHours),
+    status: activity.status
+  }
+  formErrors.value = {}
+  formStep.value = 1
+  formDialog.value = true
+}
+
+function closeFormDialog() {
+  formDialog.value = false
+  formStep.value = 1
+  editTarget.value = null
+  activityForm.value = defaultForm()
+  formErrors.value = {}
+}
+
+function openDeleteDialog(activity: ActivityDetail) {
+  deleteTarget.value = activity
+  deleteDialog.value = true
+}
+
+function closeDeleteDialog() {
+  deleteDialog.value = false
+  deleteTarget.value = null
+}
+
+function goToFormPreview() {
+  if (!validateForm()) {
+    return
+  }
+  formStep.value = 2
+}
+
+async function submitForm() {
+  if (!selectedWeek.value) {
+    snackbar.value = { show: true, message: 'Week is required.', color: 'error' }
+    return
+  }
+
+  saving.value = true
+  try {
+    if (formMode.value === 'create') {
+      const payload: CreateActivityRequest = {
+        week: selectedWeek.value,
+        category: activityForm.value.category,
+        plannedActivity: activityForm.value.plannedActivity.trim(),
+        description: activityForm.value.description.trim(),
+        plannedHours: parseNumber(activityForm.value.plannedHours),
+        actualHours: parseNumber(activityForm.value.actualHours),
+        status: activityForm.value.status
+      }
+      await createActivity(payload)
+    } else if (editTarget.value) {
+      const payload: UpdateActivityRequest = {
+        category: activityForm.value.category,
+        plannedActivity: activityForm.value.plannedActivity.trim(),
+        description: activityForm.value.description.trim(),
+        plannedHours: parseNumber(activityForm.value.plannedHours),
+        actualHours: parseNumber(activityForm.value.actualHours),
+        status: activityForm.value.status
+      }
+      await updateActivity(editTarget.value.activityId, payload)
+    }
+
+    closeFormDialog()
+    await loadWorkspace(selectedWeek.value)
+    snackbar.value = { show: true, message: 'WAR has been updated.', color: 'success' }
+  } catch (err: any) {
+    snackbar.value = {
+      show: true,
+      message: err?.response?.data?.message || 'An error occurred.',
+      color: 'error'
+    }
+    formStep.value = 1
+  } finally {
+    saving.value = false
+  }
+}
+
+async function confirmDelete() {
+  if (!deleteTarget.value) {
+    return
+  }
+
+  saving.value = true
+  try {
+    await deleteActivity(deleteTarget.value.activityId)
+    closeDeleteDialog()
+    await loadWorkspace(selectedWeek.value ?? undefined)
+    snackbar.value = { show: true, message: 'WAR has been updated.', color: 'success' }
+  } catch (err: any) {
+    snackbar.value = {
+      show: true,
+      message: err?.response?.data?.message || 'An error occurred.',
+      color: 'error'
+    }
+  } finally {
+    saving.value = false
+  }
+}
+
+function validateForm() {
+  const errors: Record<string, string[]> = {}
+
+  if (!activityForm.value.category) {
+    errors.category = ['Activity category is required.']
+  }
+  if (!activityForm.value.plannedActivity.trim()) {
+    errors.plannedActivity = ['Planned activity is required.']
+  }
+  if (activityForm.value.plannedActivity.trim().length > 255) {
+    errors.plannedActivity = ['Planned activity must be 255 characters or fewer.']
+  }
+  if (!activityForm.value.description.trim()) {
+    errors.description = ['Activity description is required.']
+  }
+  if (activityForm.value.description.trim().length > 2000) {
+    errors.description = ['Activity description must be 2000 characters or fewer.']
+  }
+
+  validateHoursField(activityForm.value.plannedHours, 'plannedHours', 'Planned hours', errors)
+  validateHoursField(activityForm.value.actualHours, 'actualHours', 'Actual hours', errors)
+
+  if (!activityForm.value.status) {
+    errors.status = ['Status is required.']
+  }
+
+  formErrors.value = errors
+  return Object.keys(errors).length === 0
+}
+
+function validateHoursField(
+  value: string,
+  key: string,
+  label: string,
+  errors: Record<string, string[]>
+) {
+  if (value === '') {
+    errors[key] = [`${label} are required.`]
+    return
+  }
+
+  const parsed = Number(value)
+  if (Number.isNaN(parsed)) {
+    errors[key] = [`${label} must be a valid number.`]
+    return
+  }
+  if (parsed < 0) {
+    errors[key] = [`${label} must be zero or greater.`]
+    return
+  }
+  if (parsed > 999.99) {
+    errors[key] = [`${label} must be 999.99 or fewer.`]
+  }
+}
+
+function parseNumber(value: string): number | null {
+  if (value === '') return null
+  const parsed = Number(value)
+  return Number.isNaN(parsed) ? null : parsed
+}
+
+function defaultForm(): ActivityFormState {
+  return {
+    category: null,
+    plannedActivity: '',
+    description: '',
+    plannedHours: '',
+    actualHours: '',
+    status: null
+  }
+}
+
+function formatCategory(category: ActivityCategory) {
+  return categoryOptions.find((option) => option.value === category)?.label ?? category
+}
+
+function formatStatus(status: ActivityStatus) {
+  return statusOptions.find((option) => option.value === status)?.label ?? status
+}
+
+function categoryChipColor(category: ActivityCategory) {
+  const colors: Record<ActivityCategory, string> = {
+    DEVELOPMENT: 'primary',
+    TESTING: 'info',
+    BUGFIX: 'warning',
+    COMMUNICATION: 'teal',
+    DOCUMENTATION: 'indigo',
+    DESIGN: 'deep-purple',
+    PLANNING: 'orange-darken-2',
+    LEARNING: 'cyan-darken-2',
+    DEPLOYMENT: 'blue-grey-darken-1',
+    SUPPORT: 'brown',
+    MISCELLANEOUS: 'secondary'
+  }
+
+  return colors[category]
+}
+
+function statusChipColor(status: ActivityStatus) {
+  const colors: Record<ActivityStatus, string> = {
+    IN_PROGRESS: 'primary',
+    UNDER_TESTING: 'warning',
+    DONE: 'success'
+  }
+
+  return colors[status]
+}
+
+function formatHours(value: number) {
+  return Number(value).toString()
+}
+</script>
+
+<style scoped lang="scss">
+.description-cell {
+  max-width: 340px;
+  white-space: normal;
+}
+</style>

--- a/src/frontend/src/features/activity/services/activityService.ts
+++ b/src/frontend/src/features/activity/services/activityService.ts
@@ -1,0 +1,17 @@
+import request from '@/shared/utils/request'
+import type { ApiResponse } from '@/shared/types/api'
+import type { ActivityDetail, ActivityWorkspace, CreateActivityRequest, UpdateActivityRequest } from './activityTypes'
+
+const BASE = '/activities'
+
+export const getActivityWorkspace = (week?: string) =>
+  request.get<ApiResponse<ActivityWorkspace>>(`${BASE}/workspace`, { params: week ? { week } : {} })
+
+export const createActivity = (payload: CreateActivityRequest) =>
+  request.post<ApiResponse<ActivityDetail>>(BASE, payload)
+
+export const updateActivity = (activityId: number, payload: UpdateActivityRequest) =>
+  request.put<ApiResponse<ActivityDetail>>(`${BASE}/${activityId}`, payload)
+
+export const deleteActivity = (activityId: number) =>
+  request.delete<ApiResponse<null>>(`${BASE}/${activityId}`)

--- a/src/frontend/src/features/activity/services/activityTypes.ts
+++ b/src/frontend/src/features/activity/services/activityTypes.ts
@@ -1,0 +1,62 @@
+export type ActivityCategory =
+  | 'DEVELOPMENT'
+  | 'TESTING'
+  | 'BUGFIX'
+  | 'COMMUNICATION'
+  | 'DOCUMENTATION'
+  | 'DESIGN'
+  | 'PLANNING'
+  | 'LEARNING'
+  | 'DEPLOYMENT'
+  | 'SUPPORT'
+  | 'MISCELLANEOUS'
+
+export type ActivityStatus = 'IN_PROGRESS' | 'UNDER_TESTING' | 'DONE'
+
+export interface ActivityWeekOption {
+  week: string
+  label: string
+  activeWeek: boolean
+}
+
+export interface ActivityDetail {
+  activityId: number
+  week: string
+  category: ActivityCategory
+  plannedActivity: string
+  description: string
+  plannedHours: number
+  actualHours: number
+  status: ActivityStatus
+}
+
+export interface ActivityWorkspace {
+  sectionId: number | null
+  sectionName: string | null
+  teamId: number | null
+  teamName: string | null
+  selectedWeek: string | null
+  availableWeeks: ActivityWeekOption[]
+  activities: ActivityDetail[]
+  canManageActivities: boolean
+  availabilityMessage: string | null
+}
+
+export interface CreateActivityRequest {
+  week: string
+  category: ActivityCategory | null
+  plannedActivity: string
+  description: string
+  plannedHours: number | null
+  actualHours: number | null
+  status: ActivityStatus | null
+}
+
+export interface UpdateActivityRequest {
+  category: ActivityCategory | null
+  plannedActivity: string
+  description: string
+  plannedHours: number | null
+  actualHours: number | null
+  status: ActivityStatus | null
+}

--- a/src/frontend/src/router/routes.ts
+++ b/src/frontend/src/router/routes.ts
@@ -47,6 +47,18 @@ export const routes = [
         name: 'home',
         meta: { title: 'Home', icon: 'mdi-home', isMenuItem: true, requiresAuth: true }
       },
+      {
+        path: '/war',
+        component: () => import('@/features/activity/pages/WarActivities.vue'),
+        name: 'war-activities',
+        meta: {
+          title: 'WAR',
+          icon: 'mdi-clipboard-text-clock-outline',
+          isMenuItem: true,
+          requiresAuth: true,
+          roles: ['student']
+        }
+      },
 
       // ── Sections ─────────────────────────────────────────────────────────
       {

--- a/src/frontend/src/shared/utils/week.ts
+++ b/src/frontend/src/shared/utils/week.ts
@@ -2,6 +2,11 @@ import moment from 'moment'
 
 export const getCurrentWeekNumber = () => moment().format('YYYY-[W]WW')
 
+export const formatIsoWeekLabel = (isoWeek: string) => {
+  const [year, week] = isoWeek.split('-W') as [string, string]
+  return `Week ${parseInt(week, 10)} (${year})`
+}
+
 export const getCurrentWeekRange = () =>
   moment().startOf('isoWeek').format('MM-DD-YYYY') +
   ' -- ' +
@@ -13,3 +18,11 @@ export const getPreviousWeekRange = () =>
   moment().subtract(1, 'weeks').endOf('isoWeek').format('MM-DD-YYYY')
 
 export const getPreviousWeek = () => moment().subtract(1, 'weeks').format('YYYY-[W]WW')
+
+export const isFutureIsoWeek = (isoWeek: string) =>
+  moment(isoWeek + '-1', 'GGGG-[W]WW-E').startOf('day').isAfter(moment().startOf('isoWeek'))
+
+export const getIsoWeekRangeLabel = (isoWeek: string) =>
+  moment(isoWeek + '-1', 'GGGG-[W]WW-E').startOf('isoWeek').format('MM-DD-YYYY') +
+  ' -- ' +
+  moment(isoWeek + '-1', 'GGGG-[W]WW-E').endOf('isoWeek').format('MM-DD-YYYY')


### PR DESCRIPTION
Implements UC-27 by adding a new student-only WAR activity management feature. This includes a new backend activity module with workspace/create/update/delete endpoints, a Flyway migration for the activities table, a dedicated /war student page in the frontend, ISO-week selection with non-future validation, and preview/confirm flows for adding, editing, and deleting activities. It also includes the follow-up UI polish where activity category and status now display as fixed color chips.