### PR TITLE
feat(uc-28): implement peer evaluations

### DIFF
--- a/src/backend/pom.xml
+++ b/src/backend/pom.xml
@@ -189,6 +189,7 @@
                 <configuration>
                     <reuseForks>false</reuseForks>
                     <forkCount>1</forkCount>
+                    <argLine>-javaagent:${settings.localRepository}/org/mockito/mockito-core/5.20.0/mockito-core-5.20.0.jar</argLine>
                 </configuration>
             </plugin>
             <plugin>

--- a/src/backend/src/main/java/team/projectpulse/config/JwtAuthFilter.java
+++ b/src/backend/src/main/java/team/projectpulse/config/JwtAuthFilter.java
@@ -6,8 +6,6 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
@@ -18,11 +16,9 @@ import java.io.IOException;
 public class JwtAuthFilter extends OncePerRequestFilter {
 
     private final JwtUtils jwtUtils;
-    private final UserDetailsService userDetailsService;
 
-    public JwtAuthFilter(JwtUtils jwtUtils, UserDetailsService userDetailsService) {
+    public JwtAuthFilter(JwtUtils jwtUtils) {
         this.jwtUtils = jwtUtils;
-        this.userDetailsService = userDetailsService;
     }
 
     @Override
@@ -44,9 +40,8 @@ public class JwtAuthFilter extends OncePerRequestFilter {
 
         String username = jwtUtils.extractUsername(token);
         if (username != null && SecurityContextHolder.getContext().getAuthentication() == null) {
-            UserDetails userDetails = userDetailsService.loadUserByUsername(username);
             UsernamePasswordAuthenticationToken auth =
-                    new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+                    new UsernamePasswordAuthenticationToken(username, null, jwtUtils.extractAuthorities(token));
             auth.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
             SecurityContextHolder.getContext().setAuthentication(auth);
         }

--- a/src/backend/src/main/java/team/projectpulse/config/JwtUtils.java
+++ b/src/backend/src/main/java/team/projectpulse/config/JwtUtils.java
@@ -7,6 +7,7 @@ import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.jwt.SignedJWT;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Component;
 
@@ -15,7 +16,9 @@ import java.text.ParseException;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Date;
+import java.util.List;
 import java.util.stream.Collectors;
 
 @Component
@@ -68,6 +71,22 @@ public class JwtUtils {
             return SignedJWT.parse(token).getJWTClaimsSet().getSubject();
         } catch (ParseException e) {
             return null;
+        }
+    }
+
+    public Collection<? extends GrantedAuthority> extractAuthorities(String token) {
+        try {
+            Object rolesClaim = SignedJWT.parse(token).getJWTClaimsSet().getClaim("roles");
+            if (!(rolesClaim instanceof String roles) || roles.isBlank()) {
+                return List.of();
+            }
+
+            return Arrays.stream(roles.split("\\s+"))
+                .filter(role -> !role.isBlank())
+                .map(SimpleGrantedAuthority::new)
+                .collect(Collectors.toList());
+        } catch (ParseException e) {
+            return List.of();
         }
     }
 }

--- a/src/backend/src/main/java/team/projectpulse/config/SecurityConfig.java
+++ b/src/backend/src/main/java/team/projectpulse/config/SecurityConfig.java
@@ -54,6 +54,7 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.POST, "/api/v1/auth/join").permitAll()
                         .requestMatchers(HttpMethod.POST, "/api/v1/auth/forget-password/**").permitAll()
                         .requestMatchers(HttpMethod.PATCH, "/api/v1/auth/reset-password").permitAll()
+                        .requestMatchers("/error").permitAll()
                         .requestMatchers("/actuator/**").permitAll()
                         .anyRequest().authenticated()
                 )

--- a/src/backend/src/main/java/team/projectpulse/evaluation/controller/PeerEvaluationController.java
+++ b/src/backend/src/main/java/team/projectpulse/evaluation/controller/PeerEvaluationController.java
@@ -1,0 +1,58 @@
+package team.projectpulse.evaluation.controller;
+
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import team.projectpulse.evaluation.dto.EvaluationWorkspace;
+import team.projectpulse.evaluation.dto.PeerEvaluationSubmissionDetail;
+import team.projectpulse.evaluation.dto.PeerEvaluationSubmissionRequest;
+import team.projectpulse.evaluation.service.EvaluationService;
+import team.projectpulse.system.Result;
+
+@RestController
+@RequestMapping("${api.endpoint.base-url}/peer-evaluations")
+public class PeerEvaluationController {
+
+    private final EvaluationService evaluationService;
+
+    public PeerEvaluationController(EvaluationService evaluationService) {
+        this.evaluationService = evaluationService;
+    }
+
+    @GetMapping("/workspace")
+    @PreAuthorize("hasRole('STUDENT')")
+    public Result<EvaluationWorkspace> getWorkspace(Authentication authentication) {
+        return Result.success(evaluationService.loadWorkspace(authentication.getName()));
+    }
+
+    @PostMapping
+    @PreAuthorize("hasRole('STUDENT')")
+    public Result<PeerEvaluationSubmissionDetail> createSubmission(
+        Authentication authentication,
+        @RequestBody PeerEvaluationSubmissionRequest request
+    ) {
+        return Result.success(
+            "Peer evaluation has been submitted.",
+            evaluationService.createSubmission(authentication.getName(), request)
+        );
+    }
+
+    @PutMapping("/{submissionId}")
+    @PreAuthorize("hasRole('STUDENT')")
+    public Result<PeerEvaluationSubmissionDetail> updateSubmission(
+        Authentication authentication,
+        @PathVariable Long submissionId,
+        @RequestBody PeerEvaluationSubmissionRequest request
+    ) {
+        return Result.success(
+            "Peer evaluation has been updated.",
+            evaluationService.updateSubmission(authentication.getName(), submissionId, request)
+        );
+    }
+}

--- a/src/backend/src/main/java/team/projectpulse/evaluation/controller/PeerEvaluationExceptionHandler.java
+++ b/src/backend/src/main/java/team/projectpulse/evaluation/controller/PeerEvaluationExceptionHandler.java
@@ -1,0 +1,26 @@
+package team.projectpulse.evaluation.controller;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import team.projectpulse.evaluation.domain.InvalidPeerEvaluationException;
+import team.projectpulse.evaluation.domain.PeerEvaluationSubmissionNotFoundException;
+import team.projectpulse.system.Result;
+import team.projectpulse.system.StatusCode;
+
+@RestControllerAdvice
+public class PeerEvaluationExceptionHandler {
+
+    @ExceptionHandler(PeerEvaluationSubmissionNotFoundException.class)
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    public Result<Void> handleSubmissionNotFound(PeerEvaluationSubmissionNotFoundException ex) {
+        return Result.notFound(ex.getMessage());
+    }
+
+    @ExceptionHandler(InvalidPeerEvaluationException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public Result<Void> handleInvalidPeerEvaluation(InvalidPeerEvaluationException ex) {
+        return Result.error(StatusCode.INVALID_ARGUMENT, ex.getMessage());
+    }
+}

--- a/src/backend/src/main/java/team/projectpulse/evaluation/domain/EvaluationEntry.java
+++ b/src/backend/src/main/java/team/projectpulse/evaluation/domain/EvaluationEntry.java
@@ -1,0 +1,97 @@
+package team.projectpulse.evaluation.domain;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import team.projectpulse.user.domain.User;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "evaluation_entries")
+public class EvaluationEntry {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "entry_id")
+    private Long entryId;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "submission_id", nullable = false)
+    private EvaluationSubmission submission;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "evaluatee_student_id", nullable = false)
+    private User evaluateeStudent;
+
+    @Column(name = "public_comment", columnDefinition = "TEXT")
+    private String publicComment;
+
+    @Column(name = "private_comment", columnDefinition = "TEXT")
+    private String privateComment;
+
+    @OneToMany(mappedBy = "entry", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<EvaluationScore> scores = new ArrayList<>();
+
+    public void addScore(EvaluationScore score) {
+        score.setEntry(this);
+        scores.add(score);
+    }
+
+    public Long getEntryId() {
+        return entryId;
+    }
+
+    public void setEntryId(Long entryId) {
+        this.entryId = entryId;
+    }
+
+    public EvaluationSubmission getSubmission() {
+        return submission;
+    }
+
+    public void setSubmission(EvaluationSubmission submission) {
+        this.submission = submission;
+    }
+
+    public User getEvaluateeStudent() {
+        return evaluateeStudent;
+    }
+
+    public void setEvaluateeStudent(User evaluateeStudent) {
+        this.evaluateeStudent = evaluateeStudent;
+    }
+
+    public String getPublicComment() {
+        return publicComment;
+    }
+
+    public void setPublicComment(String publicComment) {
+        this.publicComment = publicComment;
+    }
+
+    public String getPrivateComment() {
+        return privateComment;
+    }
+
+    public void setPrivateComment(String privateComment) {
+        this.privateComment = privateComment;
+    }
+
+    public List<EvaluationScore> getScores() {
+        return scores;
+    }
+
+    public void setScores(List<EvaluationScore> scores) {
+        this.scores = scores;
+    }
+}

--- a/src/backend/src/main/java/team/projectpulse/evaluation/domain/EvaluationScore.java
+++ b/src/backend/src/main/java/team/projectpulse/evaluation/domain/EvaluationScore.java
@@ -1,0 +1,64 @@
+package team.projectpulse.evaluation.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EmbeddedId;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.MapsId;
+import jakarta.persistence.Table;
+import team.projectpulse.rubric.domain.Criterion;
+
+@Entity
+@Table(name = "evaluation_scores")
+public class EvaluationScore {
+
+    @EmbeddedId
+    private EvaluationScoreId id = new EvaluationScoreId();
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @MapsId("entryId")
+    @JoinColumn(name = "entry_id", nullable = false)
+    private EvaluationEntry entry;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @MapsId("criterionId")
+    @JoinColumn(name = "criterion_id", nullable = false)
+    private Criterion criterion;
+
+    @Column(name = "score", nullable = false)
+    private Integer score;
+
+    public EvaluationScoreId getId() {
+        return id;
+    }
+
+    public void setId(EvaluationScoreId id) {
+        this.id = id;
+    }
+
+    public EvaluationEntry getEntry() {
+        return entry;
+    }
+
+    public void setEntry(EvaluationEntry entry) {
+        this.entry = entry;
+    }
+
+    public Criterion getCriterion() {
+        return criterion;
+    }
+
+    public void setCriterion(Criterion criterion) {
+        this.criterion = criterion;
+    }
+
+    public Integer getScore() {
+        return score;
+    }
+
+    public void setScore(Integer score) {
+        this.score = score;
+    }
+}

--- a/src/backend/src/main/java/team/projectpulse/evaluation/domain/EvaluationScoreId.java
+++ b/src/backend/src/main/java/team/projectpulse/evaluation/domain/EvaluationScoreId.java
@@ -1,0 +1,50 @@
+package team.projectpulse.evaluation.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+@Embeddable
+public class EvaluationScoreId implements Serializable {
+
+    @Column(name = "entry_id")
+    private Long entryId;
+
+    @Column(name = "criterion_id")
+    private Long criterionId;
+
+    public Long getEntryId() {
+        return entryId;
+    }
+
+    public void setEntryId(Long entryId) {
+        this.entryId = entryId;
+    }
+
+    public Long getCriterionId() {
+        return criterionId;
+    }
+
+    public void setCriterionId(Long criterionId) {
+        this.criterionId = criterionId;
+    }
+
+    @Override
+    public boolean equals(Object object) {
+        if (this == object) {
+            return true;
+        }
+        if (!(object instanceof EvaluationScoreId other)) {
+            return false;
+        }
+        return Objects.equals(entryId, other.entryId)
+            && Objects.equals(criterionId, other.criterionId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(entryId, criterionId);
+    }
+}

--- a/src/backend/src/main/java/team/projectpulse/evaluation/domain/EvaluationSubmission.java
+++ b/src/backend/src/main/java/team/projectpulse/evaluation/domain/EvaluationSubmission.java
@@ -1,0 +1,134 @@
+package team.projectpulse.evaluation.domain;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import team.projectpulse.team.domain.Team;
+import team.projectpulse.user.domain.User;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(
+    name = "evaluation_submissions",
+    uniqueConstraints = {
+        @UniqueConstraint(name = "uk_evaluation_submission_evaluator_week", columnNames = {"evaluator_student_id", "week"})
+    }
+)
+public class EvaluationSubmission {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "submission_id")
+    private Long submissionId;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "team_id", nullable = false)
+    private Team team;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "evaluator_student_id", nullable = false)
+    private User evaluatorStudent;
+
+    @Column(name = "week", nullable = false, length = 20)
+    private String week;
+
+    @OneToMany(mappedBy = "submission", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<EvaluationEntry> entries = new ArrayList<>();
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    @PrePersist
+    void onCreate() {
+        LocalDateTime now = LocalDateTime.now();
+        createdAt = now;
+        updatedAt = now;
+    }
+
+    @PreUpdate
+    void onUpdate() {
+        updatedAt = LocalDateTime.now();
+    }
+
+    public void addEntry(EvaluationEntry entry) {
+        entry.setSubmission(this);
+        entries.add(entry);
+    }
+
+    public void clearEntries() {
+        entries.clear();
+    }
+
+    public Long getSubmissionId() {
+        return submissionId;
+    }
+
+    public void setSubmissionId(Long submissionId) {
+        this.submissionId = submissionId;
+    }
+
+    public Team getTeam() {
+        return team;
+    }
+
+    public void setTeam(Team team) {
+        this.team = team;
+    }
+
+    public User getEvaluatorStudent() {
+        return evaluatorStudent;
+    }
+
+    public void setEvaluatorStudent(User evaluatorStudent) {
+        this.evaluatorStudent = evaluatorStudent;
+    }
+
+    public String getWeek() {
+        return week;
+    }
+
+    public void setWeek(String week) {
+        this.week = week;
+    }
+
+    public List<EvaluationEntry> getEntries() {
+        return entries;
+    }
+
+    public void setEntries(List<EvaluationEntry> entries) {
+        this.entries = entries;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(LocalDateTime createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public LocalDateTime getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public void setUpdatedAt(LocalDateTime updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+}

--- a/src/backend/src/main/java/team/projectpulse/evaluation/domain/InvalidPeerEvaluationException.java
+++ b/src/backend/src/main/java/team/projectpulse/evaluation/domain/InvalidPeerEvaluationException.java
@@ -1,0 +1,8 @@
+package team.projectpulse.evaluation.domain;
+
+public class InvalidPeerEvaluationException extends RuntimeException {
+
+    public InvalidPeerEvaluationException(String message) {
+        super(message);
+    }
+}

--- a/src/backend/src/main/java/team/projectpulse/evaluation/domain/PeerEvaluationSubmissionNotFoundException.java
+++ b/src/backend/src/main/java/team/projectpulse/evaluation/domain/PeerEvaluationSubmissionNotFoundException.java
@@ -1,0 +1,8 @@
+package team.projectpulse.evaluation.domain;
+
+public class PeerEvaluationSubmissionNotFoundException extends RuntimeException {
+
+    public PeerEvaluationSubmissionNotFoundException(Long submissionId) {
+        super("No peer evaluation submission found with id: " + submissionId);
+    }
+}

--- a/src/backend/src/main/java/team/projectpulse/evaluation/dto/EvaluationCriterionDto.java
+++ b/src/backend/src/main/java/team/projectpulse/evaluation/dto/EvaluationCriterionDto.java
@@ -1,0 +1,9 @@
+package team.projectpulse.evaluation.dto;
+
+public record EvaluationCriterionDto(
+    Long criterionId,
+    String criterion,
+    String description,
+    double maxScore
+) {
+}

--- a/src/backend/src/main/java/team/projectpulse/evaluation/dto/EvaluationCriterionScoreDraftDto.java
+++ b/src/backend/src/main/java/team/projectpulse/evaluation/dto/EvaluationCriterionScoreDraftDto.java
@@ -1,0 +1,7 @@
+package team.projectpulse.evaluation.dto;
+
+public record EvaluationCriterionScoreDraftDto(
+    Long criterionId,
+    Integer score
+) {
+}

--- a/src/backend/src/main/java/team/projectpulse/evaluation/dto/EvaluationMemberDraftDto.java
+++ b/src/backend/src/main/java/team/projectpulse/evaluation/dto/EvaluationMemberDraftDto.java
@@ -1,0 +1,13 @@
+package team.projectpulse.evaluation.dto;
+
+import java.util.List;
+
+public record EvaluationMemberDraftDto(
+    Long studentId,
+    String fullName,
+    boolean self,
+    String publicComment,
+    String privateComment,
+    List<EvaluationCriterionScoreDraftDto> scores
+) {
+}

--- a/src/backend/src/main/java/team/projectpulse/evaluation/dto/EvaluationWorkspace.java
+++ b/src/backend/src/main/java/team/projectpulse/evaluation/dto/EvaluationWorkspace.java
@@ -1,0 +1,22 @@
+package team.projectpulse.evaluation.dto;
+
+import java.util.List;
+
+public record EvaluationWorkspace(
+    Long sectionId,
+    String sectionName,
+    Long teamId,
+    String teamName,
+    String week,
+    String weekLabel,
+    String weekRangeLabel,
+    Long submissionId,
+    boolean submitted,
+    boolean editable,
+    boolean canSubmit,
+    String availabilityMessage,
+    String dueAt,
+    List<EvaluationCriterionDto> criteria,
+    List<EvaluationMemberDraftDto> members
+) {
+}

--- a/src/backend/src/main/java/team/projectpulse/evaluation/dto/PeerEvaluationCriterionScoreSubmission.java
+++ b/src/backend/src/main/java/team/projectpulse/evaluation/dto/PeerEvaluationCriterionScoreSubmission.java
@@ -1,0 +1,9 @@
+package team.projectpulse.evaluation.dto;
+
+import java.math.BigDecimal;
+
+public record PeerEvaluationCriterionScoreSubmission(
+    Long criterionId,
+    BigDecimal score
+) {
+}

--- a/src/backend/src/main/java/team/projectpulse/evaluation/dto/PeerEvaluationMemberSubmission.java
+++ b/src/backend/src/main/java/team/projectpulse/evaluation/dto/PeerEvaluationMemberSubmission.java
@@ -1,0 +1,11 @@
+package team.projectpulse.evaluation.dto;
+
+import java.util.List;
+
+public record PeerEvaluationMemberSubmission(
+    Long evaluateeStudentId,
+    String publicComment,
+    String privateComment,
+    List<PeerEvaluationCriterionScoreSubmission> criterionScores
+) {
+}

--- a/src/backend/src/main/java/team/projectpulse/evaluation/dto/PeerEvaluationSubmissionDetail.java
+++ b/src/backend/src/main/java/team/projectpulse/evaluation/dto/PeerEvaluationSubmissionDetail.java
@@ -1,0 +1,11 @@
+package team.projectpulse.evaluation.dto;
+
+import java.time.LocalDateTime;
+
+public record PeerEvaluationSubmissionDetail(
+    Long submissionId,
+    String week,
+    LocalDateTime submittedAt,
+    LocalDateTime updatedAt
+) {
+}

--- a/src/backend/src/main/java/team/projectpulse/evaluation/dto/PeerEvaluationSubmissionRequest.java
+++ b/src/backend/src/main/java/team/projectpulse/evaluation/dto/PeerEvaluationSubmissionRequest.java
@@ -1,0 +1,8 @@
+package team.projectpulse.evaluation.dto;
+
+import java.util.List;
+
+public record PeerEvaluationSubmissionRequest(
+    List<PeerEvaluationMemberSubmission> evaluations
+) {
+}

--- a/src/backend/src/main/java/team/projectpulse/evaluation/repository/EvaluationSubmissionRepository.java
+++ b/src/backend/src/main/java/team/projectpulse/evaluation/repository/EvaluationSubmissionRepository.java
@@ -1,0 +1,59 @@
+package team.projectpulse.evaluation.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import team.projectpulse.evaluation.domain.EvaluationSubmission;
+
+import java.util.Optional;
+
+public interface EvaluationSubmissionRepository extends JpaRepository<EvaluationSubmission, Long> {
+
+    default Optional<EvaluationSubmission> findByEvaluatorStudentIdAndWeek(Long evaluatorStudentId, String week) {
+        Optional<EvaluationSubmission> submission = findSubmissionByEvaluatorStudentIdAndWeek(evaluatorStudentId, week);
+        submission.ifPresent(found -> loadScores(found.getSubmissionId()));
+        return submission;
+    }
+
+    default Optional<EvaluationSubmission> findBySubmissionIdAndEvaluatorStudentId(Long submissionId, Long evaluatorStudentId) {
+        Optional<EvaluationSubmission> submission = findSubmissionBySubmissionIdAndEvaluatorStudentId(submissionId, evaluatorStudentId);
+        submission.ifPresent(found -> loadScores(found.getSubmissionId()));
+        return submission;
+    }
+
+    @Query("""
+        select distinct s from EvaluationSubmission s
+        join fetch s.team t
+        join fetch s.evaluatorStudent evaluator
+        left join fetch s.entries entry
+        left join fetch entry.evaluateeStudent evaluatee
+        where evaluator.id = :evaluatorStudentId
+          and s.week = :week
+        """)
+    Optional<EvaluationSubmission> findSubmissionByEvaluatorStudentIdAndWeek(
+        @Param("evaluatorStudentId") Long evaluatorStudentId,
+        @Param("week") String week
+    );
+
+    @Query("""
+        select distinct s from EvaluationSubmission s
+        join fetch s.team t
+        join fetch s.evaluatorStudent evaluator
+        left join fetch s.entries entry
+        left join fetch entry.evaluateeStudent evaluatee
+        where s.submissionId = :submissionId
+          and evaluator.id = :evaluatorStudentId
+        """)
+    Optional<EvaluationSubmission> findSubmissionBySubmissionIdAndEvaluatorStudentId(
+        @Param("submissionId") Long submissionId,
+        @Param("evaluatorStudentId") Long evaluatorStudentId
+    );
+
+    @Query("""
+        select distinct entry from EvaluationEntry entry
+        left join fetch entry.scores score
+        left join fetch score.criterion criterion
+        where entry.submission.submissionId = :submissionId
+        """)
+    java.util.List<team.projectpulse.evaluation.domain.EvaluationEntry> loadScores(@Param("submissionId") Long submissionId);
+}

--- a/src/backend/src/main/java/team/projectpulse/evaluation/service/EvaluationService.java
+++ b/src/backend/src/main/java/team/projectpulse/evaluation/service/EvaluationService.java
@@ -1,0 +1,647 @@
+package team.projectpulse.evaluation.service;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import team.projectpulse.evaluation.domain.EvaluationEntry;
+import team.projectpulse.evaluation.domain.EvaluationScore;
+import team.projectpulse.evaluation.domain.EvaluationSubmission;
+import team.projectpulse.evaluation.domain.InvalidPeerEvaluationException;
+import team.projectpulse.evaluation.domain.PeerEvaluationSubmissionNotFoundException;
+import team.projectpulse.evaluation.dto.EvaluationCriterionDto;
+import team.projectpulse.evaluation.dto.EvaluationCriterionScoreDraftDto;
+import team.projectpulse.evaluation.dto.EvaluationMemberDraftDto;
+import team.projectpulse.evaluation.dto.EvaluationWorkspace;
+import team.projectpulse.evaluation.dto.PeerEvaluationCriterionScoreSubmission;
+import team.projectpulse.evaluation.dto.PeerEvaluationMemberSubmission;
+import team.projectpulse.evaluation.dto.PeerEvaluationSubmissionDetail;
+import team.projectpulse.evaluation.dto.PeerEvaluationSubmissionRequest;
+import team.projectpulse.evaluation.repository.EvaluationSubmissionRepository;
+import team.projectpulse.rubric.domain.Criterion;
+import team.projectpulse.rubric.domain.Rubric;
+import team.projectpulse.rubric.repository.RubricRepository;
+import team.projectpulse.section.domain.Section;
+import team.projectpulse.team.domain.Team;
+import team.projectpulse.team.repository.TeamRepository;
+import team.projectpulse.user.domain.User;
+import team.projectpulse.user.repository.UserRepository;
+
+import java.math.BigDecimal;
+import java.time.Clock;
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.WeekFields;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+@Service
+public class EvaluationService {
+
+    private static final int MAX_COMMENT_LENGTH = 2000;
+    private static final DateTimeFormatter DATE_FORMAT = DateTimeFormatter.ofPattern("MM-dd-yyyy");
+    private static final WeekFields ISO = WeekFields.ISO;
+
+    private final EvaluationSubmissionRepository evaluationSubmissionRepository;
+    private final UserRepository userRepository;
+    private final TeamRepository teamRepository;
+    private final RubricRepository rubricRepository;
+    private final Clock clock;
+
+    @Autowired
+    public EvaluationService(
+        EvaluationSubmissionRepository evaluationSubmissionRepository,
+        UserRepository userRepository,
+        TeamRepository teamRepository,
+        RubricRepository rubricRepository
+    ) {
+        this(evaluationSubmissionRepository, userRepository, teamRepository, rubricRepository, Clock.systemDefaultZone());
+    }
+
+    EvaluationService(
+        EvaluationSubmissionRepository evaluationSubmissionRepository,
+        UserRepository userRepository,
+        TeamRepository teamRepository,
+        RubricRepository rubricRepository,
+        Clock clock
+    ) {
+        this.evaluationSubmissionRepository = evaluationSubmissionRepository;
+        this.userRepository = userRepository;
+        this.teamRepository = teamRepository;
+        this.rubricRepository = rubricRepository;
+        this.clock = clock;
+    }
+
+    @Transactional(readOnly = true)
+    public EvaluationWorkspace loadWorkspace(String studentEmail) {
+        User student = requireStudent(studentEmail);
+        Section section = student.getSection();
+        if (section == null) {
+            return unavailableWorkspace(
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                "You must belong to a senior design section before submitting peer evaluations."
+            );
+        }
+
+        Team baseTeam = teamRepository.findByStudentIdWithSection(student.getId())
+            .orElse(null);
+        if (baseTeam == null) {
+            return unavailableWorkspace(
+                section.getSectionId(),
+                section.getSectionName(),
+                null,
+                null,
+                null,
+                null,
+                null,
+                "You must be assigned to a senior design team before submitting peer evaluations."
+            );
+        }
+
+        Team team = teamRepository.findDetailById(baseTeam.getTeamId())
+            .orElse(baseTeam);
+
+        LocalDate today = LocalDate.now(clock);
+        String currentWeek = toIsoWeek(today);
+        String previousWeek = toIsoWeek(today.minusWeeks(1));
+        LocalDateTime dueAt = resolveDueAt(section, today);
+
+        if (!isActiveWeek(section, currentWeek)) {
+            return unavailableWorkspace(
+                section.getSectionId(),
+                section.getSectionName(),
+                team.getTeamId(),
+                team.getTeamName(),
+                previousWeek,
+                formatWeekLabel(previousWeek),
+                formatWeekRangeLabel(previousWeek),
+                "Peer evaluations can only be submitted during active weeks."
+            );
+        }
+
+        if (!weekExistsInTimeline(section, previousWeek) || !isActiveWeek(section, previousWeek)) {
+            return unavailableWorkspace(
+                section.getSectionId(),
+                section.getSectionName(),
+                team.getTeamId(),
+                team.getTeamName(),
+                previousWeek,
+                formatWeekLabel(previousWeek),
+                formatWeekRangeLabel(previousWeek),
+                "The previous week is not an active week for peer evaluations."
+            );
+        }
+
+        Rubric rubric = resolveRubric(section)
+            .orElse(null);
+        if (rubric == null) {
+            return unavailableWorkspace(
+                section.getSectionId(),
+                section.getSectionName(),
+                team.getTeamId(),
+                team.getTeamName(),
+                previousWeek,
+                formatWeekLabel(previousWeek),
+                formatWeekRangeLabel(previousWeek),
+                "This section does not have a peer evaluation rubric configured."
+            );
+        }
+
+        List<Criterion> criteria = sortCriteria(rubric.getCriteria());
+        validateRubricCriteria(criteria);
+
+        List<User> members = sortMembers(team, student.getId());
+        Optional<EvaluationSubmission> existingSubmission = evaluationSubmissionRepository
+            .findByEvaluatorStudentIdAndWeek(student.getId(), previousWeek);
+
+        boolean beforeOrAtDeadline = !LocalDateTime.now(clock).isAfter(dueAt);
+        if (!beforeOrAtDeadline && existingSubmission.isEmpty()) {
+            return new EvaluationWorkspace(
+                section.getSectionId(),
+                section.getSectionName(),
+                team.getTeamId(),
+                team.getTeamName(),
+                previousWeek,
+                formatWeekLabel(previousWeek),
+                formatWeekRangeLabel(previousWeek),
+                null,
+                false,
+                false,
+                false,
+                "The peer-evaluation submission window has closed.",
+                dueAt.toString(),
+                criteria.stream().map(this::toCriterionDto).toList(),
+                List.of()
+            );
+        }
+
+        EvaluationSubmission submission = existingSubmission.orElse(null);
+        return new EvaluationWorkspace(
+            section.getSectionId(),
+            section.getSectionName(),
+            team.getTeamId(),
+            team.getTeamName(),
+            previousWeek,
+            formatWeekLabel(previousWeek),
+            formatWeekRangeLabel(previousWeek),
+            submission == null ? null : submission.getSubmissionId(),
+            submission != null,
+            beforeOrAtDeadline,
+            beforeOrAtDeadline,
+            beforeOrAtDeadline ? null : "The peer-evaluation submission window has closed.",
+            dueAt.toString(),
+            criteria.stream().map(this::toCriterionDto).toList(),
+            buildDraftMembers(members, criteria, submission, student.getId())
+        );
+    }
+
+    @Transactional
+    public PeerEvaluationSubmissionDetail createSubmission(String studentEmail, PeerEvaluationSubmissionRequest request) {
+        SubmissionContext context = requireSubmissionContext(studentEmail);
+        if (evaluationSubmissionRepository.findByEvaluatorStudentIdAndWeek(context.student().getId(), context.previousWeek()).isPresent()) {
+            throw new InvalidPeerEvaluationException("Peer evaluation has already been submitted for this week.");
+        }
+
+        EvaluationSubmission submission = new EvaluationSubmission();
+        submission.setTeam(context.team());
+        submission.setEvaluatorStudent(context.student());
+        submission.setWeek(context.previousWeek());
+
+        applySubmission(submission, request, context);
+        EvaluationSubmission saved = evaluationSubmissionRepository.save(submission);
+        return toSubmissionDetail(saved);
+    }
+
+    @Transactional
+    public PeerEvaluationSubmissionDetail updateSubmission(String studentEmail, Long submissionId, PeerEvaluationSubmissionRequest request) {
+        SubmissionContext context = requireSubmissionContext(studentEmail);
+        EvaluationSubmission submission = evaluationSubmissionRepository
+            .findBySubmissionIdAndEvaluatorStudentId(submissionId, context.student().getId())
+            .orElseThrow(() -> new PeerEvaluationSubmissionNotFoundException(submissionId));
+
+        removeExistingEntries(submission);
+        applySubmission(submission, request, context);
+        EvaluationSubmission saved = evaluationSubmissionRepository.save(submission);
+        return toSubmissionDetail(saved);
+    }
+
+    private void applySubmission(
+        EvaluationSubmission submission,
+        PeerEvaluationSubmissionRequest request,
+        SubmissionContext context
+    ) {
+        Map<Long, User> membersById = context.members().stream()
+            .collect(java.util.stream.Collectors.toMap(User::getId, member -> member, (left, right) -> left, LinkedHashMap::new));
+        Map<Long, Criterion> criteriaById = context.criteria().stream()
+            .collect(java.util.stream.Collectors.toMap(Criterion::getCriterionId, criterion -> criterion, (left, right) -> left, LinkedHashMap::new));
+
+        validateRequest(request, membersById.keySet(), criteriaById);
+        for (PeerEvaluationMemberSubmission evaluation : request.evaluations()) {
+            EvaluationEntry entry = new EvaluationEntry();
+            entry.setEvaluateeStudent(membersById.get(evaluation.evaluateeStudentId()));
+            entry.setPublicComment(normalizeComment(evaluation.publicComment(), "Public comments"));
+            entry.setPrivateComment(normalizeComment(evaluation.privateComment(), "Private comments"));
+
+            for (PeerEvaluationCriterionScoreSubmission criterionScore : evaluation.criterionScores()) {
+                EvaluationScore score = new EvaluationScore();
+                score.setCriterion(criteriaById.get(criterionScore.criterionId()));
+                score.setScore(requireScore(criterionScore.score(), criteriaById.get(criterionScore.criterionId())));
+                entry.addScore(score);
+            }
+
+            submission.addEntry(entry);
+        }
+    }
+
+    private void removeExistingEntries(EvaluationSubmission submission) {
+        if (submission.getEntries().isEmpty()) {
+            return;
+        }
+
+        submission.clearEntries();
+        evaluationSubmissionRepository.saveAndFlush(submission);
+    }
+
+    private SubmissionContext requireSubmissionContext(String studentEmail) {
+        User student = requireStudent(studentEmail);
+        Section section = student.getSection();
+        if (section == null) {
+            throw new InvalidPeerEvaluationException("You must belong to a senior design section before submitting peer evaluations.");
+        }
+
+        Team baseTeam = teamRepository.findByStudentIdWithSection(student.getId())
+            .orElseThrow(() -> new InvalidPeerEvaluationException("You must be assigned to a senior design team before submitting peer evaluations."));
+        Team team = teamRepository.findDetailById(baseTeam.getTeamId())
+            .orElse(baseTeam);
+
+        LocalDate today = LocalDate.now(clock);
+        String currentWeek = toIsoWeek(today);
+        String previousWeek = toIsoWeek(today.minusWeeks(1));
+        LocalDateTime dueAt = resolveDueAt(section, today);
+
+        if (!isActiveWeek(section, currentWeek)) {
+            throw new InvalidPeerEvaluationException("Peer evaluations can only be submitted during active weeks.");
+        }
+        if (!weekExistsInTimeline(section, previousWeek) || !isActiveWeek(section, previousWeek)) {
+            throw new InvalidPeerEvaluationException("The previous week is not an active week for peer evaluations.");
+        }
+        if (LocalDateTime.now(clock).isAfter(dueAt)) {
+            throw new InvalidPeerEvaluationException("The peer-evaluation submission window has closed.");
+        }
+
+        Rubric rubric = resolveRubric(section)
+            .orElseThrow(() -> new InvalidPeerEvaluationException("This section does not have a peer evaluation rubric configured."));
+        List<Criterion> criteria = sortCriteria(rubric.getCriteria());
+        validateRubricCriteria(criteria);
+
+        List<User> members = sortMembers(team, student.getId());
+        return new SubmissionContext(student, section, team, previousWeek, dueAt, members, criteria);
+    }
+
+    private void validateRequest(
+        PeerEvaluationSubmissionRequest request,
+        Set<Long> expectedMemberIds,
+        Map<Long, Criterion> criteriaById
+    ) {
+        if (request == null || request.evaluations() == null) {
+            throw new InvalidPeerEvaluationException("Peer evaluation request is required.");
+        }
+        if (request.evaluations().size() != expectedMemberIds.size()) {
+            throw new InvalidPeerEvaluationException("Every team member must be evaluated exactly once.");
+        }
+
+        Set<Long> seenEvaluatees = new LinkedHashSet<>();
+        for (PeerEvaluationMemberSubmission evaluation : request.evaluations()) {
+            if (evaluation == null || evaluation.evaluateeStudentId() == null) {
+                throw new InvalidPeerEvaluationException("Every evaluation entry must identify the teammate being evaluated.");
+            }
+            if (!seenEvaluatees.add(evaluation.evaluateeStudentId())) {
+                throw new InvalidPeerEvaluationException("Each team member can only appear once in a peer evaluation submission.");
+            }
+            if (!expectedMemberIds.contains(evaluation.evaluateeStudentId())) {
+                throw new InvalidPeerEvaluationException("Peer evaluations may only be submitted for current team members.");
+            }
+            validateCriterionScores(evaluation.criterionScores(), criteriaById);
+            normalizeComment(evaluation.publicComment(), "Public comments");
+            normalizeComment(evaluation.privateComment(), "Private comments");
+        }
+
+        if (!seenEvaluatees.equals(expectedMemberIds)) {
+            throw new InvalidPeerEvaluationException("Every team member must be evaluated exactly once.");
+        }
+    }
+
+    private void validateCriterionScores(
+        List<PeerEvaluationCriterionScoreSubmission> criterionScores,
+        Map<Long, Criterion> criteriaById
+    ) {
+        if (criterionScores == null || criterionScores.size() != criteriaById.size()) {
+            throw new InvalidPeerEvaluationException("Every rubric criterion must be scored exactly once.");
+        }
+
+        Set<Long> seenCriterionIds = new LinkedHashSet<>();
+        for (PeerEvaluationCriterionScoreSubmission criterionScore : criterionScores) {
+            if (criterionScore == null || criterionScore.criterionId() == null) {
+                throw new InvalidPeerEvaluationException("Every rubric criterion must be scored exactly once.");
+            }
+            if (!seenCriterionIds.add(criterionScore.criterionId())) {
+                throw new InvalidPeerEvaluationException("Each rubric criterion can only be scored once per teammate.");
+            }
+            Criterion criterion = criteriaById.get(criterionScore.criterionId());
+            if (criterion == null) {
+                throw new InvalidPeerEvaluationException("Peer evaluations must use the current section rubric.");
+            }
+            requireScore(criterionScore.score(), criterion);
+        }
+
+        if (!seenCriterionIds.equals(criteriaById.keySet())) {
+            throw new InvalidPeerEvaluationException("Every rubric criterion must be scored exactly once.");
+        }
+    }
+
+    private Integer requireScore(BigDecimal score, Criterion criterion) {
+        if (score == null) {
+            throw new InvalidPeerEvaluationException("Scores are required for every rubric criterion.");
+        }
+        if (score.stripTrailingZeros().scale() > 0) {
+            throw new InvalidPeerEvaluationException("Scores must be integers.");
+        }
+
+        int maxScore = requireIntegerMaxScore(criterion);
+        int intScore = score.intValueExact();
+        if (intScore < 1 || intScore > maxScore) {
+            throw new InvalidPeerEvaluationException(
+                "Scores must be between 1 and " + maxScore + " for criterion \"" + criterion.getCriterion() + "\"."
+            );
+        }
+        return intScore;
+    }
+
+    private String normalizeComment(String value, String label) {
+        if (value == null) {
+            return null;
+        }
+        String normalized = value.trim();
+        if (normalized.isEmpty()) {
+            return null;
+        }
+        if (normalized.length() > MAX_COMMENT_LENGTH) {
+            throw new InvalidPeerEvaluationException(label + " must be 2000 characters or fewer.");
+        }
+        return normalized;
+    }
+
+    private Optional<Rubric> resolveRubric(Section section) {
+        if (section.getRubricId() == null) {
+            return Optional.empty();
+        }
+        return rubricRepository.findByIdWithCriteria(section.getRubricId());
+    }
+
+    private void validateRubricCriteria(List<Criterion> criteria) {
+        if (criteria.isEmpty()) {
+            throw new InvalidPeerEvaluationException("This section does not have a peer evaluation rubric configured.");
+        }
+        for (Criterion criterion : criteria) {
+            requireIntegerMaxScore(criterion);
+        }
+    }
+
+    private int requireIntegerMaxScore(Criterion criterion) {
+        double maxScore = criterion.getMaxScore();
+        if (maxScore < 1 || maxScore != Math.floor(maxScore)) {
+            throw new InvalidPeerEvaluationException("Peer evaluation rubric criteria must use integer max scores.");
+        }
+        return (int) maxScore;
+    }
+
+    private List<User> sortMembers(Team team, Long currentStudentId) {
+        List<User> members = new ArrayList<>(team.getStudents());
+        members.sort(Comparator
+            .comparing((User member) -> !member.getId().equals(currentStudentId))
+            .thenComparing(member -> member.getLastName().toLowerCase(Locale.ROOT))
+            .thenComparing(member -> member.getFirstName().toLowerCase(Locale.ROOT))
+        );
+
+        boolean includesCurrentStudent = members.stream().anyMatch(member -> member.getId().equals(currentStudentId));
+        if (!includesCurrentStudent) {
+            throw new InvalidPeerEvaluationException("You must be assigned to the current team roster to submit peer evaluations.");
+        }
+        return members;
+    }
+
+    private List<EvaluationMemberDraftDto> buildDraftMembers(
+        List<User> members,
+        List<Criterion> criteria,
+        EvaluationSubmission submission,
+        Long currentStudentId
+    ) {
+        Map<Long, EvaluationEntry> entriesByEvaluateeId = new LinkedHashMap<>();
+        if (submission != null) {
+            for (EvaluationEntry entry : submission.getEntries()) {
+                entriesByEvaluateeId.put(entry.getEvaluateeStudent().getId(), entry);
+            }
+        }
+
+        return members.stream()
+            .map(member -> {
+                EvaluationEntry existingEntry = entriesByEvaluateeId.get(member.getId());
+                Map<Long, Integer> existingScores = new LinkedHashMap<>();
+                if (existingEntry != null) {
+                    for (EvaluationScore score : existingEntry.getScores()) {
+                        existingScores.put(score.getCriterion().getCriterionId(), score.getScore());
+                    }
+                }
+
+                List<EvaluationCriterionScoreDraftDto> draftScores = criteria.stream()
+                    .map(criterion -> new EvaluationCriterionScoreDraftDto(
+                        criterion.getCriterionId(),
+                        existingScores.get(criterion.getCriterionId())
+                    ))
+                    .toList();
+
+                return new EvaluationMemberDraftDto(
+                    member.getId(),
+                    fullName(member),
+                    member.getId().equals(currentStudentId),
+                    existingEntry == null ? null : existingEntry.getPublicComment(),
+                    existingEntry == null ? null : existingEntry.getPrivateComment(),
+                    draftScores
+                );
+            })
+            .toList();
+    }
+
+    private EvaluationCriterionDto toCriterionDto(Criterion criterion) {
+        return new EvaluationCriterionDto(
+            criterion.getCriterionId(),
+            criterion.getCriterion(),
+            criterion.getDescription(),
+            criterion.getMaxScore()
+        );
+    }
+
+    private PeerEvaluationSubmissionDetail toSubmissionDetail(EvaluationSubmission submission) {
+        return new PeerEvaluationSubmissionDetail(
+            submission.getSubmissionId(),
+            submission.getWeek(),
+            submission.getCreatedAt(),
+            submission.getUpdatedAt()
+        );
+    }
+
+    private EvaluationWorkspace unavailableWorkspace(
+        Long sectionId,
+        String sectionName,
+        Long teamId,
+        String teamName,
+        String week,
+        String weekLabel,
+        String weekRangeLabel,
+        String message
+    ) {
+        return new EvaluationWorkspace(
+            sectionId,
+            sectionName,
+            teamId,
+            teamName,
+            week,
+            weekLabel,
+            weekRangeLabel,
+            null,
+            false,
+            false,
+            false,
+            message,
+            null,
+            List.of(),
+            List.of()
+        );
+    }
+
+    private User requireStudent(String studentEmail) {
+        User student = userRepository.findByEmail(studentEmail)
+            .orElseThrow(() -> new InvalidPeerEvaluationException("No student account found for the current user."));
+
+        if (!isStudent(student)) {
+            throw new InvalidPeerEvaluationException("Only students can submit peer evaluations.");
+        }
+        return student;
+    }
+
+    private boolean isStudent(User user) {
+        String roles = user.getRoles() == null ? "" : user.getRoles().toLowerCase(Locale.ROOT);
+        return List.of(roles.split("\\s+")).contains("student");
+    }
+
+    private boolean weekExistsInTimeline(Section section, String week) {
+        return deriveSectionWeeks(section).contains(week);
+    }
+
+    private boolean isActiveWeek(Section section, String week) {
+        return section.getActiveWeeks() != null && section.getActiveWeeks().contains(week);
+    }
+
+    private List<String> deriveSectionWeeks(Section section) {
+        if (section.getStartDate() == null || section.getEndDate() == null) {
+            return section.getActiveWeeks() == null ? List.of() : new ArrayList<>(section.getActiveWeeks());
+        }
+
+        LocalDate cursor = toMonday(section.getStartDate());
+        LocalDate end = toMonday(section.getEndDate());
+        List<String> weeks = new ArrayList<>();
+        while (!cursor.isAfter(end)) {
+            weeks.add(toIsoWeek(cursor));
+            cursor = cursor.plusWeeks(1);
+        }
+        return weeks;
+    }
+
+    private LocalDateTime resolveDueAt(Section section, LocalDate today) {
+        DayOfWeek dueDay;
+        try {
+            dueDay = DayOfWeek.valueOf(section.getPeerEvaluationWeeklyDueDay().trim().toUpperCase(Locale.ROOT));
+        } catch (RuntimeException ex) {
+            throw new InvalidPeerEvaluationException("Peer evaluation due day is not configured correctly for this section.");
+        }
+
+        LocalTime dueTime;
+        try {
+            dueTime = LocalTime.parse(section.getPeerEvaluationDueTime().trim());
+        } catch (RuntimeException ex) {
+            throw new InvalidPeerEvaluationException("Peer evaluation due time is not configured correctly for this section.");
+        }
+
+        LocalDate weekStart = toMonday(today);
+        return LocalDateTime.of(weekStart.with(dueDay), dueTime);
+    }
+
+    private List<Criterion> sortCriteria(List<Criterion> criteria) {
+        return criteria.stream()
+            .sorted(Comparator.comparing(Criterion::getCriterionId))
+            .toList();
+    }
+
+    private String fullName(User user) {
+        return user.getFirstName() + " " + user.getLastName();
+    }
+
+    private LocalDate toMonday(LocalDate date) {
+        return date.with(DayOfWeek.MONDAY);
+    }
+
+    private String toIsoWeek(LocalDate date) {
+        int weekYear = date.get(ISO.weekBasedYear());
+        int weekNumber = date.get(ISO.weekOfWeekBasedYear());
+        return "%d-W%02d".formatted(weekYear, weekNumber);
+    }
+
+    private String formatWeekLabel(String isoWeek) {
+        String[] parts = isoWeek.split("-W");
+        return "Week " + Integer.parseInt(parts[1]) + " (" + parts[0] + ")";
+    }
+
+    private String formatWeekRangeLabel(String isoWeek) {
+        LocalDate start = parseIsoWeekStart(isoWeek);
+        LocalDate end = start.plusDays(6);
+        return DATE_FORMAT.format(start) + " -- " + DATE_FORMAT.format(end);
+    }
+
+    private LocalDate parseIsoWeekStart(String isoWeek) {
+        if (isoWeek == null || !isoWeek.matches("\\d{4}-W\\d{2}")) {
+            throw new InvalidPeerEvaluationException("Invalid ISO week format.");
+        }
+        String[] parts = isoWeek.split("-W");
+        int year = Integer.parseInt(parts[0]);
+        int week = Integer.parseInt(parts[1]);
+        return LocalDate.of(year, 1, 4)
+            .with(ISO.weekOfWeekBasedYear(), week)
+            .with(ISO.dayOfWeek(), 1);
+    }
+
+    private record SubmissionContext(
+        User student,
+        Section section,
+        Team team,
+        String previousWeek,
+        LocalDateTime dueAt,
+        List<User> members,
+        List<Criterion> criteria
+    ) {
+    }
+}

--- a/src/backend/src/main/java/team/projectpulse/rubric/repository/RubricRepository.java
+++ b/src/backend/src/main/java/team/projectpulse/rubric/repository/RubricRepository.java
@@ -1,8 +1,20 @@
 package team.projectpulse.rubric.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import team.projectpulse.rubric.domain.Rubric;
+
+import java.util.Optional;
 
 public interface RubricRepository extends JpaRepository<Rubric, Long> {
     boolean existsByRubricNameIgnoreCase(String rubricName);
+
+    @Query("""
+        select distinct r from Rubric r
+        left join fetch r.criteria c
+        where r.rubricId = :rubricId
+        order by c.criterionId asc
+        """)
+    Optional<Rubric> findByIdWithCriteria(@Param("rubricId") Long rubricId);
 }

--- a/src/backend/src/main/resources/db/migration/V8__peer_evaluations.sql
+++ b/src/backend/src/main/resources/db/migration/V8__peer_evaluations.sql
@@ -1,0 +1,50 @@
+-- V8: Peer evaluations
+
+CREATE TABLE IF NOT EXISTS evaluation_submissions (
+    submission_id         BIGINT AUTO_INCREMENT PRIMARY KEY,
+    team_id               BIGINT      NOT NULL,
+    evaluator_student_id  BIGINT      NOT NULL,
+    week                  VARCHAR(20) NOT NULL,
+    created_at            TIMESTAMP   NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at            TIMESTAMP   NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    CONSTRAINT fk_evaluation_submissions_team
+        FOREIGN KEY (team_id) REFERENCES teams(team_id) ON DELETE CASCADE,
+    CONSTRAINT fk_evaluation_submissions_evaluator
+        FOREIGN KEY (evaluator_student_id) REFERENCES users(id) ON DELETE CASCADE,
+    CONSTRAINT uk_evaluation_submissions_evaluator_week
+        UNIQUE (evaluator_student_id, week)
+);
+
+CREATE TABLE IF NOT EXISTS evaluation_entries (
+    entry_id               BIGINT AUTO_INCREMENT PRIMARY KEY,
+    submission_id          BIGINT NOT NULL,
+    evaluatee_student_id   BIGINT NOT NULL,
+    public_comment         TEXT,
+    private_comment        TEXT,
+    CONSTRAINT fk_evaluation_entries_submission
+        FOREIGN KEY (submission_id) REFERENCES evaluation_submissions(submission_id) ON DELETE CASCADE,
+    CONSTRAINT fk_evaluation_entries_evaluatee
+        FOREIGN KEY (evaluatee_student_id) REFERENCES users(id) ON DELETE CASCADE,
+    CONSTRAINT uk_evaluation_entries_submission_evaluatee
+        UNIQUE (submission_id, evaluatee_student_id)
+);
+
+CREATE TABLE IF NOT EXISTS evaluation_scores (
+    entry_id       BIGINT NOT NULL,
+    criterion_id   BIGINT NOT NULL,
+    score          INT    NOT NULL,
+    PRIMARY KEY (entry_id, criterion_id),
+    CONSTRAINT fk_evaluation_scores_entry
+        FOREIGN KEY (entry_id) REFERENCES evaluation_entries(entry_id) ON DELETE CASCADE,
+    CONSTRAINT fk_evaluation_scores_criterion
+        FOREIGN KEY (criterion_id) REFERENCES criteria(criterion_id) ON DELETE CASCADE
+);
+
+CREATE INDEX idx_evaluation_submissions_week
+    ON evaluation_submissions (week);
+CREATE INDEX idx_evaluation_submissions_team_week
+    ON evaluation_submissions (team_id, week);
+CREATE INDEX idx_evaluation_submissions_evaluator_week
+    ON evaluation_submissions (evaluator_student_id, week);
+CREATE INDEX idx_evaluation_entries_evaluatee
+    ON evaluation_entries (evaluatee_student_id);

--- a/src/backend/src/test/java/team/projectpulse/activity/controller/ActivityControllerIntegrationTest.java
+++ b/src/backend/src/test/java/team/projectpulse/activity/controller/ActivityControllerIntegrationTest.java
@@ -2,8 +2,8 @@ package team.projectpulse.activity.controller;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.ActiveProfiles;
@@ -17,6 +17,8 @@ import team.projectpulse.activity.dto.ActivityDetail;
 import team.projectpulse.activity.dto.ActivityWeekOption;
 import team.projectpulse.activity.dto.ActivityWorkspace;
 import team.projectpulse.activity.service.ActivityService;
+import team.projectpulse.config.ControllerTestSecurityConfig;
+import team.projectpulse.config.SecurityConfig;
 
 import java.math.BigDecimal;
 import java.util.List;
@@ -31,8 +33,8 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@SpringBootTest
-@AutoConfigureMockMvc
+@WebMvcTest(controllers = ActivityController.class)
+@Import({ActivityExceptionHandler.class, SecurityConfig.class, ControllerTestSecurityConfig.class})
 @ActiveProfiles("test")
 class ActivityControllerIntegrationTest {
 

--- a/src/backend/src/test/java/team/projectpulse/config/ControllerTestSecurityConfig.java
+++ b/src/backend/src/test/java/team/projectpulse/config/ControllerTestSecurityConfig.java
@@ -1,0 +1,50 @@
+package team.projectpulse.config;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@TestConfiguration
+public class ControllerTestSecurityConfig {
+
+    @Bean
+    UserDetailsService userDetailsService() {
+        return username -> User.withUsername(username)
+            .password("{noop}password")
+            .roles("STUDENT")
+            .build();
+    }
+
+    @Bean
+    PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    JwtUtils jwtUtils() {
+        return new JwtUtils("test-secret-key-for-testing-only-32chars!!");
+    }
+
+    @Bean
+    JwtAuthFilter jwtAuthFilter(JwtUtils jwtUtils) {
+        return new JwtAuthFilter(jwtUtils) {
+            @Override
+            protected void doFilterInternal(
+                HttpServletRequest request,
+                HttpServletResponse response,
+                FilterChain filterChain
+            ) throws ServletException, IOException {
+                filterChain.doFilter(request, response);
+            }
+        };
+    }
+}

--- a/src/backend/src/test/java/team/projectpulse/evaluation/controller/PeerEvaluationControllerIntegrationTest.java
+++ b/src/backend/src/test/java/team/projectpulse/evaluation/controller/PeerEvaluationControllerIntegrationTest.java
@@ -1,0 +1,291 @@
+package team.projectpulse.evaluation.controller;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Primary;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.filter.OncePerRequestFilter;
+import team.projectpulse.config.JwtAuthFilter;
+import team.projectpulse.config.JwtUtils;
+import team.projectpulse.config.SecurityConfig;
+import team.projectpulse.evaluation.domain.InvalidPeerEvaluationException;
+import team.projectpulse.evaluation.domain.PeerEvaluationSubmissionNotFoundException;
+import team.projectpulse.evaluation.dto.EvaluationCriterionDto;
+import team.projectpulse.evaluation.dto.EvaluationCriterionScoreDraftDto;
+import team.projectpulse.evaluation.dto.EvaluationMemberDraftDto;
+import team.projectpulse.evaluation.dto.EvaluationWorkspace;
+import team.projectpulse.evaluation.dto.PeerEvaluationSubmissionDetail;
+import team.projectpulse.evaluation.service.EvaluationService;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = PeerEvaluationController.class)
+@Import({PeerEvaluationExceptionHandler.class, SecurityConfig.class, PeerEvaluationControllerIntegrationTest.TestConfig.class})
+@ActiveProfiles("test")
+class PeerEvaluationControllerIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private StubEvaluationService evaluationService;
+
+    @BeforeEach
+    void resetServiceState() {
+        evaluationService.workspace = null;
+        evaluationService.detail = null;
+        evaluationService.invalidMessage = null;
+        evaluationService.notFoundSubmissionId = null;
+    }
+
+    @Test
+    @WithMockUser(username = "ava@tcu.edu", roles = "STUDENT")
+    void should_LoadWorkspace_When_StudentRequestsIt() throws Exception {
+        evaluationService.workspace = buildWorkspace();
+
+        mockMvc.perform(get("/api/v1/peer-evaluations/workspace"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.flag").value(true))
+            .andExpect(jsonPath("$.data.sectionName").value("Spring 2026 - Section A"))
+            .andExpect(jsonPath("$.data.teamName").value("Pulse Analytics"))
+            .andExpect(jsonPath("$.data.criteria[0].criterion").value("Participation"))
+            .andExpect(jsonPath("$.data.members[0].fullName").value("Ava Johnson"));
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void should_ReturnForbidden_When_AdminLoadsWorkspace() throws Exception {
+        mockMvc.perform(get("/api/v1/peer-evaluations/workspace"))
+            .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @WithMockUser(roles = "INSTRUCTOR")
+    void should_ReturnForbidden_When_InstructorLoadsWorkspace() throws Exception {
+        mockMvc.perform(get("/api/v1/peer-evaluations/workspace"))
+            .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void should_ReturnUnauthorized_When_UnauthenticatedUserLoadsWorkspace() throws Exception {
+        mockMvc.perform(get("/api/v1/peer-evaluations/workspace"))
+            .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @WithMockUser(username = "ava@tcu.edu", roles = "STUDENT")
+    void should_CreateSubmission_When_StudentSubmitsValidPayload() throws Exception {
+        evaluationService.detail = new PeerEvaluationSubmissionDetail(900L, "2026-W16", LocalDateTime.now(), LocalDateTime.now());
+
+        mockMvc.perform(post("/api/v1/peer-evaluations")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(validPayload()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.flag").value(true))
+            .andExpect(jsonPath("$.message").value("Peer evaluation has been submitted."))
+            .andExpect(jsonPath("$.data.submissionId").value(900));
+    }
+
+    @Test
+    @WithMockUser(username = "ava@tcu.edu", roles = "STUDENT")
+    void should_UpdateSubmission_When_StudentConfirmsChanges() throws Exception {
+        evaluationService.detail = new PeerEvaluationSubmissionDetail(900L, "2026-W16", LocalDateTime.now(), LocalDateTime.now());
+
+        mockMvc.perform(put("/api/v1/peer-evaluations/900")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(validPayload()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.flag").value(true))
+            .andExpect(jsonPath("$.message").value("Peer evaluation has been updated."));
+    }
+
+    @Test
+    @WithMockUser(username = "ava@tcu.edu", roles = "STUDENT")
+    void should_ReturnBadRequest_When_SubmissionPayloadIsInvalid() throws Exception {
+        evaluationService.invalidMessage = "Scores must be integers.";
+
+        mockMvc.perform(post("/api/v1/peer-evaluations")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(validPayload()))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.flag").value(false))
+            .andExpect(jsonPath("$.code").value(400))
+            .andExpect(jsonPath("$.message").value("Scores must be integers."));
+    }
+
+    @Test
+    @WithMockUser(username = "ava@tcu.edu", roles = "STUDENT")
+    void should_ReturnNotFound_When_SubmissionDoesNotExist() throws Exception {
+        evaluationService.notFoundSubmissionId = 999L;
+
+        mockMvc.perform(put("/api/v1/peer-evaluations/999")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(validPayload()))
+            .andExpect(status().isNotFound())
+            .andExpect(jsonPath("$.flag").value(false))
+            .andExpect(jsonPath("$.code").value(404))
+            .andExpect(jsonPath("$.message").value("No peer evaluation submission found with id: 999"));
+    }
+
+    private EvaluationWorkspace buildWorkspace() {
+        return new EvaluationWorkspace(
+            1L,
+            "Spring 2026 - Section A",
+            2001L,
+            "Pulse Analytics",
+            "2026-W16",
+            "Week 16 (2026)",
+            "04-13-2026 -- 04-19-2026",
+            900L,
+            true,
+            true,
+            true,
+            null,
+            "2026-04-24T23:59",
+            List.of(
+                new EvaluationCriterionDto(501L, "Participation", "Participates", 10.0),
+                new EvaluationCriterionDto(502L, "Communication", "Communicates", 10.0)
+            ),
+            List.of(
+                new EvaluationMemberDraftDto(
+                    100L,
+                    "Ava Johnson",
+                    true,
+                    "Self comment",
+                    "Private self comment",
+                    List.of(
+                        new EvaluationCriterionScoreDraftDto(501L, 9),
+                        new EvaluationCriterionScoreDraftDto(502L, 10)
+                    )
+                )
+            )
+        );
+    }
+
+    private String validPayload() {
+        return """
+            {
+              "evaluations": [
+                {
+                  "evaluateeStudentId": 100,
+                  "publicComment": "Self comment",
+                  "privateComment": "Private self comment",
+                  "criterionScores": [
+                    { "criterionId": 501, "score": 9 },
+                    { "criterionId": 502, "score": 10 }
+                  ]
+                }
+              ]
+            }
+            """;
+    }
+
+    @TestConfiguration
+    static class TestConfig {
+
+        @Bean
+        @Primary
+        StubEvaluationService evaluationService() {
+            return new StubEvaluationService();
+        }
+
+        @Bean
+        UserDetailsService userDetailsService() {
+            return username -> User.withUsername(username)
+                .password("{noop}password")
+                .roles("STUDENT")
+                .build();
+        }
+
+        @Bean
+        PasswordEncoder passwordEncoder() {
+            return new BCryptPasswordEncoder();
+        }
+
+        @Bean
+        JwtUtils jwtUtils() {
+            return new JwtUtils("test-secret-key-for-testing-only-32chars!!");
+        }
+
+        @Bean
+        JwtAuthFilter jwtAuthFilter(JwtUtils jwtUtils) {
+            return new JwtAuthFilter(jwtUtils) {
+                @Override
+                protected void doFilterInternal(
+                    HttpServletRequest request,
+                    HttpServletResponse response,
+                    FilterChain filterChain
+                ) throws ServletException, IOException {
+                    filterChain.doFilter(request, response);
+                }
+            };
+        }
+    }
+
+    static class StubEvaluationService extends EvaluationService {
+
+        private EvaluationWorkspace workspace;
+        private PeerEvaluationSubmissionDetail detail;
+        private String invalidMessage;
+        private Long notFoundSubmissionId;
+
+        StubEvaluationService() {
+            super(null, null, null, null);
+        }
+
+        @Override
+        public EvaluationWorkspace loadWorkspace(String studentEmail) {
+            return workspace;
+        }
+
+        @Override
+        public PeerEvaluationSubmissionDetail createSubmission(
+            String studentEmail,
+            team.projectpulse.evaluation.dto.PeerEvaluationSubmissionRequest request
+        ) {
+            if (invalidMessage != null) {
+                throw new InvalidPeerEvaluationException(invalidMessage);
+            }
+            return detail;
+        }
+
+        @Override
+        public PeerEvaluationSubmissionDetail updateSubmission(
+            String studentEmail,
+            Long submissionId,
+            team.projectpulse.evaluation.dto.PeerEvaluationSubmissionRequest request
+        ) {
+            if (notFoundSubmissionId != null) {
+                throw new PeerEvaluationSubmissionNotFoundException(notFoundSubmissionId);
+            }
+            if (invalidMessage != null) {
+                throw new InvalidPeerEvaluationException(invalidMessage);
+            }
+            return detail;
+        }
+    }
+}

--- a/src/backend/src/test/java/team/projectpulse/evaluation/repository/EvaluationSubmissionRepositoryIntegrationTest.java
+++ b/src/backend/src/test/java/team/projectpulse/evaluation/repository/EvaluationSubmissionRepositoryIntegrationTest.java
@@ -1,0 +1,222 @@
+package team.projectpulse.evaluation.repository;
+
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.Test;
+import org.hibernate.exception.ConstraintViolationException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import org.springframework.test.context.ActiveProfiles;
+import team.projectpulse.evaluation.domain.EvaluationEntry;
+import team.projectpulse.evaluation.domain.EvaluationScore;
+import team.projectpulse.evaluation.domain.EvaluationSubmission;
+import team.projectpulse.rubric.domain.Criterion;
+import team.projectpulse.rubric.domain.Rubric;
+import team.projectpulse.section.domain.Section;
+import team.projectpulse.team.domain.Team;
+import team.projectpulse.user.domain.User;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@DataJpaTest
+@ActiveProfiles("test")
+class EvaluationSubmissionRepositoryIntegrationTest {
+
+    @Autowired
+    private EntityManager entityManager;
+
+    @Autowired
+    private EvaluationSubmissionRepository evaluationSubmissionRepository;
+
+    @Test
+    void should_FetchSubmissionWithEntriesAndScores_When_QueryingByEvaluatorAndWeek() {
+        SeededData data = seedSubmission();
+
+        Optional<EvaluationSubmission> submission = evaluationSubmissionRepository.findByEvaluatorStudentIdAndWeek(
+            data.evaluator().getId(),
+            "2026-W16"
+        );
+
+        assertTrue(submission.isPresent());
+        assertEquals(2, submission.get().getEntries().size());
+        assertEquals(2, submission.get().getEntries().get(0).getScores().size());
+    }
+
+    @Test
+    void should_EnforceOneSubmissionPerEvaluatorPerWeek() {
+        SeededData data = seedSubmission();
+
+        RuntimeException ex = assertThrows(RuntimeException.class, () -> {
+            EvaluationSubmission duplicate = new EvaluationSubmission();
+            duplicate.setTeam(data.team());
+            duplicate.setEvaluatorStudent(data.evaluator());
+            duplicate.setWeek("2026-W16");
+            entityManager.persist(duplicate);
+            entityManager.flush();
+            entityManager.clear();
+        });
+        assertTrue(hasCause(ex, ConstraintViolationException.class));
+    }
+
+    @Test
+    void should_DeleteEntriesAndScores_When_SubmissionIsDeleted() {
+        SeededData data = seedSubmission();
+
+        evaluationSubmissionRepository.delete(data.submission());
+        entityManager.flush();
+
+        Long entryCount = entityManager.createQuery(
+            "select count(e) from EvaluationEntry e",
+            Long.class
+        ).getSingleResult();
+        Long scoreCount = entityManager.createQuery(
+            "select count(s) from EvaluationScore s",
+            Long.class
+        ).getSingleResult();
+
+        assertEquals(0L, entryCount);
+        assertEquals(0L, scoreCount);
+    }
+
+    @Test
+    void should_AllowReplacingEntriesWithSameEvaluatees_When_SubmissionIsUpdated() {
+        SeededData data = seedSubmission();
+
+        EvaluationSubmission managedSubmission = evaluationSubmissionRepository
+            .findBySubmissionIdAndEvaluatorStudentId(data.submission().getSubmissionId(), data.evaluator().getId())
+            .orElseThrow();
+
+        managedSubmission.clearEntries();
+        evaluationSubmissionRepository.saveAndFlush(managedSubmission);
+
+        EvaluationEntry selfEntry = new EvaluationEntry();
+        selfEntry.setEvaluateeStudent(data.evaluator());
+        selfEntry.setPublicComment("Updated self");
+        selfEntry.setPrivateComment("Updated private self");
+        selfEntry.addScore(persistScore(data.participation(), 10));
+        selfEntry.addScore(persistScore(data.communication(), 10));
+
+        EvaluationEntry teammateEntry = new EvaluationEntry();
+        teammateEntry.setEvaluateeStudent(data.teammate());
+        teammateEntry.setPublicComment("Updated teammate");
+        teammateEntry.setPrivateComment("Updated private teammate");
+        teammateEntry.addScore(persistScore(data.participation(), 9));
+        teammateEntry.addScore(persistScore(data.communication(), 9));
+
+        managedSubmission.addEntry(selfEntry);
+        managedSubmission.addEntry(teammateEntry);
+
+        assertDoesNotThrow(() -> evaluationSubmissionRepository.saveAndFlush(managedSubmission));
+        assertEquals(2, managedSubmission.getEntries().size());
+    }
+
+    private SeededData seedSubmission() {
+        Criterion participation = new Criterion();
+        participation.setCriterion("Participation");
+        participation.setDescription("Participates");
+        participation.setMaxScore(10);
+        entityManager.persist(participation);
+
+        Criterion communication = new Criterion();
+        communication.setCriterion("Communication");
+        communication.setDescription("Communicates");
+        communication.setMaxScore(10);
+        entityManager.persist(communication);
+
+        Rubric rubric = new Rubric();
+        rubric.setRubricName("Evaluation Test Rubric");
+        rubric.setCriteria(List.of(participation, communication));
+        entityManager.persist(rubric);
+
+        Section section = new Section();
+        section.setSectionName("Spring 2026 - Section A");
+        section.setStartDate(LocalDate.of(2026, 1, 12));
+        section.setEndDate(LocalDate.of(2026, 5, 8));
+        section.setRubricId(rubric.getRubricId());
+        entityManager.persist(section);
+
+        User ava = persistUser("Ava", "Johnson", "ava.evaluation@tcu.edu", section);
+        User mia = persistUser("Mia", "Chen", "mia.evaluation@tcu.edu", section);
+
+        Team team = new Team();
+        team.setSection(section);
+        team.setTeamName("Pulse Analytics Evaluation");
+        team.getStudents().add(ava);
+        team.getStudents().add(mia);
+        entityManager.persist(team);
+
+        EvaluationSubmission submission = new EvaluationSubmission();
+        submission.setTeam(team);
+        submission.setEvaluatorStudent(ava);
+        submission.setWeek("2026-W16");
+
+        EvaluationEntry selfEntry = new EvaluationEntry();
+        selfEntry.setEvaluateeStudent(ava);
+        selfEntry.setPublicComment("Self");
+        selfEntry.setPrivateComment("Private self");
+        selfEntry.addScore(persistScore(participation, 9));
+        selfEntry.addScore(persistScore(communication, 10));
+
+        EvaluationEntry teammateEntry = new EvaluationEntry();
+        teammateEntry.setEvaluateeStudent(mia);
+        teammateEntry.setPublicComment("Great teammate");
+        teammateEntry.setPrivateComment("Reliable");
+        teammateEntry.addScore(persistScore(participation, 8));
+        teammateEntry.addScore(persistScore(communication, 9));
+
+        submission.addEntry(selfEntry);
+        submission.addEntry(teammateEntry);
+        entityManager.persist(submission);
+        entityManager.flush();
+        entityManager.clear();
+
+        return new SeededData(ava, mia, team, submission, participation, communication);
+    }
+
+    private EvaluationScore persistScore(Criterion criterion, int value) {
+        EvaluationScore score = new EvaluationScore();
+        score.setCriterion(criterion);
+        score.setScore(value);
+        return score;
+    }
+
+    private User persistUser(String firstName, String lastName, String email, Section section) {
+        User user = new User();
+        user.setFirstName(firstName);
+        user.setLastName(lastName);
+        user.setEmail(email);
+        user.setPassword("encoded");
+        user.setRoles("student");
+        user.setEnabled(true);
+        user.setSection(section);
+        entityManager.persist(user);
+        return user;
+    }
+
+    private boolean hasCause(Throwable throwable, Class<? extends Throwable> expectedType) {
+        Throwable current = throwable;
+        while (current != null) {
+            if (expectedType.isInstance(current)) {
+                return true;
+            }
+            current = current.getCause();
+        }
+        return false;
+    }
+
+    private record SeededData(
+        User evaluator,
+        User teammate,
+        Team team,
+        EvaluationSubmission submission,
+        Criterion participation,
+        Criterion communication
+    ) {
+    }
+}

--- a/src/backend/src/test/java/team/projectpulse/evaluation/service/EvaluationServiceTest.java
+++ b/src/backend/src/test/java/team/projectpulse/evaluation/service/EvaluationServiceTest.java
@@ -1,0 +1,601 @@
+package team.projectpulse.evaluation.service;
+
+import org.junit.jupiter.api.Test;
+import team.projectpulse.evaluation.domain.EvaluationEntry;
+import team.projectpulse.evaluation.domain.EvaluationScore;
+import team.projectpulse.evaluation.domain.EvaluationSubmission;
+import team.projectpulse.evaluation.domain.InvalidPeerEvaluationException;
+import team.projectpulse.evaluation.domain.PeerEvaluationSubmissionNotFoundException;
+import team.projectpulse.evaluation.dto.EvaluationWorkspace;
+import team.projectpulse.evaluation.dto.PeerEvaluationCriterionScoreSubmission;
+import team.projectpulse.evaluation.dto.PeerEvaluationMemberSubmission;
+import team.projectpulse.evaluation.dto.PeerEvaluationSubmissionRequest;
+import team.projectpulse.evaluation.repository.EvaluationSubmissionRepository;
+import team.projectpulse.rubric.domain.Criterion;
+import team.projectpulse.rubric.domain.Rubric;
+import team.projectpulse.rubric.repository.RubricRepository;
+import team.projectpulse.section.domain.Section;
+import team.projectpulse.team.domain.Team;
+import team.projectpulse.team.repository.TeamRepository;
+import team.projectpulse.user.domain.User;
+import team.projectpulse.user.repository.UserRepository;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.math.BigDecimal;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.time.temporal.WeekFields;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class EvaluationServiceTest {
+
+    private final Clock clock = Clock.fixed(
+        Instant.parse("2026-04-22T15:00:00Z"),
+        ZoneId.of("America/Chicago")
+    );
+
+    @Test
+    void should_LoadUnavailableWorkspace_When_StudentHasNoSection() {
+        User student = buildStudent(100L, "Ava", "Johnson", null);
+        EvaluationService service = buildService(student, null, null, null, clock);
+
+        EvaluationWorkspace workspace = service.loadWorkspace("ava@tcu.edu");
+
+        assertFalse(workspace.canSubmit());
+        assertEquals("You must belong to a senior design section before submitting peer evaluations.", workspace.availabilityMessage());
+    }
+
+    @Test
+    void should_LoadUnavailableWorkspace_When_StudentHasNoTeam() {
+        Section section = buildSection(List.of(currentIsoWeek(clock), previousIsoWeek(clock)));
+        User student = buildStudent(100L, "Ava", "Johnson", section);
+        EvaluationService service = buildService(student, null, null, null, clock);
+
+        EvaluationWorkspace workspace = service.loadWorkspace("ava@tcu.edu");
+
+        assertFalse(workspace.canSubmit());
+        assertEquals("You must be assigned to a senior design team before submitting peer evaluations.", workspace.availabilityMessage());
+    }
+
+    @Test
+    void should_LoadUnavailableWorkspace_When_CurrentWeekIsInactive() {
+        Section section = buildSection(List.of(previousIsoWeek(clock)));
+        User student = buildStudent(100L, "Ava", "Johnson", section);
+        Team team = buildTeam(section, student, buildStudent(101L, "Mia", "Chen", section));
+        EvaluationService service = buildService(student, team, buildRubric(10.0), null, clock);
+
+        EvaluationWorkspace workspace = service.loadWorkspace("ava@tcu.edu");
+
+        assertFalse(workspace.canSubmit());
+        assertEquals("Peer evaluations can only be submitted during active weeks.", workspace.availabilityMessage());
+    }
+
+    @Test
+    void should_LoadUnavailableWorkspace_When_PreviousWeekIsNotActive() {
+        Section section = buildSection(List.of(currentIsoWeek(clock)));
+        User student = buildStudent(100L, "Ava", "Johnson", section);
+        Team team = buildTeam(section, student, buildStudent(101L, "Mia", "Chen", section));
+        EvaluationService service = buildService(student, team, buildRubric(10.0), null, clock);
+
+        EvaluationWorkspace workspace = service.loadWorkspace("ava@tcu.edu");
+
+        assertFalse(workspace.canSubmit());
+        assertEquals("The previous week is not an active week for peer evaluations.", workspace.availabilityMessage());
+    }
+
+    @Test
+    void should_LoadEditableWorkspaceWithCurrentTeamAndRubric() {
+        Section section = buildSection(List.of(currentIsoWeek(clock), previousIsoWeek(clock)));
+        User student = buildStudent(100L, "Ava", "Johnson", section);
+        User teammate = buildStudent(101L, "Mia", "Chen", section);
+        Team team = buildTeam(section, student, teammate);
+        Rubric rubric = buildRubric(10.0);
+        EvaluationService service = buildService(student, team, rubric, null, clock);
+
+        EvaluationWorkspace workspace = service.loadWorkspace("ava@tcu.edu");
+
+        assertTrue(workspace.canSubmit());
+        assertTrue(workspace.editable());
+        assertFalse(workspace.submitted());
+        assertEquals(previousIsoWeek(clock), workspace.week());
+        assertEquals(2, workspace.criteria().size());
+        assertEquals(2, workspace.members().size());
+        assertTrue(workspace.members().get(0).self());
+        assertEquals("Ava Johnson", workspace.members().get(0).fullName());
+    }
+
+    @Test
+    void should_LoadExistingSubmissionIntoWorkspace() {
+        Section section = buildSection(List.of(currentIsoWeek(clock), previousIsoWeek(clock)));
+        User student = buildStudent(100L, "Ava", "Johnson", section);
+        User teammate = buildStudent(101L, "Mia", "Chen", section);
+        Team team = buildTeam(section, student, teammate);
+        Rubric rubric = buildRubric(10.0);
+        EvaluationSubmission submission = buildSubmission(team, student, teammate, rubric.getCriteria(), previousIsoWeek(clock));
+        EvaluationService service = buildService(student, team, rubric, submission, clock);
+
+        EvaluationWorkspace workspace = service.loadWorkspace("ava@tcu.edu");
+
+        assertTrue(workspace.submitted());
+        assertEquals(900L, workspace.submissionId());
+        assertEquals("Great teammate", workspace.members().get(1).publicComment());
+        assertEquals(8, workspace.members().get(1).scores().get(0).score());
+    }
+
+    @Test
+    void should_ReturnReadOnlyWorkspace_When_DeadlinePassedAndSubmissionExists() {
+        Clock lateClock = Clock.fixed(Instant.parse("2026-04-25T06:00:00Z"), ZoneId.of("America/Chicago"));
+        Section section = buildSection(List.of(currentIsoWeek(lateClock), previousIsoWeek(lateClock)));
+        User student = buildStudent(100L, "Ava", "Johnson", section);
+        User teammate = buildStudent(101L, "Mia", "Chen", section);
+        Team team = buildTeam(section, student, teammate);
+        Rubric rubric = buildRubric(10.0);
+        EvaluationSubmission submission = buildSubmission(team, student, teammate, rubric.getCriteria(), previousIsoWeek(lateClock));
+        EvaluationService service = buildService(student, team, rubric, submission, lateClock);
+
+        EvaluationWorkspace workspace = service.loadWorkspace("ava@tcu.edu");
+
+        assertFalse(workspace.canSubmit());
+        assertFalse(workspace.editable());
+        assertTrue(workspace.submitted());
+        assertEquals("The peer-evaluation submission window has closed.", workspace.availabilityMessage());
+    }
+
+    @Test
+    void should_CreateSubmission_When_RequestIsValid() {
+        Section section = buildSection(List.of(currentIsoWeek(clock), previousIsoWeek(clock)));
+        User student = buildStudent(100L, "Ava", "Johnson", section);
+        User teammate = buildStudent(101L, "Mia", "Chen", section);
+        Team team = buildTeam(section, student, teammate);
+        Rubric rubric = buildRubric(10.0);
+        EvaluationService service = buildService(student, team, rubric, null, clock);
+
+        var detail = service.createSubmission("ava@tcu.edu", validRequest(student, teammate, rubric.getCriteria()));
+
+        assertEquals(901L, detail.submissionId());
+        assertEquals(previousIsoWeek(clock), detail.week());
+        assertNotNull(detail.submittedAt());
+    }
+
+    @Test
+    void should_UpdateSubmission_When_RequestIsValidAndBeforeDeadline() {
+        Section section = buildSection(List.of(currentIsoWeek(clock), previousIsoWeek(clock)));
+        User student = buildStudent(100L, "Ava", "Johnson", section);
+        User teammate = buildStudent(101L, "Mia", "Chen", section);
+        Team team = buildTeam(section, student, teammate);
+        Rubric rubric = buildRubric(10.0);
+        EvaluationSubmission submission = buildSubmission(team, student, teammate, rubric.getCriteria(), previousIsoWeek(clock));
+        EvaluationService service = buildService(student, team, rubric, submission, clock);
+
+        var detail = service.updateSubmission("ava@tcu.edu", 900L, validRequest(student, teammate, rubric.getCriteria()));
+
+        assertEquals(900L, detail.submissionId());
+    }
+
+    @Test
+    void should_RejectSubmissionAfterDeadline() {
+        Clock lateClock = Clock.fixed(Instant.parse("2026-04-25T06:00:00Z"), ZoneId.of("America/Chicago"));
+        Section section = buildSection(List.of(currentIsoWeek(lateClock), previousIsoWeek(lateClock)));
+        User student = buildStudent(100L, "Ava", "Johnson", section);
+        User teammate = buildStudent(101L, "Mia", "Chen", section);
+        Team team = buildTeam(section, student, teammate);
+        Rubric rubric = buildRubric(10.0);
+        EvaluationService service = buildService(student, team, rubric, null, lateClock);
+
+        InvalidPeerEvaluationException ex = assertThrows(
+            InvalidPeerEvaluationException.class,
+            () -> service.createSubmission("ava@tcu.edu", validRequest(student, teammate, rubric.getCriteria()))
+        );
+
+        assertEquals("The peer-evaluation submission window has closed.", ex.getMessage());
+    }
+
+    @Test
+    void should_RejectDuplicateEvaluatees() {
+        Section section = buildSection(List.of(currentIsoWeek(clock), previousIsoWeek(clock)));
+        User student = buildStudent(100L, "Ava", "Johnson", section);
+        User teammate = buildStudent(101L, "Mia", "Chen", section);
+        Team team = buildTeam(section, student, teammate);
+        Rubric rubric = buildRubric(10.0);
+        EvaluationService service = buildService(student, team, rubric, null, clock);
+
+        InvalidPeerEvaluationException ex = assertThrows(
+            InvalidPeerEvaluationException.class,
+            () -> service.createSubmission(
+                "ava@tcu.edu",
+                new PeerEvaluationSubmissionRequest(List.of(
+                    new PeerEvaluationMemberSubmission(student.getId(), null, null, validScores(rubric.getCriteria())),
+                    new PeerEvaluationMemberSubmission(student.getId(), null, null, validScores(rubric.getCriteria()))
+                ))
+            )
+        );
+
+        assertEquals("Each team member can only appear once in a peer evaluation submission.", ex.getMessage());
+    }
+
+    @Test
+    void should_RejectMissingEvaluatee() {
+        Section section = buildSection(List.of(currentIsoWeek(clock), previousIsoWeek(clock)));
+        User student = buildStudent(100L, "Ava", "Johnson", section);
+        User teammate = buildStudent(101L, "Mia", "Chen", section);
+        Team team = buildTeam(section, student, teammate);
+        Rubric rubric = buildRubric(10.0);
+        EvaluationService service = buildService(student, team, rubric, null, clock);
+
+        InvalidPeerEvaluationException ex = assertThrows(
+            InvalidPeerEvaluationException.class,
+            () -> service.createSubmission(
+                "ava@tcu.edu",
+                new PeerEvaluationSubmissionRequest(List.of(
+                    new PeerEvaluationMemberSubmission(student.getId(), null, null, validScores(rubric.getCriteria()))
+                ))
+            )
+        );
+
+        assertEquals("Every team member must be evaluated exactly once.", ex.getMessage());
+    }
+
+    @Test
+    void should_RejectEvaluateeOutsideCurrentTeam() {
+        Section section = buildSection(List.of(currentIsoWeek(clock), previousIsoWeek(clock)));
+        User student = buildStudent(100L, "Ava", "Johnson", section);
+        User teammate = buildStudent(101L, "Mia", "Chen", section);
+        User outsider = buildStudent(999L, "Noah", "Bennett", section);
+        Team team = buildTeam(section, student, teammate);
+        Rubric rubric = buildRubric(10.0);
+        EvaluationService service = buildService(student, team, rubric, null, clock);
+
+        InvalidPeerEvaluationException ex = assertThrows(
+            InvalidPeerEvaluationException.class,
+            () -> service.createSubmission(
+                "ava@tcu.edu",
+                new PeerEvaluationSubmissionRequest(List.of(
+                    new PeerEvaluationMemberSubmission(student.getId(), null, null, validScores(rubric.getCriteria())),
+                    new PeerEvaluationMemberSubmission(outsider.getId(), null, null, validScores(rubric.getCriteria()))
+                ))
+            )
+        );
+
+        assertEquals("Peer evaluations may only be submitted for current team members.", ex.getMessage());
+    }
+
+    @Test
+    void should_RejectMissingCriterionScore() {
+        Section section = buildSection(List.of(currentIsoWeek(clock), previousIsoWeek(clock)));
+        User student = buildStudent(100L, "Ava", "Johnson", section);
+        Team team = buildTeam(section, student);
+        Rubric rubric = buildRubric(10.0);
+        EvaluationService service = buildService(student, team, rubric, null, clock);
+
+        InvalidPeerEvaluationException ex = assertThrows(
+            InvalidPeerEvaluationException.class,
+            () -> service.createSubmission(
+                "ava@tcu.edu",
+                new PeerEvaluationSubmissionRequest(List.of(
+                    new PeerEvaluationMemberSubmission(
+                        student.getId(),
+                        null,
+                        null,
+                        List.of(new PeerEvaluationCriterionScoreSubmission(501L, BigDecimal.TEN))
+                    )
+                ))
+            )
+        );
+
+        assertEquals("Every rubric criterion must be scored exactly once.", ex.getMessage());
+    }
+
+    @Test
+    void should_RejectDuplicateCriterionScore() {
+        Section section = buildSection(List.of(currentIsoWeek(clock), previousIsoWeek(clock)));
+        User student = buildStudent(100L, "Ava", "Johnson", section);
+        Team team = buildTeam(section, student);
+        Rubric rubric = buildRubric(10.0);
+        EvaluationService service = buildService(student, team, rubric, null, clock);
+
+        InvalidPeerEvaluationException ex = assertThrows(
+            InvalidPeerEvaluationException.class,
+            () -> service.createSubmission(
+                "ava@tcu.edu",
+                new PeerEvaluationSubmissionRequest(List.of(
+                    new PeerEvaluationMemberSubmission(
+                        student.getId(),
+                        null,
+                        null,
+                        List.of(
+                            new PeerEvaluationCriterionScoreSubmission(501L, BigDecimal.TEN),
+                            new PeerEvaluationCriterionScoreSubmission(501L, BigDecimal.valueOf(9))
+                        )
+                    )
+                ))
+            )
+        );
+
+        assertEquals("Each rubric criterion can only be scored once per teammate.", ex.getMessage());
+    }
+
+    @Test
+    void should_RejectOutOfRangeScore() {
+        Section section = buildSection(List.of(currentIsoWeek(clock), previousIsoWeek(clock)));
+        User student = buildStudent(100L, "Ava", "Johnson", section);
+        Team team = buildTeam(section, student);
+        Rubric rubric = buildRubric(10.0);
+        EvaluationService service = buildService(student, team, rubric, null, clock);
+
+        InvalidPeerEvaluationException ex = assertThrows(
+            InvalidPeerEvaluationException.class,
+            () -> service.createSubmission(
+                "ava@tcu.edu",
+                new PeerEvaluationSubmissionRequest(List.of(
+                    new PeerEvaluationMemberSubmission(
+                        student.getId(),
+                        null,
+                        null,
+                        List.of(
+                            new PeerEvaluationCriterionScoreSubmission(501L, BigDecimal.valueOf(11)),
+                            new PeerEvaluationCriterionScoreSubmission(502L, BigDecimal.TEN)
+                        )
+                    )
+                ))
+            )
+        );
+
+        assertEquals("Scores must be between 1 and 10 for criterion \"Participation\".", ex.getMessage());
+    }
+
+    @Test
+    void should_RejectNonIntegerRubricConfiguration() {
+        Section section = buildSection(List.of(currentIsoWeek(clock), previousIsoWeek(clock)));
+        User student = buildStudent(100L, "Ava", "Johnson", section);
+        Team team = buildTeam(section, student);
+        Rubric rubric = buildRubric(9.5);
+        EvaluationService service = buildService(student, team, rubric, null, clock);
+
+        InvalidPeerEvaluationException ex = assertThrows(
+            InvalidPeerEvaluationException.class,
+            () -> service.loadWorkspace("ava@tcu.edu")
+        );
+
+        assertEquals("Peer evaluation rubric criteria must use integer max scores.", ex.getMessage());
+    }
+
+    @Test
+    void should_ReturnNotFound_When_UpdatingMissingOwnedSubmission() {
+        Section section = buildSection(List.of(currentIsoWeek(clock), previousIsoWeek(clock)));
+        User student = buildStudent(100L, "Ava", "Johnson", section);
+        Team team = buildTeam(section, student);
+        Rubric rubric = buildRubric(10.0);
+        EvaluationService service = buildService(student, team, rubric, null, clock);
+
+        assertThrows(
+            PeerEvaluationSubmissionNotFoundException.class,
+            () -> service.updateSubmission("ava@tcu.edu", 999L, validRequest(student, null, rubric.getCriteria()))
+        );
+    }
+
+    private EvaluationService buildService(
+        User student,
+        Team team,
+        Rubric rubric,
+        EvaluationSubmission submission,
+        Clock activeClock
+    ) {
+        AtomicLong submissionIds = new AtomicLong(901L);
+        UserRepository userRepository = proxy(UserRepository.class, (method, args) -> switch (method.getName()) {
+            case "findByEmail" -> Optional.ofNullable(student);
+            default -> defaultValue(method);
+        });
+        TeamRepository teamRepository = proxy(TeamRepository.class, (method, args) -> switch (method.getName()) {
+            case "findByStudentIdWithSection" -> Optional.ofNullable(team);
+            case "findDetailById" -> Optional.ofNullable(team);
+            default -> defaultValue(method);
+        });
+        RubricRepository rubricRepository = proxy(RubricRepository.class, (method, args) -> switch (method.getName()) {
+            case "findByIdWithCriteria" -> Optional.ofNullable(rubric);
+            default -> defaultValue(method);
+        });
+        EvaluationSubmissionRepository submissionRepository = proxy(EvaluationSubmissionRepository.class, (method, args) -> switch (method.getName()) {
+            case "findByEvaluatorStudentIdAndWeek" -> submission != null && submission.getEvaluatorStudent().getId().equals(args[0]) && submission.getWeek().equals(args[1])
+                ? Optional.of(submission)
+                : Optional.empty();
+            case "findBySubmissionIdAndEvaluatorStudentId" -> submission != null
+                && submission.getSubmissionId().equals(args[0])
+                && submission.getEvaluatorStudent().getId().equals(args[1])
+                ? Optional.of(submission)
+                : Optional.empty();
+            case "save" -> {
+                EvaluationSubmission saved = (EvaluationSubmission) args[0];
+                if (saved.getSubmissionId() == null) {
+                    saved.setSubmissionId(submissionIds.getAndIncrement());
+                }
+                if (saved.getCreatedAt() == null) {
+                    saved.setCreatedAt(java.time.LocalDateTime.now(activeClock));
+                }
+                saved.setUpdatedAt(java.time.LocalDateTime.now(activeClock));
+                yield saved;
+            }
+            default -> defaultValue(method);
+        });
+
+        return new EvaluationService(submissionRepository, userRepository, teamRepository, rubricRepository, activeClock);
+    }
+
+    @SuppressWarnings("unchecked")
+    private <T> T proxy(Class<T> type, RepositoryCall handler) {
+        InvocationHandler invocationHandler = (proxy, method, args) -> {
+            if (method.getDeclaringClass() == Object.class) {
+                return switch (method.getName()) {
+                    case "toString" -> type.getSimpleName() + "Proxy";
+                    case "hashCode" -> System.identityHashCode(proxy);
+                    case "equals" -> proxy == args[0];
+                    default -> null;
+                };
+            }
+            return handler.invoke(method, args == null ? new Object[0] : args);
+        };
+        return (T) Proxy.newProxyInstance(type.getClassLoader(), new Class<?>[]{type}, invocationHandler);
+    }
+
+    private Object defaultValue(Method method) {
+        Class<?> returnType = method.getReturnType();
+        if (returnType.equals(boolean.class)) {
+            return false;
+        }
+        if (returnType.equals(int.class) || returnType.equals(long.class) || returnType.equals(short.class) || returnType.equals(byte.class)) {
+            return 0;
+        }
+        if (returnType.equals(double.class) || returnType.equals(float.class)) {
+            return 0.0;
+        }
+        return null;
+    }
+
+    private Section buildSection(List<String> activeWeeks) {
+        Section section = new Section();
+        section.setSectionId(1L);
+        section.setSectionName("Spring 2026 - Section A");
+        section.setStartDate(LocalDate.of(2026, 1, 12));
+        section.setEndDate(LocalDate.of(2026, 5, 8));
+        section.setRubricId(11L);
+        section.setActiveWeeks(activeWeeks);
+        section.setPeerEvaluationWeeklyDueDay("FRIDAY");
+        section.setPeerEvaluationDueTime("23:59");
+        return section;
+    }
+
+    private Team buildTeam(Section section, User... students) {
+        Team team = new Team();
+        team.setTeamId(2001L);
+        team.setTeamName("Pulse Analytics");
+        team.setSection(section);
+        team.setStudents(new LinkedHashSet<>(List.of(students)));
+        return team;
+    }
+
+    private User buildStudent(Long id, String firstName, String lastName, Section section) {
+        User user = new User();
+        user.setId(id);
+        user.setFirstName(firstName);
+        user.setLastName(lastName);
+        user.setEmail(firstName.toLowerCase(Locale.ROOT) + "@tcu.edu");
+        user.setPassword("encoded");
+        user.setRoles("student");
+        user.setEnabled(true);
+        user.setSection(section);
+        return user;
+    }
+
+    private Rubric buildRubric(double maxScore) {
+        Criterion participation = new Criterion();
+        participation.setCriterionId(501L);
+        participation.setCriterion("Participation");
+        participation.setDescription("Participates");
+        participation.setMaxScore(maxScore);
+
+        Criterion communication = new Criterion();
+        communication.setCriterionId(502L);
+        communication.setCriterion("Communication");
+        communication.setDescription("Communicates");
+        communication.setMaxScore(10.0);
+
+        Rubric rubric = new Rubric();
+        rubric.setRubricId(11L);
+        rubric.setRubricName("Default Peer Evaluation Rubric");
+        rubric.setCriteria(List.of(participation, communication));
+        return rubric;
+    }
+
+    private EvaluationSubmission buildSubmission(Team team, User evaluator, User teammate, List<Criterion> criteria, String week) {
+        EvaluationSubmission submission = new EvaluationSubmission();
+        submission.setSubmissionId(900L);
+        submission.setTeam(team);
+        submission.setEvaluatorStudent(evaluator);
+        submission.setWeek(week);
+        submission.setCreatedAt(java.time.LocalDateTime.now(clock));
+        submission.setUpdatedAt(java.time.LocalDateTime.now(clock));
+
+        EvaluationEntry selfEntry = new EvaluationEntry();
+        selfEntry.setEntryId(700L);
+        selfEntry.setEvaluateeStudent(evaluator);
+        selfEntry.setPublicComment("Self review");
+        selfEntry.setPrivateComment("Private self review");
+        selfEntry.addScore(buildScore(criteria.get(0), 9));
+        selfEntry.addScore(buildScore(criteria.get(1), 10));
+
+        EvaluationEntry teammateEntry = new EvaluationEntry();
+        teammateEntry.setEntryId(701L);
+        teammateEntry.setEvaluateeStudent(teammate);
+        teammateEntry.setPublicComment("Great teammate");
+        teammateEntry.setPrivateComment("Very reliable");
+        teammateEntry.addScore(buildScore(criteria.get(0), 8));
+        teammateEntry.addScore(buildScore(criteria.get(1), 9));
+
+        submission.addEntry(selfEntry);
+        submission.addEntry(teammateEntry);
+        return submission;
+    }
+
+    private EvaluationScore buildScore(Criterion criterion, int value) {
+        EvaluationScore score = new EvaluationScore();
+        score.setCriterion(criterion);
+        score.setScore(value);
+        return score;
+    }
+
+    private PeerEvaluationSubmissionRequest validRequest(User evaluator, User teammate, List<Criterion> criteria) {
+        List<PeerEvaluationMemberSubmission> evaluations = new java.util.ArrayList<>();
+        evaluations.add(new PeerEvaluationMemberSubmission(
+            evaluator.getId(),
+            "Self comment",
+            "Self private",
+            validScores(criteria)
+        ));
+        if (teammate != null) {
+            evaluations.add(new PeerEvaluationMemberSubmission(
+                teammate.getId(),
+                "Teammate comment",
+                "Teammate private",
+                validScores(criteria)
+            ));
+        }
+        return new PeerEvaluationSubmissionRequest(evaluations);
+    }
+
+    private List<PeerEvaluationCriterionScoreSubmission> validScores(List<Criterion> criteria) {
+        return criteria.stream()
+            .map(criterion -> new PeerEvaluationCriterionScoreSubmission(
+                criterion.getCriterionId(),
+                BigDecimal.valueOf(Math.min(10, (int) criterion.getMaxScore()))
+            ))
+            .toList();
+    }
+
+    private static String currentIsoWeek(Clock activeClock) {
+        LocalDate now = LocalDate.now(activeClock);
+        return "%d-W%02d".formatted(now.get(WeekFields.ISO.weekBasedYear()), now.get(WeekFields.ISO.weekOfWeekBasedYear()));
+    }
+
+    private static String previousIsoWeek(Clock activeClock) {
+        LocalDate previous = LocalDate.now(activeClock).minusWeeks(1);
+        return "%d-W%02d".formatted(previous.get(WeekFields.ISO.weekBasedYear()), previous.get(WeekFields.ISO.weekOfWeekBasedYear()));
+    }
+
+    @FunctionalInterface
+    private interface RepositoryCall {
+        Object invoke(Method method, Object[] args) throws Throwable;
+    }
+}

--- a/src/backend/src/test/java/team/projectpulse/team/controller/TeamControllerIntegrationTest.java
+++ b/src/backend/src/test/java/team/projectpulse/team/controller/TeamControllerIntegrationTest.java
@@ -2,13 +2,15 @@ package team.projectpulse.team.controller;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
+import team.projectpulse.config.ControllerTestSecurityConfig;
+import team.projectpulse.config.SecurityConfig;
 import team.projectpulse.section.domain.SectionNotFoundException;
 import team.projectpulse.team.domain.InstructorNotFoundException;
 import team.projectpulse.team.domain.InvalidTeamException;
@@ -36,8 +38,8 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@SpringBootTest
-@AutoConfigureMockMvc
+@WebMvcTest(controllers = TeamController.class)
+@Import({TeamExceptionHandler.class, SecurityConfig.class, ControllerTestSecurityConfig.class})
 @ActiveProfiles("test")
 class TeamControllerIntegrationTest {
 

--- a/src/backend/src/test/java/team/projectpulse/team/controller/TeamInstructorAssignmentControllerIntegrationTest.java
+++ b/src/backend/src/test/java/team/projectpulse/team/controller/TeamInstructorAssignmentControllerIntegrationTest.java
@@ -2,13 +2,15 @@ package team.projectpulse.team.controller;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
+import team.projectpulse.config.ControllerTestSecurityConfig;
+import team.projectpulse.config.SecurityConfig;
 import team.projectpulse.section.domain.SectionNotFoundException;
 import team.projectpulse.team.domain.InvalidTeamInstructorAssignmentException;
 import team.projectpulse.team.dto.InstructorAssignmentCandidate;
@@ -26,8 +28,8 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@SpringBootTest
-@AutoConfigureMockMvc
+@WebMvcTest(controllers = TeamInstructorAssignmentController.class)
+@Import({TeamExceptionHandler.class, SecurityConfig.class, ControllerTestSecurityConfig.class})
 @ActiveProfiles("test")
 class TeamInstructorAssignmentControllerIntegrationTest {
 

--- a/src/backend/src/test/java/team/projectpulse/team/controller/TeamStudentAssignmentControllerIntegrationTest.java
+++ b/src/backend/src/test/java/team/projectpulse/team/controller/TeamStudentAssignmentControllerIntegrationTest.java
@@ -2,13 +2,15 @@ package team.projectpulse.team.controller;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
+import team.projectpulse.config.ControllerTestSecurityConfig;
+import team.projectpulse.config.SecurityConfig;
 import team.projectpulse.section.domain.SectionNotFoundException;
 import team.projectpulse.team.domain.InvalidTeamStudentAssignmentException;
 import team.projectpulse.team.dto.StudentAssignmentCandidate;
@@ -25,8 +27,8 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@SpringBootTest
-@AutoConfigureMockMvc
+@WebMvcTest(controllers = TeamStudentAssignmentController.class)
+@Import({TeamExceptionHandler.class, SecurityConfig.class, ControllerTestSecurityConfig.class})
 @ActiveProfiles("test")
 class TeamStudentAssignmentControllerIntegrationTest {
 

--- a/src/frontend/src/features/evaluation/pages/PeerEvaluations.vue
+++ b/src/frontend/src/features/evaluation/pages/PeerEvaluations.vue
@@ -1,0 +1,508 @@
+<template>
+  <v-container>
+    <v-row class="mb-4" align="center">
+      <v-col>
+        <h2 class="text-h5 font-weight-bold">Peer Evaluations</h2>
+        <div class="text-body-2 text-medium-emphasis">
+          Complete one peer evaluation for the previous week for every teammate, including yourself.
+        </div>
+      </v-col>
+      <v-col cols="auto" v-if="workspace && isEditableWorkspace">
+        <v-btn color="primary" :loading="saving" @click="openPreviewDialog">
+          {{ workspace.submitted ? 'Preview Update' : 'Preview Submission' }}
+        </v-btn>
+      </v-col>
+    </v-row>
+
+    <v-card variant="outlined" class="mb-4">
+      <v-card-text class="pa-4">
+        <v-row>
+          <v-col cols="12" md="8" class="d-flex flex-wrap ga-2">
+            <v-chip v-if="workspace?.sectionName" color="primary" variant="tonal">
+              {{ workspace.sectionName }}
+            </v-chip>
+            <v-chip v-if="workspace?.teamName" color="secondary" variant="tonal">
+              {{ workspace.teamName }}
+            </v-chip>
+            <v-chip v-if="workspace?.weekLabel" color="success" variant="tonal">
+              {{ workspace.weekLabel }}
+            </v-chip>
+            <v-chip v-if="workspace?.weekRangeLabel" variant="outlined">
+              {{ workspace.weekRangeLabel }}
+            </v-chip>
+            <v-chip
+              v-if="workspace"
+              :color="isEditableWorkspace ? 'success' : 'warning'"
+              variant="tonal"
+            >
+              {{ isEditableWorkspace ? 'Editable' : 'Read only' }}
+            </v-chip>
+          </v-col>
+          <v-col cols="12" md="4" class="text-md-right">
+            <div class="text-caption text-medium-emphasis">Submission deadline</div>
+            <div class="text-body-2 font-weight-medium">{{ dueAtLabel }}</div>
+          </v-col>
+        </v-row>
+
+        <v-alert v-if="workspace?.availabilityMessage" type="info" variant="tonal" class="mt-4">
+          {{ workspace.availabilityMessage }}
+        </v-alert>
+      </v-card-text>
+    </v-card>
+
+    <v-row v-if="loading">
+      <v-col class="text-center">
+        <v-progress-circular indeterminate />
+      </v-col>
+    </v-row>
+
+    <template v-else-if="workspace">
+      <v-alert
+        v-if="!workspace.members.length"
+        type="info"
+        variant="tonal"
+      >
+        No peer-evaluation draft is available for the selected week.
+      </v-alert>
+
+      <v-row v-else>
+        <v-col
+          v-for="member in evaluationForm.evaluations"
+          :key="member.studentId"
+          cols="12"
+        >
+          <v-card variant="outlined">
+            <v-card-title class="pa-4 pb-2 d-flex flex-wrap align-center ga-2">
+              <span>{{ member.fullName }}</span>
+              <v-chip v-if="member.self" size="small" color="primary" variant="tonal">Self</v-chip>
+            </v-card-title>
+
+            <v-card-text class="pt-0">
+              <v-row>
+                <v-col
+                  v-for="criterion in workspace.criteria"
+                  :key="criterion.criterionId"
+                  cols="12"
+                  md="6"
+                >
+                  <v-text-field
+                    v-if="isEditableWorkspace"
+                    :model-value="getScoreValue(member.studentId, criterion.criterionId)"
+                    :label="criterionLabel(criterion)"
+                    type="number"
+                    min="1"
+                    :max="criterion.maxScore"
+                    step="1"
+                    :hint="criterion.description || `Score from 1 to ${criterion.maxScore}`"
+                    persistent-hint
+                    :error-messages="errorMessages(scoreErrorKey(member.studentId, criterion.criterionId))"
+                    @update:model-value="setScoreValue(member.studentId, criterion.criterionId, $event)"
+                  />
+                  <div v-else class="readonly-field">
+                    <div class="text-caption text-medium-emphasis">{{ criterionLabel(criterion) }}</div>
+                    <div class="text-body-1 font-weight-medium">
+                      {{ displayScore(member.studentId, criterion.criterionId) }}
+                    </div>
+                    <div v-if="criterion.description" class="text-caption text-medium-emphasis">
+                      {{ criterion.description }}
+                    </div>
+                  </div>
+                </v-col>
+              </v-row>
+
+              <v-textarea
+                v-if="isEditableWorkspace"
+                v-model="member.publicComment"
+                label="Public Comments"
+                rows="3"
+                counter="2000"
+                :error-messages="errorMessages(publicCommentErrorKey(member.studentId))"
+                class="mt-2"
+              />
+              <div v-else class="readonly-field mt-3">
+                <div class="text-caption text-medium-emphasis">Public Comments</div>
+                <div class="text-body-2 preserve-lines">{{ member.publicComment?.trim() || 'No public comments.' }}</div>
+              </div>
+
+              <v-textarea
+                v-if="isEditableWorkspace"
+                v-model="member.privateComment"
+                label="Private Comments"
+                rows="3"
+                counter="2000"
+                :error-messages="errorMessages(privateCommentErrorKey(member.studentId))"
+                class="mt-2"
+              />
+              <div v-else class="readonly-field mt-3">
+                <div class="text-caption text-medium-emphasis">Private Comments</div>
+                <div class="text-body-2 preserve-lines">{{ member.privateComment?.trim() || 'No private comments.' }}</div>
+              </div>
+            </v-card-text>
+          </v-card>
+        </v-col>
+      </v-row>
+    </template>
+
+    <v-dialog v-model="previewDialog" max-width="960" persistent scrollable>
+      <v-card v-if="workspace">
+        <v-card-title class="pa-4">
+          {{ workspace.submitted ? 'Confirm Peer Evaluation Update' : 'Confirm Peer Evaluation Submission' }}
+        </v-card-title>
+        <v-divider />
+
+        <v-card-text class="pa-4">
+          <v-alert type="info" variant="tonal" class="mb-4">
+            Review every score and comment before confirming.
+          </v-alert>
+
+          <v-table density="compact" class="mb-4">
+            <tbody>
+              <tr>
+                <th class="text-left">Section</th>
+                <td>{{ workspace.sectionName || '—' }}</td>
+              </tr>
+              <tr>
+                <th class="text-left">Team</th>
+                <td>{{ workspace.teamName || '—' }}</td>
+              </tr>
+              <tr>
+                <th class="text-left">Week</th>
+                <td>{{ workspace.weekRangeLabel || workspace.weekLabel || '—' }}</td>
+              </tr>
+              <tr>
+                <th class="text-left">Deadline</th>
+                <td>{{ dueAtLabel }}</td>
+              </tr>
+            </tbody>
+          </v-table>
+
+          <v-card
+            v-for="member in evaluationForm.evaluations"
+            :key="`preview-${member.studentId}`"
+            variant="outlined"
+            class="mb-4"
+          >
+            <v-card-title class="pa-4 pb-2 d-flex flex-wrap align-center ga-2">
+              <span>{{ member.fullName }}</span>
+              <v-chip v-if="member.self" size="small" color="primary" variant="tonal">Self</v-chip>
+            </v-card-title>
+            <v-card-text class="pt-0">
+              <v-table density="compact" class="mb-3">
+                <tbody>
+                  <tr v-for="criterion in workspace.criteria" :key="`preview-score-${member.studentId}-${criterion.criterionId}`">
+                    <th class="text-left">{{ criterion.criterion }}</th>
+                    <td>{{ scoreField(member.studentId, criterion.criterionId).score || '—' }}</td>
+                  </tr>
+                </tbody>
+              </v-table>
+
+              <div class="readonly-field mb-3">
+                <div class="text-caption text-medium-emphasis">Public Comments</div>
+                <div class="text-body-2 preserve-lines">{{ member.publicComment.trim() || 'No public comments.' }}</div>
+              </div>
+
+              <div class="readonly-field">
+                <div class="text-caption text-medium-emphasis">Private Comments</div>
+                <div class="text-body-2 preserve-lines">{{ member.privateComment.trim() || 'No private comments.' }}</div>
+              </div>
+            </v-card-text>
+          </v-card>
+        </v-card-text>
+
+        <v-divider />
+        <v-card-actions class="pa-4">
+          <v-btn variant="text" @click="previewDialog = false">Cancel</v-btn>
+          <v-spacer />
+          <v-btn variant="outlined" @click="previewDialog = false">Modify</v-btn>
+          <v-btn color="primary" :loading="saving" @click="submitEvaluation">
+            {{ workspace.submitted ? 'Confirm Update' : 'Confirm Submission' }}
+          </v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
+
+    <v-snackbar v-model="snackbar.show" :color="snackbar.color" timeout="3000">
+      {{ snackbar.message }}
+    </v-snackbar>
+  </v-container>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted, ref } from 'vue'
+import { createPeerEvaluation, getPeerEvaluationWorkspace, updatePeerEvaluation } from '../services/evaluationService'
+import type {
+  EvaluationCriterion,
+  EvaluationWorkspace,
+  PeerEvaluationSubmissionRequest
+} from '../services/evaluationTypes'
+
+interface EvaluationCriterionFormState {
+  criterionId: number
+  score: string
+}
+
+interface EvaluationMemberFormState {
+  studentId: number
+  fullName: string
+  self: boolean
+  publicComment: string
+  privateComment: string
+  scores: EvaluationCriterionFormState[]
+}
+
+interface EvaluationFormState {
+  evaluations: EvaluationMemberFormState[]
+}
+
+const loading = ref(false)
+const saving = ref(false)
+const previewDialog = ref(false)
+const workspace = ref<EvaluationWorkspace | null>(null)
+const evaluationForm = ref<EvaluationFormState>({ evaluations: [] })
+const formErrors = ref<Record<string, string[]>>({})
+const snackbar = ref({ show: false, message: '', color: 'success' })
+
+const isEditableWorkspace = computed(() =>
+  Boolean(workspace.value?.editable && workspace.value?.canSubmit && workspace.value?.members.length)
+)
+
+const dueAtLabel = computed(() => formatDueAt(workspace.value?.dueAt ?? null))
+
+onMounted(() => {
+  loadWorkspace()
+})
+
+async function loadWorkspace() {
+  loading.value = true
+  try {
+    const response = await getPeerEvaluationWorkspace()
+    workspace.value = response.flag ? response.data : null
+    syncFormWithWorkspace()
+  } catch (err: any) {
+    snackbar.value = {
+      show: true,
+      message: err?.response?.data?.message || 'An error occurred.',
+      color: 'error'
+    }
+  } finally {
+    loading.value = false
+  }
+}
+
+function syncFormWithWorkspace() {
+  if (!workspace.value) {
+    evaluationForm.value = { evaluations: [] }
+    return
+  }
+
+  evaluationForm.value = {
+    evaluations: workspace.value.members.map((member) => ({
+      studentId: member.studentId,
+      fullName: member.fullName,
+      self: member.self,
+      publicComment: member.publicComment ?? '',
+      privateComment: member.privateComment ?? '',
+      scores: workspace.value?.criteria.map((criterion) => ({
+        criterionId: criterion.criterionId,
+        score: String(member.scores.find((score) => score.criterionId === criterion.criterionId)?.score ?? '')
+      })) ?? []
+    }))
+  }
+  formErrors.value = {}
+}
+
+function scoreField(studentId: number, criterionId: number) {
+  return evaluationForm.value.evaluations
+    .find((member) => member.studentId === studentId)
+    ?.scores.find((score) => score.criterionId === criterionId) ?? { criterionId, score: '' }
+}
+
+function getScoreValue(studentId: number, criterionId: number) {
+  return scoreField(studentId, criterionId).score
+}
+
+function setScoreValue(studentId: number, criterionId: number, value: string | number | null) {
+  const member = evaluationForm.value.evaluations.find((item) => item.studentId === studentId)
+  const score = member?.scores.find((item) => item.criterionId === criterionId)
+
+  if (score) {
+    score.score = value == null ? '' : String(value)
+  }
+}
+
+function openPreviewDialog() {
+  if (!validateForm()) {
+    return
+  }
+  previewDialog.value = true
+}
+
+async function submitEvaluation() {
+  if (!workspace.value) {
+    return
+  }
+
+  saving.value = true
+  const wasSubmitted = workspace.value.submitted
+  try {
+    const payload = buildPayload()
+    const response = workspace.value.submitted && workspace.value.submissionId
+      ? await updatePeerEvaluation(workspace.value.submissionId, payload)
+      : await createPeerEvaluation(payload)
+
+    previewDialog.value = false
+    applySavedSubmission(response.data.submissionId)
+    snackbar.value = {
+      show: true,
+      message: response.message || (wasSubmitted ? 'Peer evaluation has been updated.' : 'Peer evaluation has been submitted.'),
+      color: 'success'
+    }
+  } catch (err: any) {
+    previewDialog.value = false
+    snackbar.value = {
+      show: true,
+      message: err?.response?.data?.message || 'An error occurred.',
+      color: 'error'
+    }
+  } finally {
+    saving.value = false
+  }
+}
+
+function validateForm() {
+  const currentWorkspace = workspace.value
+  const errors: Record<string, string[]> = {}
+
+  if (!currentWorkspace) {
+    snackbar.value = { show: true, message: 'Peer evaluation workspace is unavailable.', color: 'error' }
+    return false
+  }
+
+  if (evaluationForm.value.evaluations.length !== currentWorkspace.members.length) {
+    snackbar.value = { show: true, message: 'Every team member must be evaluated exactly once.', color: 'error' }
+    return false
+  }
+
+  for (const member of evaluationForm.value.evaluations) {
+    for (const criterion of currentWorkspace.criteria) {
+      const scoreValue = scoreField(member.studentId, criterion.criterionId).score.trim()
+      const key = scoreErrorKey(member.studentId, criterion.criterionId)
+
+      if (!scoreValue) {
+        errors[key] = ['A score is required.']
+        continue
+      }
+      if (!/^-?\d+$/.test(scoreValue)) {
+        errors[key] = ['Scores must be integers.']
+        continue
+      }
+
+      const numericScore = Number(scoreValue)
+      if (numericScore < 1 || numericScore > criterion.maxScore) {
+        errors[key] = [`Score must be between 1 and ${criterion.maxScore}.`]
+      }
+    }
+
+    if (member.publicComment.trim().length > 2000) {
+      errors[publicCommentErrorKey(member.studentId)] = ['Public comments must be 2000 characters or fewer.']
+    }
+    if (member.privateComment.trim().length > 2000) {
+      errors[privateCommentErrorKey(member.studentId)] = ['Private comments must be 2000 characters or fewer.']
+    }
+  }
+
+  formErrors.value = errors
+  if (Object.keys(errors).length > 0) {
+    snackbar.value = { show: true, message: 'Fix the highlighted evaluation fields before continuing.', color: 'error' }
+    return false
+  }
+  return true
+}
+
+function buildPayload(): PeerEvaluationSubmissionRequest {
+  return {
+    evaluations: evaluationForm.value.evaluations.map((member) => ({
+      evaluateeStudentId: member.studentId,
+      publicComment: normalizeComment(member.publicComment),
+      privateComment: normalizeComment(member.privateComment),
+      criterionScores: member.scores.map((score) => ({
+        criterionId: score.criterionId,
+        score: Number(score.score)
+      }))
+    }))
+  }
+}
+
+function applySavedSubmission(submissionId: number) {
+  if (!workspace.value) {
+    return
+  }
+
+  workspace.value = {
+    ...workspace.value,
+    submissionId,
+    submitted: true
+  }
+}
+
+function normalizeComment(value: string) {
+  const normalized = value.trim()
+  return normalized ? normalized : null
+}
+
+function displayScore(studentId: number, criterionId: number) {
+  return scoreField(studentId, criterionId).score || '—'
+}
+
+function criterionLabel(criterion: EvaluationCriterion) {
+  return `${criterion.criterion} (1-${criterion.maxScore})`
+}
+
+function formatDueAt(value: string | null) {
+  if (!value) {
+    return '—'
+  }
+
+  const parsed = new Date(value)
+  if (Number.isNaN(parsed.getTime())) {
+    return value
+  }
+
+  return new Intl.DateTimeFormat(undefined, {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit'
+  }).format(parsed)
+}
+
+function scoreErrorKey(studentId: number, criterionId: number) {
+  return `score-${studentId}-${criterionId}`
+}
+
+function publicCommentErrorKey(studentId: number) {
+  return `public-comment-${studentId}`
+}
+
+function privateCommentErrorKey(studentId: number) {
+  return `private-comment-${studentId}`
+}
+
+function errorMessages(key: string) {
+  return formErrors.value[key] ?? []
+}
+</script>
+
+<style scoped lang="scss">
+.readonly-field {
+  border: 1px solid rgba(0, 0, 0, 0.08);
+  border-radius: 12px;
+  padding: 12px 14px;
+  background: rgba(0, 0, 0, 0.02);
+}
+
+.preserve-lines {
+  white-space: pre-line;
+}
+</style>

--- a/src/frontend/src/features/evaluation/services/evaluationService.ts
+++ b/src/frontend/src/features/evaluation/services/evaluationService.ts
@@ -1,0 +1,18 @@
+import request from '@/shared/utils/request'
+import type { ApiResponse } from '@/shared/types/api'
+import type {
+  EvaluationWorkspace,
+  PeerEvaluationSubmissionDetail,
+  PeerEvaluationSubmissionRequest
+} from './evaluationTypes'
+
+const BASE = '/peer-evaluations'
+
+export const getPeerEvaluationWorkspace = () =>
+  request.get<ApiResponse<EvaluationWorkspace>>(`${BASE}/workspace`) as unknown as Promise<ApiResponse<EvaluationWorkspace>>
+
+export const createPeerEvaluation = (payload: PeerEvaluationSubmissionRequest) =>
+  request.post<ApiResponse<PeerEvaluationSubmissionDetail>>(BASE, payload) as unknown as Promise<ApiResponse<PeerEvaluationSubmissionDetail>>
+
+export const updatePeerEvaluation = (submissionId: number, payload: PeerEvaluationSubmissionRequest) =>
+  request.put<ApiResponse<PeerEvaluationSubmissionDetail>>(`${BASE}/${submissionId}`, payload) as unknown as Promise<ApiResponse<PeerEvaluationSubmissionDetail>>

--- a/src/frontend/src/features/evaluation/services/evaluationTypes.ts
+++ b/src/frontend/src/features/evaluation/services/evaluationTypes.ts
@@ -1,0 +1,61 @@
+export interface EvaluationCriterion {
+  criterionId: number
+  criterion: string
+  description: string | null
+  maxScore: number
+}
+
+export interface EvaluationCriterionDraftScore {
+  criterionId: number
+  score: number | null
+}
+
+export interface EvaluationMemberDraft {
+  studentId: number
+  fullName: string
+  self: boolean
+  publicComment: string | null
+  privateComment: string | null
+  scores: EvaluationCriterionDraftScore[]
+}
+
+export interface EvaluationWorkspace {
+  sectionId: number | null
+  sectionName: string | null
+  teamId: number | null
+  teamName: string | null
+  week: string | null
+  weekLabel: string | null
+  weekRangeLabel: string | null
+  submissionId: number | null
+  submitted: boolean
+  editable: boolean
+  canSubmit: boolean
+  availabilityMessage: string | null
+  dueAt: string | null
+  criteria: EvaluationCriterion[]
+  members: EvaluationMemberDraft[]
+}
+
+export interface PeerEvaluationCriterionScoreSubmission {
+  criterionId: number
+  score: number | null
+}
+
+export interface PeerEvaluationMemberSubmission {
+  evaluateeStudentId: number
+  publicComment: string | null
+  privateComment: string | null
+  criterionScores: PeerEvaluationCriterionScoreSubmission[]
+}
+
+export interface PeerEvaluationSubmissionRequest {
+  evaluations: PeerEvaluationMemberSubmission[]
+}
+
+export interface PeerEvaluationSubmissionDetail {
+  submissionId: number
+  week: string
+  submittedAt: string
+  updatedAt: string
+}

--- a/src/frontend/src/router/routes.ts
+++ b/src/frontend/src/router/routes.ts
@@ -59,6 +59,18 @@ export const routes = [
           roles: ['student']
         }
       },
+      {
+        path: '/peer-evaluations',
+        component: () => import('@/features/evaluation/pages/PeerEvaluations.vue'),
+        name: 'peer-evaluations',
+        meta: {
+          title: 'Peer Evaluations',
+          icon: 'mdi-account-star-outline',
+          isMenuItem: true,
+          requiresAuth: true,
+          roles: ['student']
+        }
+      },
 
       // ── Sections ─────────────────────────────────────────────────────────
       {


### PR DESCRIPTION
## Summary
- Implemented UC-28 peer evaluations for students
- Added backend APIs, database migration, validation, and tests
- Added frontend `/peer-evaluations` page with create and update flow
- Fixed the update bug that was redirecting users to login
