### PR TITLE
feat(uc-32): implement WAR report generation for a senior design team

### DIFF
--- a/docs/development-plan.md
+++ b/docs/development-plan.md
@@ -36,7 +36,7 @@ Modules: `auth`, `section`, `rubric`
 | UC-6 | Set up active weeks for a section | Done |
 | UC-25 | Student sets up a student account | Done |
 | UC-31 | Generate peer eval report for entire section | Not started |
-| UC-32 | Generate WAR report for a team | Not started |
+| UC-32 | Generate WAR report for a team | Done |
 | UC-33 | Generate peer eval report for a student | Not started |
 | UC-34 | Generate WAR report for a student | Not started |
 

--- a/src/backend/src/main/java/team/projectpulse/activity/domain/Activity.java
+++ b/src/backend/src/main/java/team/projectpulse/activity/domain/Activity.java
@@ -1,23 +1,10 @@
 package team.projectpulse.activity.domain;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.PrePersist;
-import jakarta.persistence.PreUpdate;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
 import team.projectpulse.team.domain.Team;
 import team.projectpulse.user.domain.User;
 
 import java.math.BigDecimal;
-import java.time.LocalDateTime;
 
 @Entity
 @Table(name = "activities")
@@ -29,147 +16,63 @@ public class Activity {
     private Long activityId;
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
-    @JoinColumn(name = "team_id", nullable = false)
-    private Team team;
-
-    @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "student_id", nullable = false)
     private User student;
 
-    @Column(name = "week", nullable = false, length = 20)
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "team_id", nullable = false)
+    private Team team;
+
+    @Column(nullable = false)
     private String week;
 
     @Enumerated(EnumType.STRING)
-    @Column(name = "category", nullable = false, length = 50)
+    @Column(nullable = false)
     private ActivityCategory category;
 
-    @Column(name = "planned_activity", nullable = false, length = 255)
+    @Column(name = "planned_activity", nullable = false)
     private String plannedActivity;
 
-    @Column(name = "description", nullable = false, columnDefinition = "TEXT")
+    @Column(nullable = false, columnDefinition = "TEXT")
     private String description;
 
-    @Column(name = "planned_hours", nullable = false, precision = 6, scale = 2)
+    @Column(name = "planned_hours", nullable = false)
     private BigDecimal plannedHours;
 
-    @Column(name = "actual_hours", nullable = false, precision = 6, scale = 2)
+    @Column(name = "actual_hours", nullable = false)
     private BigDecimal actualHours;
 
     @Enumerated(EnumType.STRING)
-    @Column(name = "status", nullable = false, length = 30)
+    @Column(nullable = false)
     private ActivityStatus status;
 
-    @Column(name = "created_at", nullable = false, updatable = false)
-    private LocalDateTime createdAt;
+    public Long getActivityId()               { return activityId; }
+    public void setActivityId(Long v)         { this.activityId = v; }
 
-    @Column(name = "updated_at", nullable = false)
-    private LocalDateTime updatedAt;
+    public User getStudent()                  { return student; }
+    public void setStudent(User v)            { this.student = v; }
 
-    @PrePersist
-    void onCreate() {
-        LocalDateTime now = LocalDateTime.now();
-        createdAt = now;
-        updatedAt = now;
-    }
+    public Team getTeam()                     { return team; }
+    public void setTeam(Team v)               { this.team = v; }
 
-    @PreUpdate
-    void onUpdate() {
-        updatedAt = LocalDateTime.now();
-    }
+    public String getWeek()                   { return week; }
+    public void setWeek(String v)             { this.week = v; }
 
-    public Long getActivityId() {
-        return activityId;
-    }
+    public ActivityCategory getCategory()     { return category; }
+    public void setCategory(ActivityCategory v) { this.category = v; }
 
-    public void setActivityId(Long activityId) {
-        this.activityId = activityId;
-    }
+    public String getPlannedActivity()        { return plannedActivity; }
+    public void setPlannedActivity(String v)  { this.plannedActivity = v; }
 
-    public Team getTeam() {
-        return team;
-    }
+    public String getDescription()            { return description; }
+    public void setDescription(String v)      { this.description = v; }
 
-    public void setTeam(Team team) {
-        this.team = team;
-    }
+    public BigDecimal getPlannedHours()       { return plannedHours; }
+    public void setPlannedHours(BigDecimal v) { this.plannedHours = v; }
 
-    public User getStudent() {
-        return student;
-    }
+    public BigDecimal getActualHours()        { return actualHours; }
+    public void setActualHours(BigDecimal v)  { this.actualHours = v; }
 
-    public void setStudent(User student) {
-        this.student = student;
-    }
-
-    public String getWeek() {
-        return week;
-    }
-
-    public void setWeek(String week) {
-        this.week = week;
-    }
-
-    public ActivityCategory getCategory() {
-        return category;
-    }
-
-    public void setCategory(ActivityCategory category) {
-        this.category = category;
-    }
-
-    public String getPlannedActivity() {
-        return plannedActivity;
-    }
-
-    public void setPlannedActivity(String plannedActivity) {
-        this.plannedActivity = plannedActivity;
-    }
-
-    public String getDescription() {
-        return description;
-    }
-
-    public void setDescription(String description) {
-        this.description = description;
-    }
-
-    public BigDecimal getPlannedHours() {
-        return plannedHours;
-    }
-
-    public void setPlannedHours(BigDecimal plannedHours) {
-        this.plannedHours = plannedHours;
-    }
-
-    public BigDecimal getActualHours() {
-        return actualHours;
-    }
-
-    public void setActualHours(BigDecimal actualHours) {
-        this.actualHours = actualHours;
-    }
-
-    public ActivityStatus getStatus() {
-        return status;
-    }
-
-    public void setStatus(ActivityStatus status) {
-        this.status = status;
-    }
-
-    public LocalDateTime getCreatedAt() {
-        return createdAt;
-    }
-
-    public void setCreatedAt(LocalDateTime createdAt) {
-        this.createdAt = createdAt;
-    }
-
-    public LocalDateTime getUpdatedAt() {
-        return updatedAt;
-    }
-
-    public void setUpdatedAt(LocalDateTime updatedAt) {
-        this.updatedAt = updatedAt;
-    }
+    public ActivityStatus getStatus()         { return status; }
+    public void setStatus(ActivityStatus v)   { this.status = v; }
 }

--- a/src/backend/src/main/java/team/projectpulse/activity/repository/ActivityRepository.java
+++ b/src/backend/src/main/java/team/projectpulse/activity/repository/ActivityRepository.java
@@ -10,28 +10,10 @@ import java.util.Optional;
 
 public interface ActivityRepository extends JpaRepository<Activity, Long> {
 
-    @Query("""
-        select a from Activity a
-        join fetch a.team t
-        join fetch a.student s
-        where s.id = :studentId
-          and a.week = :week
-        order by a.activityId asc
-        """)
-    List<Activity> findAllByStudentIdAndWeekOrderByActivityIdAsc(
-        @Param("studentId") Long studentId,
-        @Param("week") String week
-    );
+    List<Activity> findAllByStudentIdAndWeekOrderByActivityIdAsc(Long studentId, String week);
 
-    @Query("""
-        select a from Activity a
-        join fetch a.team t
-        join fetch a.student s
-        where a.activityId = :activityId
-          and s.id = :studentId
-        """)
-    Optional<Activity> findByActivityIdAndStudentId(
-        @Param("activityId") Long activityId,
-        @Param("studentId") Long studentId
-    );
+    Optional<Activity> findByActivityIdAndStudentId(Long activityId, Long studentId);
+
+    @Query("SELECT a FROM Activity a JOIN FETCH a.student WHERE a.team.teamId = :teamId AND a.week = :week ORDER BY a.student.lastName ASC, a.student.firstName ASC")
+    List<Activity> findByTeamIdAndWeek(@Param("teamId") Long teamId, @Param("week") String week);
 }

--- a/src/backend/src/main/java/team/projectpulse/report/controller/ReportController.java
+++ b/src/backend/src/main/java/team/projectpulse/report/controller/ReportController.java
@@ -1,0 +1,27 @@
+package team.projectpulse.report.controller;
+
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+import team.projectpulse.report.dto.TeamWarReportResponse;
+import team.projectpulse.report.service.ReportService;
+import team.projectpulse.system.Result;
+
+@RestController
+@RequestMapping("${api.endpoint.base-url}/teams/{teamId}/war-report")
+public class ReportController {
+
+    private final ReportService reportService;
+
+    public ReportController(ReportService reportService) {
+        this.reportService = reportService;
+    }
+
+    @GetMapping
+    @PreAuthorize("hasAnyRole('ADMIN', 'INSTRUCTOR', 'STUDENT')")
+    public Result<TeamWarReportResponse> getTeamWarReport(
+            @PathVariable Long teamId,
+            @RequestParam String week
+    ) {
+        return Result.success(reportService.generateTeamWarReport(teamId, week));
+    }
+}

--- a/src/backend/src/main/java/team/projectpulse/report/dto/StudentWarReport.java
+++ b/src/backend/src/main/java/team/projectpulse/report/dto/StudentWarReport.java
@@ -1,0 +1,10 @@
+package team.projectpulse.report.dto;
+
+import java.util.List;
+
+public record StudentWarReport(
+    Long studentId,
+    String studentName,
+    boolean submitted,
+    List<WarReportRow> activities
+) {}

--- a/src/backend/src/main/java/team/projectpulse/report/dto/TeamWarReportResponse.java
+++ b/src/backend/src/main/java/team/projectpulse/report/dto/TeamWarReportResponse.java
@@ -1,0 +1,10 @@
+package team.projectpulse.report.dto;
+
+import java.util.List;
+
+public record TeamWarReportResponse(
+    Long teamId,
+    String teamName,
+    String week,
+    List<StudentWarReport> studentReports
+) {}

--- a/src/backend/src/main/java/team/projectpulse/report/dto/WarReportRow.java
+++ b/src/backend/src/main/java/team/projectpulse/report/dto/WarReportRow.java
@@ -1,0 +1,12 @@
+package team.projectpulse.report.dto;
+
+import java.math.BigDecimal;
+
+public record WarReportRow(
+    String activityCategory,
+    String plannedActivity,
+    String description,
+    BigDecimal plannedHours,
+    BigDecimal actualHours,
+    String status
+) {}

--- a/src/backend/src/main/java/team/projectpulse/report/service/ReportService.java
+++ b/src/backend/src/main/java/team/projectpulse/report/service/ReportService.java
@@ -1,0 +1,70 @@
+package team.projectpulse.report.service;
+
+import org.springframework.stereotype.Service;
+import team.projectpulse.activity.domain.Activity;
+import team.projectpulse.activity.repository.ActivityRepository;
+import team.projectpulse.report.dto.StudentWarReport;
+import team.projectpulse.report.dto.TeamWarReportResponse;
+import team.projectpulse.report.dto.WarReportRow;
+import team.projectpulse.team.domain.InvalidTeamException;
+import team.projectpulse.team.domain.Team;
+import team.projectpulse.team.repository.TeamRepository;
+import team.projectpulse.user.domain.User;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Service
+public class ReportService {
+
+    private final TeamRepository teamRepository;
+    private final ActivityRepository activityRepository;
+
+    public ReportService(TeamRepository teamRepository, ActivityRepository activityRepository) {
+        this.teamRepository = teamRepository;
+        this.activityRepository = activityRepository;
+    }
+
+    public TeamWarReportResponse generateTeamWarReport(Long teamId, String week) {
+        Team team = teamRepository.findById(teamId)
+                .orElseThrow(() -> new InvalidTeamException("Team not found with id " + teamId));
+
+        List<Activity> activities = activityRepository.findByTeamIdAndWeek(teamId, week);
+
+        Map<Long, List<Activity>> byStudent = activities.stream()
+                .collect(Collectors.groupingBy(a -> a.getStudent().getId()));
+
+        List<User> students = new ArrayList<>(team.getStudents());
+        students.sort((a, b) -> {
+            int cmp = a.getLastName().compareToIgnoreCase(b.getLastName());
+            return cmp != 0 ? cmp : a.getFirstName().compareToIgnoreCase(b.getFirstName());
+        });
+
+        List<StudentWarReport> studentReports = students.stream()
+                .map(student -> {
+                    List<Activity> studentActivities = byStudent.getOrDefault(student.getId(), List.of());
+                    boolean submitted = !studentActivities.isEmpty();
+                    List<WarReportRow> rows = studentActivities.stream()
+                            .map(a -> new WarReportRow(
+                                    a.getCategory().name(),
+                                    a.getPlannedActivity(),
+                                    a.getDescription(),
+                                    a.getPlannedHours(),
+                                    a.getActualHours(),
+                                    a.getStatus().name()
+                            ))
+                            .toList();
+                    return new StudentWarReport(
+                            student.getId(),
+                            student.getFirstName() + " " + student.getLastName(),
+                            submitted,
+                            rows
+                    );
+                })
+                .toList();
+
+        return new TeamWarReportResponse(team.getTeamId(), team.getTeamName(), week, studentReports);
+    }
+}

--- a/src/backend/src/main/resources/db/migration/V8__activities_seed.sql
+++ b/src/backend/src/main/resources/db/migration/V8__activities_seed.sql
@@ -1,0 +1,9 @@
+-- V8: Seed activity data for UC-32 WAR report testing
+-- Team 2001 (Pulse Analytics): Ava Johnson (1003), Liam Parker (1004)
+-- Team 2002 (Peer Review Tool): Mia Chen (1005), Ethan Wright (1006) — Ethan has no entries to demo "did not submit"
+
+INSERT INTO activities (team_id, student_id, week, category, planned_activity, description, planned_hours, actual_hours, status) VALUES
+    (2001, 1003, '2026-W16', 'BUGFIX',        'Fix login bug',       'Resolve the authentication redirect issue on mobile.', 4.00, 5.00, 'DONE'),
+    (2001, 1003, '2026-W16', 'DOCUMENTATION', 'Write use cases',     'Write three new use cases for the registration flow.', 5.00, 3.00, 'IN_PROGRESS'),
+    (2001, 1004, '2026-W16', 'DEVELOPMENT',   'Implement dashboard', 'Add activity summary chart to the team dashboard.',   10.00, 9.00, 'DONE'),
+    (2002, 1005, '2026-W16', 'TESTING',       'Write unit tests',    'Cover AuthService with unit tests.',                   6.00, 6.50, 'DONE');

--- a/src/frontend/src/features/report/services/reportService.ts
+++ b/src/frontend/src/features/report/services/reportService.ts
@@ -1,0 +1,7 @@
+import request from '@/shared/utils/request'
+import type { TeamWarReportResponse } from './reportTypes'
+
+const BASE = '/teams'
+
+export const getTeamWarReport = (teamId: number, week: string) =>
+  request.get<any>(`${BASE}/${teamId}/war-report`, { params: { week } })

--- a/src/frontend/src/features/report/services/reportTypes.ts
+++ b/src/frontend/src/features/report/services/reportTypes.ts
@@ -1,0 +1,22 @@
+export interface WarReportRow {
+  activityCategory: string
+  plannedActivity: string
+  description: string | null
+  plannedHours: number | null
+  actualHours: number | null
+  status: string
+}
+
+export interface StudentWarReport {
+  studentId: number
+  studentName: string
+  submitted: boolean
+  activities: WarReportRow[]
+}
+
+export interface TeamWarReportResponse {
+  teamId: number
+  teamName: string
+  week: string
+  studentReports: StudentWarReport[]
+}

--- a/src/frontend/src/features/team/pages/TeamDetail.vue
+++ b/src/frontend/src/features/team/pages/TeamDetail.vue
@@ -1108,7 +1108,7 @@ async function openWarDialog() {
         const previousWeek = getPreviousIsoWeek()
         warSelectedWeek.value = activeWeeks.value.includes(previousWeek)
           ? previousWeek
-          : activeWeeks.value[activeWeeks.value.length - 1]
+          : activeWeeks.value[activeWeeks.value.length - 1] as string
       }
     }
   } catch {

--- a/src/frontend/src/features/team/pages/TeamDetail.vue
+++ b/src/frontend/src/features/team/pages/TeamDetail.vue
@@ -22,6 +22,9 @@
           </div>
         </v-col>
         <v-col cols="auto">
+          <v-btn variant="outlined" prepend-icon="mdi-file-chart" @click="openWarDialog">WAR Report</v-btn>
+        </v-col>
+        <v-col cols="auto">
           <v-chip color="primary" variant="tonal">
             {{ team.sectionName }}
           </v-chip>
@@ -627,6 +630,86 @@
       </v-card>
     </v-dialog>
 
+    <!-- WAR Report Dialog -->
+    <v-dialog v-model="warDialog" max-width="900" scrollable>
+      <v-card rounded="lg">
+        <v-card-title class="pa-6 pb-2">
+          <span v-if="warStep === 1">Generate WAR Report</span>
+          <span v-else>WAR Report — {{ warSelectedWeek }}</span>
+        </v-card-title>
+
+        <v-card-text class="px-6">
+          <!-- Step 1: Pick a week -->
+          <template v-if="warStep === 1">
+            <p class="text-medium-emphasis mb-4">Select the active week to generate the WAR report for <strong>{{ team?.teamName }}</strong>.</p>
+            <v-select
+              v-model="warSelectedWeek"
+              :items="activeWeeks"
+              label="Active Week"
+              variant="outlined"
+              density="comfortable"
+              :rules="[(v) => !!v || 'Please select a week.']"
+            />
+            <v-alert v-if="!activeWeeks.length" type="warning" variant="tonal" class="mt-2">
+              No active weeks configured for this section.
+            </v-alert>
+          </template>
+
+          <!-- Step 2: Report -->
+          <template v-else>
+            <template v-if="warReport && warReport.studentReports.length">
+              <div v-for="student in warReport.studentReports" :key="student.studentId" class="mb-6">
+                <div class="d-flex align-center mb-2 gap-2">
+                  <span class="font-weight-bold">{{ student.studentName }}</span>
+                  <v-chip v-if="!student.submitted" color="error" size="small" variant="tonal">Did not submit</v-chip>
+                </div>
+                <template v-if="student.submitted">
+                  <v-table density="compact">
+                    <thead>
+                      <tr>
+                        <th>Activity Category</th>
+                        <th>Planned Activity</th>
+                        <th>Description</th>
+                        <th>Planned Hrs</th>
+                        <th>Actual Hrs</th>
+                        <th>Status</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      <tr v-for="(row, i) in student.activities" :key="i">
+                        <td>{{ row.activityCategory }}</td>
+                        <td>{{ row.plannedActivity }}</td>
+                        <td>{{ row.description ?? '—' }}</td>
+                        <td>{{ row.plannedHours ?? '—' }}</td>
+                        <td>{{ row.actualHours ?? '—' }}</td>
+                        <td>
+                          <v-chip :color="row.status === 'Done' ? 'success' : 'warning'" size="small" variant="tonal">
+                            {{ row.status }}
+                          </v-chip>
+                        </td>
+                      </tr>
+                    </tbody>
+                  </v-table>
+                </template>
+              </div>
+            </template>
+            <v-alert v-else type="info" variant="tonal">
+              No activity data found for week {{ warSelectedWeek }}.
+            </v-alert>
+          </template>
+        </v-card-text>
+
+        <v-card-actions class="px-6 pb-4">
+          <v-spacer />
+          <v-btn variant="outlined" @click="closeWarDialog">Close</v-btn>
+          <v-btn v-if="warStep === 1" color="primary" :disabled="!warSelectedWeek || !activeWeeks.length" :loading="warLoading" @click="generateWarReport">
+            Generate
+          </v-btn>
+          <v-btn v-else variant="outlined" @click="warStep = 1">Back</v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
+
     <v-snackbar v-model="snackbar.show" :color="snackbar.color" timeout="3000">
       {{ snackbar.message }}
     </v-snackbar>
@@ -639,6 +722,8 @@ import { useRoute, useRouter } from 'vue-router'
 import { useUserInfoStore } from '@/stores/userInfo'
 import { deleteTeam, getTeam, removeInstructorFromTeam, removeStudentFromTeam, updateTeam } from '../services/teamService'
 import { useTeamNotificationsStore } from '../stores/teamNotifications'
+import { getSection } from '@/features/section/services/sectionService'
+import { getTeamWarReport } from '@/features/report/services/reportService'
 import type {
   TeamDeletionNotification,
   TeamDetail,
@@ -646,6 +731,7 @@ import type {
   TeamMemberDetail,
   UpdateTeamRequest
 } from '../services/teamTypes'
+import type { TeamWarReportResponse } from '@/features/report/services/reportTypes'
 
 interface RemovedStudentNotification {
   fullName: string
@@ -690,6 +776,13 @@ const deleteSaving = ref(false)
 const removedStudentNotification = ref<RemovedStudentNotification | null>(null)
 const removedInstructorNotification = ref<RemovedInstructorNotification | null>(null)
 const snackbar = ref({ show: false, message: '', color: 'success' })
+
+const warDialog = ref(false)
+const warStep = ref(1)
+const warLoading = ref(false)
+const warSelectedWeek = ref<string>('')
+const activeWeeks = ref<string[]>([])
+const warReport = ref<TeamWarReportResponse | null>(null)
 
 const emptyForm = () => ({
   teamName: '',
@@ -997,6 +1090,63 @@ function buildDeletedTeamNotification(currentTeam: TeamDetail): TeamDeletionNoti
 function normalizeOptional(value: string): string | null {
   const trimmed = value.trim()
   return trimmed ? trimmed : null
+}
+
+async function openWarDialog() {
+  if (!team.value) return
+  warStep.value = 1
+  warReport.value = null
+  warSelectedWeek.value = ''
+  activeWeeks.value = []
+  warDialog.value = true
+
+  try {
+    const res = await getSection(team.value.sectionId) as any
+    if (res.flag && res.data?.activeWeeks) {
+      activeWeeks.value = [...res.data.activeWeeks].sort()
+      if (activeWeeks.value.length) {
+        const previousWeek = getPreviousIsoWeek()
+        warSelectedWeek.value = activeWeeks.value.includes(previousWeek)
+          ? previousWeek
+          : activeWeeks.value[activeWeeks.value.length - 1]
+      }
+    }
+  } catch {
+    snackbar.value = { show: true, message: 'Failed to load section weeks.', color: 'error' }
+  }
+}
+
+function getPreviousIsoWeek(): string {
+  const d = new Date()
+  d.setDate(d.getDate() - 7)
+  const jan4 = new Date(d.getFullYear(), 0, 4)
+  const dayOfYear = Math.floor((d.getTime() - new Date(d.getFullYear(), 0, 0).getTime()) / 86400000)
+  const weekNum = Math.ceil((dayOfYear + jan4.getDay()) / 7)
+  return `${d.getFullYear()}-W${String(weekNum).padStart(2, '0')}`
+}
+
+async function generateWarReport() {
+  if (!team.value || !warSelectedWeek.value) return
+  warLoading.value = true
+  try {
+    const res = await getTeamWarReport(team.value.teamId, warSelectedWeek.value) as any
+    if (res.flag) {
+      warReport.value = res.data
+      warStep.value = 2
+    } else {
+      snackbar.value = { show: true, message: res.message || 'Failed to generate report.', color: 'error' }
+    }
+  } catch {
+    snackbar.value = { show: true, message: 'An error occurred generating the report.', color: 'error' }
+  } finally {
+    warLoading.value = false
+  }
+}
+
+function closeWarDialog() {
+  warDialog.value = false
+  warStep.value = 1
+  warReport.value = null
 }
 </script>
 

--- a/src/frontend/src/router/routes.ts
+++ b/src/frontend/src/router/routes.ts
@@ -97,7 +97,7 @@ export const routes = [
         path: '/teams/:id',
         component: () => import('@/features/team/pages/TeamDetail.vue'),
         name: 'team-detail',
-        meta: { requiresAuth: true, roles: ['admin', 'instructor'] }
+        meta: { requiresAuth: true, roles: ['admin', 'instructor', 'student'] }
       },
 
       // ── Rubrics ──────────────────────────────────────────────────────────


### PR DESCRIPTION
- Add report module with ReportService and ReportController (GET /teams/{id}/war-report?week=)
- Add findByTeamIdAndWeek JPQL query to ActivityRepository
- Restore Activity entity and repository to match UC-27 implementation
- Add V8 migration with seed activity data for testing
- Add WAR Report button and 2-step dialog to TeamDetail.vue
- Allow student role on /teams/:id route