### PR TITLE
feat(uc-34): implement generate WAR report for a student

### DIFF
--- a/docs/development-plan.md
+++ b/docs/development-plan.md
@@ -38,7 +38,7 @@ Modules: `auth`, `section`, `rubric`
 | UC-31 | Generate peer eval report for entire section | Not started |
 | UC-32 | Generate WAR report for a team | Done |
 | UC-33 | Generate peer eval report for a student | Not started |
-| UC-34 | Generate WAR report for a student | Not started |
+| UC-34 | Generate WAR report for a student | Done |
 
 ---
 

--- a/src/backend/src/main/java/team/projectpulse/activity/repository/ActivityRepository.java
+++ b/src/backend/src/main/java/team/projectpulse/activity/repository/ActivityRepository.java
@@ -16,4 +16,12 @@ public interface ActivityRepository extends JpaRepository<Activity, Long> {
 
     @Query("SELECT a FROM Activity a JOIN FETCH a.student WHERE a.team.teamId = :teamId AND a.week = :week ORDER BY a.student.lastName ASC, a.student.firstName ASC")
     List<Activity> findByTeamIdAndWeek(@Param("teamId") Long teamId, @Param("week") String week);
+
+    @Query("SELECT a FROM Activity a WHERE a.student.id = :studentId AND a.team.teamId = :teamId AND a.week >= :startWeek AND a.week <= :endWeek ORDER BY a.week ASC, a.activityId ASC")
+    List<Activity> findByStudentIdAndTeamIdAndWeekRange(
+            @Param("studentId") Long studentId,
+            @Param("teamId") Long teamId,
+            @Param("startWeek") String startWeek,
+            @Param("endWeek") String endWeek
+    );
 }

--- a/src/backend/src/main/java/team/projectpulse/report/controller/ReportController.java
+++ b/src/backend/src/main/java/team/projectpulse/report/controller/ReportController.java
@@ -2,12 +2,13 @@ package team.projectpulse.report.controller;
 
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
+import team.projectpulse.report.dto.StudentWarReportResponse;
 import team.projectpulse.report.dto.TeamWarReportResponse;
 import team.projectpulse.report.service.ReportService;
 import team.projectpulse.system.Result;
 
 @RestController
-@RequestMapping("${api.endpoint.base-url}/teams/{teamId}/war-report")
+@RequestMapping("${api.endpoint.base-url}/teams/{teamId}")
 public class ReportController {
 
     private final ReportService reportService;
@@ -16,12 +17,23 @@ public class ReportController {
         this.reportService = reportService;
     }
 
-    @GetMapping
+    @GetMapping("/war-report")
     @PreAuthorize("hasAnyRole('ADMIN', 'INSTRUCTOR', 'STUDENT')")
     public Result<TeamWarReportResponse> getTeamWarReport(
             @PathVariable Long teamId,
             @RequestParam String week
     ) {
         return Result.success(reportService.generateTeamWarReport(teamId, week));
+    }
+
+    @GetMapping("/students/{studentId}/war-report")
+    @PreAuthorize("hasAnyRole('ADMIN', 'INSTRUCTOR')")
+    public Result<StudentWarReportResponse> getStudentWarReport(
+            @PathVariable Long teamId,
+            @PathVariable Long studentId,
+            @RequestParam String startWeek,
+            @RequestParam String endWeek
+    ) {
+        return Result.success(reportService.generateStudentWarReport(teamId, studentId, startWeek, endWeek));
     }
 }

--- a/src/backend/src/main/java/team/projectpulse/report/dto/StudentWarReportResponse.java
+++ b/src/backend/src/main/java/team/projectpulse/report/dto/StudentWarReportResponse.java
@@ -1,0 +1,11 @@
+package team.projectpulse.report.dto;
+
+import java.util.List;
+
+public record StudentWarReportResponse(
+    Long studentId,
+    String studentName,
+    String startWeek,
+    String endWeek,
+    List<StudentWeekWarReport> weekReports
+) {}

--- a/src/backend/src/main/java/team/projectpulse/report/dto/StudentWeekWarReport.java
+++ b/src/backend/src/main/java/team/projectpulse/report/dto/StudentWeekWarReport.java
@@ -1,0 +1,8 @@
+package team.projectpulse.report.dto;
+
+import java.util.List;
+
+public record StudentWeekWarReport(
+    String week,
+    List<WarReportRow> activities
+) {}

--- a/src/backend/src/main/java/team/projectpulse/report/service/ReportService.java
+++ b/src/backend/src/main/java/team/projectpulse/report/service/ReportService.java
@@ -4,14 +4,18 @@ import org.springframework.stereotype.Service;
 import team.projectpulse.activity.domain.Activity;
 import team.projectpulse.activity.repository.ActivityRepository;
 import team.projectpulse.report.dto.StudentWarReport;
+import team.projectpulse.report.dto.StudentWarReportResponse;
+import team.projectpulse.report.dto.StudentWeekWarReport;
 import team.projectpulse.report.dto.TeamWarReportResponse;
 import team.projectpulse.report.dto.WarReportRow;
 import team.projectpulse.team.domain.InvalidTeamException;
 import team.projectpulse.team.domain.Team;
 import team.projectpulse.team.repository.TeamRepository;
 import team.projectpulse.user.domain.User;
+import team.projectpulse.user.repository.UserRepository;
 
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -21,10 +25,12 @@ public class ReportService {
 
     private final TeamRepository teamRepository;
     private final ActivityRepository activityRepository;
+    private final UserRepository userRepository;
 
-    public ReportService(TeamRepository teamRepository, ActivityRepository activityRepository) {
+    public ReportService(TeamRepository teamRepository, ActivityRepository activityRepository, UserRepository userRepository) {
         this.teamRepository = teamRepository;
         this.activityRepository = activityRepository;
+        this.userRepository = userRepository;
     }
 
     public TeamWarReportResponse generateTeamWarReport(Long teamId, String week) {
@@ -66,5 +72,43 @@ public class ReportService {
                 .toList();
 
         return new TeamWarReportResponse(team.getTeamId(), team.getTeamName(), week, studentReports);
+    }
+
+    public StudentWarReportResponse generateStudentWarReport(Long teamId, Long studentId, String startWeek, String endWeek) {
+        teamRepository.findById(teamId)
+                .orElseThrow(() -> new InvalidTeamException("Team not found with id " + teamId));
+
+        User student = userRepository.findById(studentId)
+                .orElseThrow(() -> new InvalidTeamException("Student not found with id " + studentId));
+
+        List<Activity> activities = activityRepository
+                .findByStudentIdAndTeamIdAndWeekRange(studentId, teamId, startWeek, endWeek);
+
+        Map<String, List<Activity>> byWeek = activities.stream()
+                .collect(Collectors.groupingBy(Activity::getWeek, LinkedHashMap::new, Collectors.toList()));
+
+        List<StudentWeekWarReport> weekReports = byWeek.entrySet().stream()
+                .map(entry -> {
+                    List<WarReportRow> rows = entry.getValue().stream()
+                            .map(a -> new WarReportRow(
+                                    a.getCategory().name(),
+                                    a.getPlannedActivity(),
+                                    a.getDescription(),
+                                    a.getPlannedHours(),
+                                    a.getActualHours(),
+                                    a.getStatus().name()
+                            ))
+                            .toList();
+                    return new StudentWeekWarReport(entry.getKey(), rows);
+                })
+                .toList();
+
+        return new StudentWarReportResponse(
+                student.getId(),
+                student.getFirstName() + " " + student.getLastName(),
+                startWeek,
+                endWeek,
+                weekReports
+        );
     }
 }

--- a/src/backend/src/main/resources/db/migration/V9__activities_seed.sql
+++ b/src/backend/src/main/resources/db/migration/V9__activities_seed.sql
@@ -1,8 +1,8 @@
--- V8: Seed activity data for UC-32 WAR report testing
+-- V9: Seed activity data for UC-32/UC-34 WAR report testing
 -- Team 2001 (Pulse Analytics): Ava Johnson (1003), Liam Parker (1004)
 -- Team 2002 (Peer Review Tool): Mia Chen (1005), Ethan Wright (1006) — Ethan has no entries to demo "did not submit"
 
-INSERT INTO activities (team_id, student_id, week, category, planned_activity, description, planned_hours, actual_hours, status) VALUES
+INSERT IGNORE INTO activities (team_id, student_id, week, category, planned_activity, description, planned_hours, actual_hours, status) VALUES
     (2001, 1003, '2026-W16', 'BUGFIX',        'Fix login bug',       'Resolve the authentication redirect issue on mobile.', 4.00, 5.00, 'DONE'),
     (2001, 1003, '2026-W16', 'DOCUMENTATION', 'Write use cases',     'Write three new use cases for the registration flow.', 5.00, 3.00, 'IN_PROGRESS'),
     (2001, 1004, '2026-W16', 'DEVELOPMENT',   'Implement dashboard', 'Add activity summary chart to the team dashboard.',   10.00, 9.00, 'DONE'),

--- a/src/frontend/src/features/report/services/reportService.ts
+++ b/src/frontend/src/features/report/services/reportService.ts
@@ -1,7 +1,9 @@
 import request from '@/shared/utils/request'
-import type { TeamWarReportResponse } from './reportTypes'
 
 const BASE = '/teams'
 
 export const getTeamWarReport = (teamId: number, week: string) =>
   request.get<any>(`${BASE}/${teamId}/war-report`, { params: { week } })
+
+export const getStudentWarReport = (teamId: number, studentId: number, startWeek: string, endWeek: string) =>
+  request.get<any>(`${BASE}/${teamId}/students/${studentId}/war-report`, { params: { startWeek, endWeek } })

--- a/src/frontend/src/features/report/services/reportTypes.ts
+++ b/src/frontend/src/features/report/services/reportTypes.ts
@@ -20,3 +20,16 @@ export interface TeamWarReportResponse {
   week: string
   studentReports: StudentWarReport[]
 }
+
+export interface StudentWeekWarReport {
+  week: string
+  activities: WarReportRow[]
+}
+
+export interface StudentWarReportResponse {
+  studentId: number
+  studentName: string
+  startWeek: string
+  endWeek: string
+  weekReports: StudentWeekWarReport[]
+}

--- a/src/frontend/src/features/team/pages/TeamDetail.vue
+++ b/src/frontend/src/features/team/pages/TeamDetail.vue
@@ -82,8 +82,13 @@
                   :key="member.studentId"
                   size="small"
                   class="mr-1 mb-1"
+                  :color="(isAdmin || isInstructor) ? 'primary' : undefined"
+                  :variant="(isAdmin || isInstructor) ? 'tonal' : 'elevated'"
+                  :style="(isAdmin || isInstructor) ? 'cursor:pointer' : ''"
+                  @click="(isAdmin || isInstructor) && openStudentWarDialog(member)"
                 >
                   {{ member.fullName }}
+                  <v-tooltip v-if="isAdmin || isInstructor" activator="parent">Generate WAR Report</v-tooltip>
                 </v-chip>
               </div>
             </v-card-text>
@@ -710,6 +715,94 @@
       </v-card>
     </v-dialog>
 
+    <!-- Student WAR Report Dialog (UC-34) -->
+    <v-dialog v-model="studentWarDialog" max-width="900" persistent>
+      <v-card>
+        <v-card-title class="pa-6 pb-2">
+          <span class="text-h6">WAR Report — {{ selectedStudent?.fullName }}</span>
+        </v-card-title>
+
+        <v-card-text class="pa-6">
+          <template v-if="studentWarStep === 1">
+            <p class="mb-4 text-body-2">Select the week range to generate the WAR report for this student.</p>
+            <v-row>
+              <v-col cols="12" sm="6">
+                <v-select
+                  v-model="studentWarStartWeek"
+                  :items="activeWeeks"
+                  label="Start Week"
+                  density="compact"
+                  variant="outlined"
+                  :disabled="!activeWeeks.length"
+                />
+              </v-col>
+              <v-col cols="12" sm="6">
+                <v-select
+                  v-model="studentWarEndWeek"
+                  :items="activeWeeks"
+                  label="End Week"
+                  density="compact"
+                  variant="outlined"
+                  :disabled="!activeWeeks.length"
+                />
+              </v-col>
+            </v-row>
+          </template>
+
+          <template v-else>
+            <div class="text-subtitle-1 font-weight-bold mb-4">
+              {{ selectedStudent?.fullName }} — {{ studentWarReport?.startWeek }} to {{ studentWarReport?.endWeek }}
+            </div>
+            <template v-if="studentWarReport && studentWarReport.weekReports.length > 0">
+              <div v-for="weekReport in studentWarReport.weekReports" :key="weekReport.week" class="mb-6">
+                <div class="text-subtitle-2 font-weight-medium mb-2">Week {{ weekReport.week }}</div>
+                <v-table density="compact">
+                  <thead>
+                    <tr>
+                      <th>Category</th>
+                      <th>Planned Activity</th>
+                      <th>Description</th>
+                      <th>Planned Hrs</th>
+                      <th>Actual Hrs</th>
+                      <th>Status</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr v-for="(row, idx) in weekReport.activities" :key="idx">
+                      <td>{{ row.activityCategory }}</td>
+                      <td>{{ row.plannedActivity }}</td>
+                      <td>{{ row.description ?? '—' }}</td>
+                      <td>{{ row.plannedHours ?? '—' }}</td>
+                      <td>{{ row.actualHours ?? '—' }}</td>
+                      <td>{{ row.status }}</td>
+                    </tr>
+                  </tbody>
+                </v-table>
+              </div>
+            </template>
+            <v-alert v-else type="info" variant="tonal">
+              No activity data found for the selected period.
+            </v-alert>
+          </template>
+        </v-card-text>
+
+        <v-card-actions class="px-6 pb-4">
+          <v-spacer />
+          <v-btn variant="outlined" @click="closeStudentWarDialog">Close</v-btn>
+          <v-btn
+            v-if="studentWarStep === 1"
+            color="primary"
+            :disabled="!studentWarStartWeek || !studentWarEndWeek || !activeWeeks.length"
+            :loading="studentWarLoading"
+            @click="generateStudentWarReport"
+          >
+            Generate
+          </v-btn>
+          <v-btn v-else variant="outlined" @click="studentWarStep = 1">Back</v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
+
     <v-snackbar v-model="snackbar.show" :color="snackbar.color" timeout="3000">
       {{ snackbar.message }}
     </v-snackbar>
@@ -723,7 +816,7 @@ import { useUserInfoStore } from '@/stores/userInfo'
 import { deleteTeam, getTeam, removeInstructorFromTeam, removeStudentFromTeam, updateTeam } from '../services/teamService'
 import { useTeamNotificationsStore } from '../stores/teamNotifications'
 import { getSection } from '@/features/section/services/sectionService'
-import { getTeamWarReport } from '@/features/report/services/reportService'
+import { getTeamWarReport, getStudentWarReport } from '@/features/report/services/reportService'
 import type {
   TeamDeletionNotification,
   TeamDetail,
@@ -731,7 +824,7 @@ import type {
   TeamMemberDetail,
   UpdateTeamRequest
 } from '../services/teamTypes'
-import type { TeamWarReportResponse } from '@/features/report/services/reportTypes'
+import type { TeamWarReportResponse, StudentWarReportResponse } from '@/features/report/services/reportTypes'
 
 interface RemovedStudentNotification {
   fullName: string
@@ -784,6 +877,14 @@ const warSelectedWeek = ref<string>('')
 const activeWeeks = ref<string[]>([])
 const warReport = ref<TeamWarReportResponse | null>(null)
 
+const studentWarDialog = ref(false)
+const studentWarStep = ref(1)
+const studentWarLoading = ref(false)
+const studentWarStartWeek = ref<string>('')
+const studentWarEndWeek = ref<string>('')
+const selectedStudent = ref<{ studentId: number; fullName: string } | null>(null)
+const studentWarReport = ref<StudentWarReportResponse | null>(null)
+
 const emptyForm = () => ({
   teamName: '',
   teamDescription: '',
@@ -793,6 +894,7 @@ const emptyForm = () => ({
 const form = ref(emptyForm())
 
 const isAdmin = computed(() => userInfoStore.isAdmin)
+const isInstructor = computed(() => userInfoStore.isInstructor)
 
 const previewPayload = computed<UpdateTeamRequest>(() => ({
   teamName: form.value.teamName.trim(),
@@ -1147,6 +1249,62 @@ function closeWarDialog() {
   warDialog.value = false
   warStep.value = 1
   warReport.value = null
+}
+
+async function openStudentWarDialog(member: { studentId: number; fullName: string }) {
+  if (!team.value) return
+  selectedStudent.value = member
+  studentWarStep.value = 1
+  studentWarReport.value = null
+  studentWarStartWeek.value = ''
+  studentWarEndWeek.value = ''
+  studentWarDialog.value = true
+
+  if (!activeWeeks.value.length) {
+    try {
+      const res = await getSection(team.value.sectionId) as any
+      if (res.flag && res.data?.activeWeeks) {
+        activeWeeks.value = [...res.data.activeWeeks].sort()
+      }
+    } catch {
+      snackbar.value = { show: true, message: 'Failed to load section weeks.', color: 'error' }
+    }
+  }
+
+  if (activeWeeks.value.length) {
+    studentWarStartWeek.value = activeWeeks.value[0] as string
+    studentWarEndWeek.value = activeWeeks.value[activeWeeks.value.length - 1] as string
+  }
+}
+
+async function generateStudentWarReport() {
+  if (!team.value || !selectedStudent.value || !studentWarStartWeek.value || !studentWarEndWeek.value) return
+  studentWarLoading.value = true
+  try {
+    const res = await getStudentWarReport(
+      team.value.teamId,
+      selectedStudent.value.studentId,
+      studentWarStartWeek.value,
+      studentWarEndWeek.value
+    ) as any
+    if (res.flag) {
+      studentWarReport.value = res.data
+      studentWarStep.value = 2
+    } else {
+      snackbar.value = { show: true, message: res.message || 'Failed to generate report.', color: 'error' }
+    }
+  } catch {
+    snackbar.value = { show: true, message: 'An error occurred generating the report.', color: 'error' }
+  } finally {
+    studentWarLoading.value = false
+  }
+}
+
+function closeStudentWarDialog() {
+  studentWarDialog.value = false
+  studentWarStep.value = 1
+  studentWarReport.value = null
+  selectedStudent.value = null
 }
 </script>
 


### PR DESCRIPTION
- Add GET /teams/{teamId}/students/{studentId}/war-report endpoint (ADMIN/INSTRUCTOR)
- Add StudentWarReportResponse and StudentWeekWarReport DTOs
- Add generateStudentWarReport service method (grouped by week, date-ordered)
- Add findByStudentIdAndTeamIdAndWeekRange JPQL query to ActivityRepository
- Add getStudentWarReport frontend service call and types
- Add student WAR report dialog to TeamDetail (clickable student chips for admin/instructor)
- Rename V8__activities_seed.sql to V9 to resolve version conflict with peer_evaluations migration