### PR TITLE
feat(uc-29): add student peer evaluation report

### DIFF
--- a/src/backend/src/main/java/team/projectpulse/evaluation/repository/EvaluationSubmissionRepository.java
+++ b/src/backend/src/main/java/team/projectpulse/evaluation/repository/EvaluationSubmissionRepository.java
@@ -56,4 +56,37 @@ public interface EvaluationSubmissionRepository extends JpaRepository<Evaluation
         where entry.submission.submissionId = :submissionId
         """)
     java.util.List<team.projectpulse.evaluation.domain.EvaluationEntry> loadScores(@Param("submissionId") Long submissionId);
+
+    @Query("""
+        select distinct entry from EvaluationEntry entry
+        join fetch entry.submission submission
+        join fetch submission.team team
+        join fetch team.section section
+        join fetch submission.evaluatorStudent evaluator
+        join fetch entry.evaluateeStudent evaluatee
+        where evaluatee.id = :evaluateeStudentId
+          and submission.week = :week
+        """)
+    java.util.List<team.projectpulse.evaluation.domain.EvaluationEntry> findReceivedEntriesByEvaluateeStudentIdAndWeek(
+        @Param("evaluateeStudentId") Long evaluateeStudentId,
+        @Param("week") String week
+    );
+
+    @Query("""
+        select distinct entry from EvaluationEntry entry
+        left join fetch entry.scores score
+        left join fetch score.criterion criterion
+        where entry.entryId in :entryIds
+        """)
+    java.util.List<team.projectpulse.evaluation.domain.EvaluationEntry> loadScoresByEntryIds(@Param("entryIds") java.util.List<Long> entryIds);
+
+    default java.util.List<team.projectpulse.evaluation.domain.EvaluationEntry> findEntriesByEvaluateeStudentIdAndWeek(Long evaluateeStudentId, String week) {
+        java.util.List<team.projectpulse.evaluation.domain.EvaluationEntry> entries =
+            findReceivedEntriesByEvaluateeStudentIdAndWeek(evaluateeStudentId, week);
+        if (entries.isEmpty()) {
+            return entries;
+        }
+        loadScoresByEntryIds(entries.stream().map(team.projectpulse.evaluation.domain.EvaluationEntry::getEntryId).toList());
+        return entries;
+    }
 }

--- a/src/backend/src/main/java/team/projectpulse/evaluation/service/EvaluationService.java
+++ b/src/backend/src/main/java/team/projectpulse/evaluation/service/EvaluationService.java
@@ -23,6 +23,7 @@ import team.projectpulse.rubric.repository.RubricRepository;
 import team.projectpulse.section.domain.Section;
 import team.projectpulse.team.domain.Team;
 import team.projectpulse.team.repository.TeamRepository;
+import team.projectpulse.system.IsoWeekUtils;
 import team.projectpulse.user.domain.User;
 import team.projectpulse.user.repository.UserRepository;
 
@@ -32,8 +33,6 @@ import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
-import java.time.format.DateTimeFormatter;
-import java.time.temporal.WeekFields;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.LinkedHashMap;
@@ -48,8 +47,6 @@ import java.util.Set;
 public class EvaluationService {
 
     private static final int MAX_COMMENT_LENGTH = 2000;
-    private static final DateTimeFormatter DATE_FORMAT = DateTimeFormatter.ofPattern("MM-dd-yyyy");
-    private static final WeekFields ISO = WeekFields.ISO;
 
     private final EvaluationSubmissionRepository evaluationSubmissionRepository;
     private final UserRepository userRepository;
@@ -117,8 +114,8 @@ public class EvaluationService {
             .orElse(baseTeam);
 
         LocalDate today = LocalDate.now(clock);
-        String currentWeek = toIsoWeek(today);
-        String previousWeek = toIsoWeek(today.minusWeeks(1));
+        String currentWeek = IsoWeekUtils.toIsoWeek(today);
+        String previousWeek = IsoWeekUtils.toIsoWeek(today.minusWeeks(1));
         LocalDateTime dueAt = resolveDueAt(section, today);
 
         if (!isActiveWeek(section, currentWeek)) {
@@ -128,8 +125,8 @@ public class EvaluationService {
                 team.getTeamId(),
                 team.getTeamName(),
                 previousWeek,
-                formatWeekLabel(previousWeek),
-                formatWeekRangeLabel(previousWeek),
+                IsoWeekUtils.formatWeekLabel(previousWeek),
+                IsoWeekUtils.formatWeekRangeLabel(previousWeek),
                 "Peer evaluations can only be submitted during active weeks."
             );
         }
@@ -141,8 +138,8 @@ public class EvaluationService {
                 team.getTeamId(),
                 team.getTeamName(),
                 previousWeek,
-                formatWeekLabel(previousWeek),
-                formatWeekRangeLabel(previousWeek),
+                IsoWeekUtils.formatWeekLabel(previousWeek),
+                IsoWeekUtils.formatWeekRangeLabel(previousWeek),
                 "The previous week is not an active week for peer evaluations."
             );
         }
@@ -156,8 +153,8 @@ public class EvaluationService {
                 team.getTeamId(),
                 team.getTeamName(),
                 previousWeek,
-                formatWeekLabel(previousWeek),
-                formatWeekRangeLabel(previousWeek),
+                IsoWeekUtils.formatWeekLabel(previousWeek),
+                IsoWeekUtils.formatWeekRangeLabel(previousWeek),
                 "This section does not have a peer evaluation rubric configured."
             );
         }
@@ -177,8 +174,8 @@ public class EvaluationService {
                 team.getTeamId(),
                 team.getTeamName(),
                 previousWeek,
-                formatWeekLabel(previousWeek),
-                formatWeekRangeLabel(previousWeek),
+                IsoWeekUtils.formatWeekLabel(previousWeek),
+                IsoWeekUtils.formatWeekRangeLabel(previousWeek),
                 null,
                 false,
                 false,
@@ -197,8 +194,8 @@ public class EvaluationService {
             team.getTeamId(),
             team.getTeamName(),
             previousWeek,
-            formatWeekLabel(previousWeek),
-            formatWeekRangeLabel(previousWeek),
+            IsoWeekUtils.formatWeekLabel(previousWeek),
+            IsoWeekUtils.formatWeekRangeLabel(previousWeek),
             submission == null ? null : submission.getSubmissionId(),
             submission != null,
             beforeOrAtDeadline,
@@ -290,8 +287,8 @@ public class EvaluationService {
             .orElse(baseTeam);
 
         LocalDate today = LocalDate.now(clock);
-        String currentWeek = toIsoWeek(today);
-        String previousWeek = toIsoWeek(today.minusWeeks(1));
+        String currentWeek = IsoWeekUtils.toIsoWeek(today);
+        String previousWeek = IsoWeekUtils.toIsoWeek(today.minusWeeks(1));
         LocalDateTime dueAt = resolveDueAt(section, today);
 
         if (!isActiveWeek(section, currentWeek)) {
@@ -562,11 +559,11 @@ public class EvaluationService {
             return section.getActiveWeeks() == null ? List.of() : new ArrayList<>(section.getActiveWeeks());
         }
 
-        LocalDate cursor = toMonday(section.getStartDate());
-        LocalDate end = toMonday(section.getEndDate());
+        LocalDate cursor = IsoWeekUtils.toMonday(section.getStartDate());
+        LocalDate end = IsoWeekUtils.toMonday(section.getEndDate());
         List<String> weeks = new ArrayList<>();
         while (!cursor.isAfter(end)) {
-            weeks.add(toIsoWeek(cursor));
+            weeks.add(IsoWeekUtils.toIsoWeek(cursor));
             cursor = cursor.plusWeeks(1);
         }
         return weeks;
@@ -587,7 +584,7 @@ public class EvaluationService {
             throw new InvalidPeerEvaluationException("Peer evaluation due time is not configured correctly for this section.");
         }
 
-        LocalDate weekStart = toMonday(today);
+        LocalDate weekStart = IsoWeekUtils.toMonday(today);
         return LocalDateTime.of(weekStart.with(dueDay), dueTime);
     }
 
@@ -599,39 +596,6 @@ public class EvaluationService {
 
     private String fullName(User user) {
         return user.getFirstName() + " " + user.getLastName();
-    }
-
-    private LocalDate toMonday(LocalDate date) {
-        return date.with(DayOfWeek.MONDAY);
-    }
-
-    private String toIsoWeek(LocalDate date) {
-        int weekYear = date.get(ISO.weekBasedYear());
-        int weekNumber = date.get(ISO.weekOfWeekBasedYear());
-        return "%d-W%02d".formatted(weekYear, weekNumber);
-    }
-
-    private String formatWeekLabel(String isoWeek) {
-        String[] parts = isoWeek.split("-W");
-        return "Week " + Integer.parseInt(parts[1]) + " (" + parts[0] + ")";
-    }
-
-    private String formatWeekRangeLabel(String isoWeek) {
-        LocalDate start = parseIsoWeekStart(isoWeek);
-        LocalDate end = start.plusDays(6);
-        return DATE_FORMAT.format(start) + " -- " + DATE_FORMAT.format(end);
-    }
-
-    private LocalDate parseIsoWeekStart(String isoWeek) {
-        if (isoWeek == null || !isoWeek.matches("\\d{4}-W\\d{2}")) {
-            throw new InvalidPeerEvaluationException("Invalid ISO week format.");
-        }
-        String[] parts = isoWeek.split("-W");
-        int year = Integer.parseInt(parts[0]);
-        int week = Integer.parseInt(parts[1]);
-        return LocalDate.of(year, 1, 4)
-            .with(ISO.weekOfWeekBasedYear(), week)
-            .with(ISO.dayOfWeek(), 1);
     }
 
     private record SubmissionContext(

--- a/src/backend/src/main/java/team/projectpulse/report/controller/ReportExceptionHandler.java
+++ b/src/backend/src/main/java/team/projectpulse/report/controller/ReportExceptionHandler.java
@@ -1,0 +1,19 @@
+package team.projectpulse.report.controller;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import team.projectpulse.report.domain.InvalidPeerEvaluationReportException;
+import team.projectpulse.system.Result;
+import team.projectpulse.system.StatusCode;
+
+@RestControllerAdvice
+public class ReportExceptionHandler {
+
+    @ExceptionHandler(InvalidPeerEvaluationReportException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public Result<Void> handleInvalidPeerEvaluationReport(InvalidPeerEvaluationReportException ex) {
+        return Result.error(StatusCode.INVALID_ARGUMENT, ex.getMessage());
+    }
+}

--- a/src/backend/src/main/java/team/projectpulse/report/controller/StudentPeerEvaluationReportController.java
+++ b/src/backend/src/main/java/team/projectpulse/report/controller/StudentPeerEvaluationReportController.java
@@ -1,0 +1,31 @@
+package team.projectpulse.report.controller;
+
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import team.projectpulse.report.dto.StudentPeerEvaluationReportResponse;
+import team.projectpulse.report.service.ReportService;
+import team.projectpulse.system.Result;
+
+@RestController
+@RequestMapping("${api.endpoint.base-url}/reports/peer-evaluations/me")
+public class StudentPeerEvaluationReportController {
+
+    private final ReportService reportService;
+
+    public StudentPeerEvaluationReportController(ReportService reportService) {
+        this.reportService = reportService;
+    }
+
+    @GetMapping
+    @PreAuthorize("hasRole('STUDENT')")
+    public Result<StudentPeerEvaluationReportResponse> getOwnPeerEvaluationReport(
+        Authentication authentication,
+        @RequestParam(required = false) String week
+    ) {
+        return Result.success(reportService.generateOwnPeerEvaluationReport(authentication.getName(), week));
+    }
+}

--- a/src/backend/src/main/java/team/projectpulse/report/domain/InvalidPeerEvaluationReportException.java
+++ b/src/backend/src/main/java/team/projectpulse/report/domain/InvalidPeerEvaluationReportException.java
@@ -1,0 +1,8 @@
+package team.projectpulse.report.domain;
+
+public class InvalidPeerEvaluationReportException extends RuntimeException {
+
+    public InvalidPeerEvaluationReportException(String message) {
+        super(message);
+    }
+}

--- a/src/backend/src/main/java/team/projectpulse/report/dto/ReportWeekOption.java
+++ b/src/backend/src/main/java/team/projectpulse/report/dto/ReportWeekOption.java
@@ -1,0 +1,8 @@
+package team.projectpulse.report.dto;
+
+public record ReportWeekOption(
+    String week,
+    String label,
+    String rangeLabel
+) {
+}

--- a/src/backend/src/main/java/team/projectpulse/report/dto/StudentPeerEvaluationCriterionAverageDto.java
+++ b/src/backend/src/main/java/team/projectpulse/report/dto/StudentPeerEvaluationCriterionAverageDto.java
@@ -1,0 +1,12 @@
+package team.projectpulse.report.dto;
+
+import java.math.BigDecimal;
+
+public record StudentPeerEvaluationCriterionAverageDto(
+    Long criterionId,
+    String criterion,
+    String description,
+    BigDecimal averageScore,
+    double maxScore
+) {
+}

--- a/src/backend/src/main/java/team/projectpulse/report/dto/StudentPeerEvaluationReportResponse.java
+++ b/src/backend/src/main/java/team/projectpulse/report/dto/StudentPeerEvaluationReportResponse.java
@@ -1,0 +1,24 @@
+package team.projectpulse.report.dto;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+public record StudentPeerEvaluationReportResponse(
+    Long sectionId,
+    String sectionName,
+    Long teamId,
+    String teamName,
+    Long studentId,
+    String studentName,
+    String selectedWeek,
+    String selectedWeekLabel,
+    String selectedWeekRangeLabel,
+    List<ReportWeekOption> availableWeeks,
+    boolean reportAvailable,
+    String availabilityMessage,
+    List<StudentPeerEvaluationCriterionAverageDto> criterionAverages,
+    List<String> publicComments,
+    BigDecimal overallGrade,
+    Integer maxTotalScore
+) {
+}

--- a/src/backend/src/main/java/team/projectpulse/report/service/ReportService.java
+++ b/src/backend/src/main/java/team/projectpulse/report/service/ReportService.java
@@ -1,19 +1,38 @@
 package team.projectpulse.report.service;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import team.projectpulse.activity.domain.Activity;
 import team.projectpulse.activity.repository.ActivityRepository;
+import team.projectpulse.evaluation.domain.EvaluationEntry;
+import team.projectpulse.evaluation.domain.EvaluationScore;
+import team.projectpulse.evaluation.repository.EvaluationSubmissionRepository;
 import team.projectpulse.report.dto.StudentWarReport;
+import team.projectpulse.report.dto.ReportWeekOption;
+import team.projectpulse.report.dto.StudentPeerEvaluationCriterionAverageDto;
+import team.projectpulse.report.dto.StudentPeerEvaluationReportResponse;
 import team.projectpulse.report.dto.TeamWarReportResponse;
 import team.projectpulse.report.dto.WarReportRow;
+import team.projectpulse.report.domain.InvalidPeerEvaluationReportException;
+import team.projectpulse.rubric.domain.Criterion;
+import team.projectpulse.section.domain.Section;
 import team.projectpulse.team.domain.InvalidTeamException;
 import team.projectpulse.team.domain.Team;
 import team.projectpulse.team.repository.TeamRepository;
+import team.projectpulse.system.IsoWeekUtils;
 import team.projectpulse.user.domain.User;
+import team.projectpulse.user.repository.UserRepository;
 
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.Clock;
+import java.time.LocalDate;
 import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 @Service
@@ -21,10 +40,32 @@ public class ReportService {
 
     private final TeamRepository teamRepository;
     private final ActivityRepository activityRepository;
+    private final EvaluationSubmissionRepository evaluationSubmissionRepository;
+    private final UserRepository userRepository;
+    private final Clock clock;
 
-    public ReportService(TeamRepository teamRepository, ActivityRepository activityRepository) {
+    @Autowired
+    public ReportService(
+        TeamRepository teamRepository,
+        ActivityRepository activityRepository,
+        EvaluationSubmissionRepository evaluationSubmissionRepository,
+        UserRepository userRepository
+    ) {
+        this(teamRepository, activityRepository, evaluationSubmissionRepository, userRepository, Clock.systemDefaultZone());
+    }
+
+    ReportService(
+        TeamRepository teamRepository,
+        ActivityRepository activityRepository,
+        EvaluationSubmissionRepository evaluationSubmissionRepository,
+        UserRepository userRepository,
+        Clock clock
+    ) {
         this.teamRepository = teamRepository;
         this.activityRepository = activityRepository;
+        this.evaluationSubmissionRepository = evaluationSubmissionRepository;
+        this.userRepository = userRepository;
+        this.clock = clock;
     }
 
     public TeamWarReportResponse generateTeamWarReport(Long teamId, String week) {
@@ -66,5 +107,208 @@ public class ReportService {
                 .toList();
 
         return new TeamWarReportResponse(team.getTeamId(), team.getTeamName(), week, studentReports);
+    }
+
+    public StudentPeerEvaluationReportResponse generateOwnPeerEvaluationReport(String studentEmail, String requestedWeek) {
+        User student = requireStudent(studentEmail);
+        Section section = student.getSection();
+        if (section == null) {
+            throw new InvalidPeerEvaluationReportException("You must belong to a senior design section to view your peer evaluation report.");
+        }
+
+        List<String> availableWeeks = deriveAvailableWeeks(section);
+        if (availableWeeks.isEmpty()) {
+            throw new InvalidPeerEvaluationReportException("No active peer evaluation report weeks are available.");
+        }
+
+        String selectedWeek = resolveSelectedWeek(availableWeeks, requestedWeek);
+        List<ReportWeekOption> weekOptions = availableWeeks.stream()
+            .map(week -> new ReportWeekOption(
+                week,
+                IsoWeekUtils.formatWeekLabel(week),
+                IsoWeekUtils.formatWeekRangeLabel(week)
+            ))
+            .toList();
+
+        List<EvaluationEntry> teammateEntries = evaluationSubmissionRepository
+            .findEntriesByEvaluateeStudentIdAndWeek(student.getId(), selectedWeek)
+            .stream()
+            .filter(entry -> !Objects.equals(entry.getSubmission().getEvaluatorStudent().getId(), student.getId()))
+            .sorted(Comparator
+                .comparing((EvaluationEntry entry) -> entry.getSubmission().getEvaluatorStudent().getLastName(), String.CASE_INSENSITIVE_ORDER)
+                .thenComparing(entry -> entry.getSubmission().getEvaluatorStudent().getFirstName(), String.CASE_INSENSITIVE_ORDER))
+            .toList();
+
+        if (teammateEntries.isEmpty()) {
+            return new StudentPeerEvaluationReportResponse(
+                section.getSectionId(),
+                section.getSectionName(),
+                null,
+                null,
+                student.getId(),
+                student.getFirstName() + " " + student.getLastName(),
+                selectedWeek,
+                IsoWeekUtils.formatWeekLabel(selectedWeek),
+                IsoWeekUtils.formatWeekRangeLabel(selectedWeek),
+                weekOptions,
+                false,
+                "No peer evaluation data is available for the selected week.",
+                List.of(),
+                List.of(),
+                null,
+                null
+            );
+        }
+
+        Team team = teammateEntries.getFirst().getSubmission().getTeam();
+        List<StudentPeerEvaluationCriterionAverageDto> criterionAverages = buildCriterionAverages(teammateEntries);
+        List<String> publicComments = teammateEntries.stream()
+            .map(EvaluationEntry::getPublicComment)
+            .filter(Objects::nonNull)
+            .map(String::trim)
+            .filter(comment -> !comment.isEmpty())
+            .toList();
+        BigDecimal overallGrade = buildOverallGrade(teammateEntries);
+        Integer maxTotalScore = criterionAverages.isEmpty()
+            ? null
+            : criterionAverages.stream().mapToInt(average -> (int) average.maxScore()).sum();
+
+        return new StudentPeerEvaluationReportResponse(
+            section.getSectionId(),
+            section.getSectionName(),
+            team.getTeamId(),
+            team.getTeamName(),
+            student.getId(),
+            student.getFirstName() + " " + student.getLastName(),
+            selectedWeek,
+            IsoWeekUtils.formatWeekLabel(selectedWeek),
+            IsoWeekUtils.formatWeekRangeLabel(selectedWeek),
+            weekOptions,
+            true,
+            null,
+            criterionAverages,
+            publicComments,
+            overallGrade,
+            maxTotalScore
+        );
+    }
+
+    private List<StudentPeerEvaluationCriterionAverageDto> buildCriterionAverages(List<EvaluationEntry> entries) {
+        Map<Long, CriterionAggregate> aggregates = new LinkedHashMap<>();
+        for (EvaluationEntry entry : entries) {
+            for (EvaluationScore score : entry.getScores()) {
+                Criterion criterion = score.getCriterion();
+                aggregates.computeIfAbsent(
+                    criterion.getCriterionId(),
+                    ignored -> new CriterionAggregate(criterion)
+                ).add(score.getScore());
+            }
+        }
+
+        return aggregates.values().stream()
+            .sorted(Comparator.comparing(aggregate -> aggregate.criterion().getCriterionId()))
+            .map(aggregate -> new StudentPeerEvaluationCriterionAverageDto(
+                aggregate.criterion().getCriterionId(),
+                aggregate.criterion().getCriterion(),
+                aggregate.criterion().getDescription(),
+                average(aggregate.total(), aggregate.count()),
+                aggregate.criterion().getMaxScore()
+            ))
+            .toList();
+    }
+
+    private BigDecimal buildOverallGrade(List<EvaluationEntry> entries) {
+        BigDecimal total = entries.stream()
+            .map(entry -> entry.getScores().stream()
+                .map(EvaluationScore::getScore)
+                .map(BigDecimal::valueOf)
+                .reduce(BigDecimal.ZERO, BigDecimal::add))
+            .reduce(BigDecimal.ZERO, BigDecimal::add);
+        return average(total, entries.size());
+    }
+
+    private BigDecimal average(BigDecimal total, int count) {
+        return total.divide(BigDecimal.valueOf(count), 2, RoundingMode.HALF_UP);
+    }
+
+    private User requireStudent(String studentEmail) {
+        User student = userRepository.findByEmail(studentEmail)
+            .orElseThrow(() -> new InvalidPeerEvaluationReportException("No student account found for the current user."));
+        if (!isStudent(student)) {
+            throw new InvalidPeerEvaluationReportException("Only students can view their peer evaluation report.");
+        }
+        return student;
+    }
+
+    private boolean isStudent(User user) {
+        String roles = user.getRoles() == null ? "" : user.getRoles().toLowerCase();
+        return List.of(roles.split("\\s+")).contains("student");
+    }
+
+    private List<String> deriveAvailableWeeks(Section section) {
+        String currentWeek = IsoWeekUtils.toIsoWeek(LocalDate.now(clock));
+        List<String> sectionWeeks = deriveSectionWeeks(section);
+        return sectionWeeks.stream()
+            .filter(week -> section.getActiveWeeks() != null && section.getActiveWeeks().contains(week))
+            .filter(week -> IsoWeekUtils.parseIsoWeekStart(week).isBefore(IsoWeekUtils.parseIsoWeekStart(currentWeek)))
+            .sorted(IsoWeekUtils.descendingComparator())
+            .toList();
+    }
+
+    private String resolveSelectedWeek(List<String> availableWeeks, String requestedWeek) {
+        if (requestedWeek != null && !requestedWeek.isBlank()) {
+            if (!availableWeeks.contains(requestedWeek)) {
+                throw new InvalidPeerEvaluationReportException("The selected week is not available for your peer evaluation report.");
+            }
+            return requestedWeek;
+        }
+
+        String previousWeek = IsoWeekUtils.toIsoWeek(LocalDate.now(clock).minusWeeks(1));
+        if (availableWeeks.contains(previousWeek)) {
+            return previousWeek;
+        }
+        return availableWeeks.getFirst();
+    }
+
+    private List<String> deriveSectionWeeks(Section section) {
+        if (section.getStartDate() == null || section.getEndDate() == null) {
+            return List.of();
+        }
+
+        LocalDate cursor = IsoWeekUtils.toMonday(section.getStartDate());
+        LocalDate end = IsoWeekUtils.toMonday(section.getEndDate());
+        List<String> weeks = new ArrayList<>();
+        while (!cursor.isAfter(end)) {
+            weeks.add(IsoWeekUtils.toIsoWeek(cursor));
+            cursor = cursor.plusWeeks(1);
+        }
+        return weeks;
+    }
+
+    private static final class CriterionAggregate {
+        private final Criterion criterion;
+        private BigDecimal total = BigDecimal.ZERO;
+        private int count = 0;
+
+        private CriterionAggregate(Criterion criterion) {
+            this.criterion = criterion;
+        }
+
+        private void add(Integer score) {
+            total = total.add(BigDecimal.valueOf(score));
+            count++;
+        }
+
+        private Criterion criterion() {
+            return criterion;
+        }
+
+        private BigDecimal total() {
+            return total;
+        }
+
+        private int count() {
+            return count;
+        }
     }
 }

--- a/src/backend/src/main/java/team/projectpulse/system/IsoWeekUtils.java
+++ b/src/backend/src/main/java/team/projectpulse/system/IsoWeekUtils.java
@@ -1,0 +1,62 @@
+package team.projectpulse.system;
+
+import team.projectpulse.evaluation.domain.InvalidPeerEvaluationException;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.WeekFields;
+import java.util.Comparator;
+import java.util.List;
+
+public final class IsoWeekUtils {
+
+    private static final WeekFields ISO = WeekFields.ISO;
+    private static final DateTimeFormatter DATE_FORMAT = DateTimeFormatter.ofPattern("MM-dd-yyyy");
+
+    private IsoWeekUtils() {
+    }
+
+    public static String toIsoWeek(LocalDate date) {
+        int weekYear = date.get(ISO.weekBasedYear());
+        int weekNumber = date.get(ISO.weekOfWeekBasedYear());
+        return "%d-W%02d".formatted(weekYear, weekNumber);
+    }
+
+    public static LocalDate parseIsoWeekStart(String isoWeek) {
+        if (isoWeek == null || !isoWeek.matches("\\d{4}-W\\d{2}")) {
+            throw new InvalidPeerEvaluationException("Invalid ISO week format.");
+        }
+        String[] parts = isoWeek.split("-W");
+        int year = Integer.parseInt(parts[0]);
+        int week = Integer.parseInt(parts[1]);
+        return LocalDate.of(year, 1, 4)
+            .with(ISO.weekOfWeekBasedYear(), week)
+            .with(ISO.dayOfWeek(), 1);
+    }
+
+    public static String formatWeekLabel(String isoWeek) {
+        String[] parts = isoWeek.split("-W");
+        return "Week " + Integer.parseInt(parts[1]) + " (" + parts[0] + ")";
+    }
+
+    public static String formatWeekRangeLabel(String isoWeek) {
+        LocalDate start = parseIsoWeekStart(isoWeek);
+        LocalDate end = start.plusDays(6);
+        return DATE_FORMAT.format(start) + " -- " + DATE_FORMAT.format(end);
+    }
+
+    public static LocalDate toMonday(LocalDate date) {
+        return date.with(DayOfWeek.MONDAY);
+    }
+
+    public static Comparator<String> descendingComparator() {
+        return Comparator.comparing(IsoWeekUtils::parseIsoWeekStart).reversed();
+    }
+
+    public static List<String> sortDescending(List<String> isoWeeks) {
+        return isoWeeks.stream()
+            .sorted(descendingComparator())
+            .toList();
+    }
+}

--- a/src/backend/src/main/resources/db/migration/V8__activities_seed.sql
+++ b/src/backend/src/main/resources/db/migration/V8__activities_seed.sql
@@ -1,9 +1,0 @@
--- V8: Seed activity data for UC-32 WAR report testing
--- Team 2001 (Pulse Analytics): Ava Johnson (1003), Liam Parker (1004)
--- Team 2002 (Peer Review Tool): Mia Chen (1005), Ethan Wright (1006) — Ethan has no entries to demo "did not submit"
-
-INSERT INTO activities (team_id, student_id, week, category, planned_activity, description, planned_hours, actual_hours, status) VALUES
-    (2001, 1003, '2026-W16', 'BUGFIX',        'Fix login bug',       'Resolve the authentication redirect issue on mobile.', 4.00, 5.00, 'DONE'),
-    (2001, 1003, '2026-W16', 'DOCUMENTATION', 'Write use cases',     'Write three new use cases for the registration flow.', 5.00, 3.00, 'IN_PROGRESS'),
-    (2001, 1004, '2026-W16', 'DEVELOPMENT',   'Implement dashboard', 'Add activity summary chart to the team dashboard.',   10.00, 9.00, 'DONE'),
-    (2002, 1005, '2026-W16', 'TESTING',       'Write unit tests',    'Cover AuthService with unit tests.',                   6.00, 6.50, 'DONE');

--- a/src/backend/src/main/resources/db/migration/V9__activities_seed.sql
+++ b/src/backend/src/main/resources/db/migration/V9__activities_seed.sql
@@ -1,0 +1,61 @@
+-- V9: Seed activity data for UC-32 WAR report testing
+-- Team 2001 (Pulse Analytics): Ava Johnson (1003), Liam Parker (1004)
+-- Team 2002 (Peer Review Tool): Mia Chen (1005), Ethan Wright (1006) — Ethan has no entries to demo "did not submit"
+
+INSERT INTO users (id, first_name, last_name, email, password, roles, enabled)
+VALUES
+    (1001, 'Ivy',   'Stone',   'ivy.stone@tcu.edu',    '$2y$10$xsTQw5eM..haCE5neBk7AOEYqyvE65uyBlLZo.svoOKNKmrwfPLcG', 'instructor', TRUE),
+    (1002, 'Noah',  'Bennett', 'noah.bennett@tcu.edu', '$2y$10$xsTQw5eM..haCE5neBk7AOEYqyvE65uyBlLZo.svoOKNKmrwfPLcG', 'instructor', TRUE),
+    (1003, 'Ava',   'Johnson', 'ava.johnson@tcu.edu',  '$2y$10$xsTQw5eM..haCE5neBk7AOEYqyvE65uyBlLZo.svoOKNKmrwfPLcG', 'student', TRUE),
+    (1004, 'Liam',  'Parker',  'liam.parker@tcu.edu',  '$2y$10$xsTQw5eM..haCE5neBk7AOEYqyvE65uyBlLZo.svoOKNKmrwfPLcG', 'student', TRUE),
+    (1005, 'Mia',   'Chen',    'mia.chen@tcu.edu',     '$2y$10$xsTQw5eM..haCE5neBk7AOEYqyvE65uyBlLZo.svoOKNKmrwfPLcG', 'student', TRUE),
+    (1006, 'Ethan', 'Wright',  'ethan.wright@tcu.edu', '$2y$10$xsTQw5eM..haCE5neBk7AOEYqyvE65uyBlLZo.svoOKNKmrwfPLcG', 'student', TRUE)
+ON DUPLICATE KEY UPDATE
+    first_name = VALUES(first_name),
+    last_name = VALUES(last_name),
+    password = VALUES(password),
+    roles = VALUES(roles),
+    enabled = VALUES(enabled);
+
+INSERT INTO teams (team_id, section_id, team_name, team_description, team_website_url)
+SELECT
+    2001,
+    section_id,
+    'Pulse Analytics',
+    'Analytics dashboard for tracking senior design team progress.',
+    'https://pulse-analytics.example.com'
+FROM sections
+WHERE section_name = 'Spring 2026 – Section A'
+ON DUPLICATE KEY UPDATE
+    section_id = VALUES(section_id),
+    team_description = VALUES(team_description),
+    team_website_url = VALUES(team_website_url);
+
+INSERT INTO teams (team_id, section_id, team_name, team_description, team_website_url)
+SELECT
+    2002,
+    section_id,
+    'Peer Review Tool',
+    'Platform for collecting and summarizing peer evaluation feedback.',
+    'https://peer-review-tool.example.com'
+FROM sections
+WHERE section_name = 'Spring 2026 – Section A'
+ON DUPLICATE KEY UPDATE
+    section_id = VALUES(section_id),
+    team_description = VALUES(team_description),
+    team_website_url = VALUES(team_website_url);
+
+INSERT INTO team_students (team_id, user_id)
+VALUES
+    (2001, 1003),
+    (2001, 1004),
+    (2002, 1005),
+    (2002, 1006)
+ON DUPLICATE KEY UPDATE
+    team_id = VALUES(team_id);
+
+INSERT INTO activities (team_id, student_id, week, category, planned_activity, description, planned_hours, actual_hours, status) VALUES
+    (2001, 1003, '2026-W16', 'BUGFIX',        'Fix login bug',       'Resolve the authentication redirect issue on mobile.', 4.00, 5.00, 'DONE'),
+    (2001, 1003, '2026-W16', 'DOCUMENTATION', 'Write use cases',     'Write three new use cases for the registration flow.', 5.00, 3.00, 'IN_PROGRESS'),
+    (2001, 1004, '2026-W16', 'DEVELOPMENT',   'Implement dashboard', 'Add activity summary chart to the team dashboard.',   10.00, 9.00, 'DONE'),
+    (2002, 1005, '2026-W16', 'TESTING',       'Write unit tests',    'Cover AuthService with unit tests.',                   6.00, 6.50, 'DONE');

--- a/src/backend/src/test/java/team/projectpulse/config/ControllerTestSecurityConfig.java
+++ b/src/backend/src/test/java/team/projectpulse/config/ControllerTestSecurityConfig.java
@@ -2,6 +2,7 @@ package team.projectpulse.config;
 
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
@@ -14,6 +15,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 
 @TestConfiguration
+@EnableMethodSecurity
 public class ControllerTestSecurityConfig {
 
     @Bean

--- a/src/backend/src/test/java/team/projectpulse/evaluation/repository/EvaluationSubmissionRepositoryIntegrationTest.java
+++ b/src/backend/src/test/java/team/projectpulse/evaluation/repository/EvaluationSubmissionRepositoryIntegrationTest.java
@@ -116,6 +116,22 @@ class EvaluationSubmissionRepositoryIntegrationTest {
         assertEquals(2, managedSubmission.getEntries().size());
     }
 
+    @Test
+    void should_FetchReceivedEntriesByEvaluateeAndWeek_When_QueryingReportData() {
+        SeededData data = seedSubmission();
+
+        List<EvaluationEntry> entries = evaluationSubmissionRepository.findEntriesByEvaluateeStudentIdAndWeek(
+            data.teammate().getId(),
+            "2026-W16"
+        );
+
+        assertEquals(1, entries.size());
+        assertEquals(data.evaluator().getId(), entries.getFirst().getSubmission().getEvaluatorStudent().getId());
+        assertEquals("Great teammate", entries.getFirst().getPublicComment());
+        assertEquals("Reliable", entries.getFirst().getPrivateComment());
+        assertEquals(2, entries.getFirst().getScores().size());
+    }
+
     private SeededData seedSubmission() {
         Criterion participation = new Criterion();
         participation.setCriterion("Participation");

--- a/src/backend/src/test/java/team/projectpulse/report/controller/StudentPeerEvaluationReportControllerIntegrationTest.java
+++ b/src/backend/src/test/java/team/projectpulse/report/controller/StudentPeerEvaluationReportControllerIntegrationTest.java
@@ -1,0 +1,115 @@
+package team.projectpulse.report.controller;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import team.projectpulse.config.ControllerTestSecurityConfig;
+import team.projectpulse.report.domain.InvalidPeerEvaluationReportException;
+import team.projectpulse.report.dto.ReportWeekOption;
+import team.projectpulse.report.dto.StudentPeerEvaluationCriterionAverageDto;
+import team.projectpulse.report.dto.StudentPeerEvaluationReportResponse;
+import team.projectpulse.report.service.ReportService;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = StudentPeerEvaluationReportController.class)
+@Import({ReportExceptionHandler.class, ControllerTestSecurityConfig.class})
+@ActiveProfiles("test")
+class StudentPeerEvaluationReportControllerIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private ReportService reportService;
+
+    @Test
+    @WithMockUser(username = "ava.johnson@tcu.edu", roles = "STUDENT")
+    void should_LoadReportWithDefaultWeek_When_StudentRequestsIt() throws Exception {
+        when(reportService.generateOwnPeerEvaluationReport("ava.johnson@tcu.edu", null)).thenReturn(response());
+
+        mockMvc.perform(get("/api/v1/reports/peer-evaluations/me"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.flag").value(true))
+            .andExpect(jsonPath("$.data.studentName").value("Ava Johnson"))
+            .andExpect(jsonPath("$.data.selectedWeek").value("2026-W16"));
+    }
+
+    @Test
+    @WithMockUser(username = "ava.johnson@tcu.edu", roles = "STUDENT")
+    void should_LoadReportForExplicitValidWeek_When_StudentRequestsIt() throws Exception {
+        when(reportService.generateOwnPeerEvaluationReport("ava.johnson@tcu.edu", "2026-W16")).thenReturn(response());
+
+        mockMvc.perform(get("/api/v1/reports/peer-evaluations/me").param("week", "2026-W16"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.flag").value(true))
+            .andExpect(jsonPath("$.data.selectedWeek").value("2026-W16"));
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void should_ReturnForbidden_When_AdminRequestsReport() throws Exception {
+        mockMvc.perform(get("/api/v1/reports/peer-evaluations/me"))
+            .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @WithMockUser(roles = "INSTRUCTOR")
+    void should_ReturnForbidden_When_InstructorRequestsReport() throws Exception {
+        mockMvc.perform(get("/api/v1/reports/peer-evaluations/me"))
+            .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void should_ReturnUnauthorized_When_UnauthenticatedUserRequestsReport() throws Exception {
+        mockMvc.perform(get("/api/v1/reports/peer-evaluations/me"))
+            .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @WithMockUser(username = "ava.johnson@tcu.edu", roles = "STUDENT")
+    void should_ReturnBadRequest_When_WeekIsInvalid() throws Exception {
+        when(reportService.generateOwnPeerEvaluationReport(eq("ava.johnson@tcu.edu"), eq("2026-W18")))
+            .thenThrow(new InvalidPeerEvaluationReportException("The selected week is not available for your peer evaluation report."));
+
+        mockMvc.perform(get("/api/v1/reports/peer-evaluations/me").param("week", "2026-W18"))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.flag").value(false))
+            .andExpect(jsonPath("$.code").value(400))
+            .andExpect(jsonPath("$.message").value("The selected week is not available for your peer evaluation report."));
+    }
+
+    private StudentPeerEvaluationReportResponse response() {
+        return new StudentPeerEvaluationReportResponse(
+            1L,
+            "Spring 2026 - Section A",
+            2001L,
+            "Pulse Analytics",
+            1003L,
+            "Ava Johnson",
+            "2026-W16",
+            "Week 16 (2026)",
+            "04-13-2026 -- 04-19-2026",
+            List.of(new ReportWeekOption("2026-W16", "Week 16 (2026)", "04-13-2026 -- 04-19-2026")),
+            true,
+            null,
+            List.of(new StudentPeerEvaluationCriterionAverageDto(1L, "Participation", "Participates", new BigDecimal("8.50"), 10)),
+            List.of("Great teammate."),
+            new BigDecimal("17.00"),
+            20
+        );
+    }
+
+}

--- a/src/backend/src/test/java/team/projectpulse/report/service/ReportServiceTest.java
+++ b/src/backend/src/test/java/team/projectpulse/report/service/ReportServiceTest.java
@@ -1,0 +1,277 @@
+package team.projectpulse.report.service;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import team.projectpulse.activity.repository.ActivityRepository;
+import team.projectpulse.evaluation.domain.EvaluationEntry;
+import team.projectpulse.evaluation.domain.EvaluationScore;
+import team.projectpulse.evaluation.domain.EvaluationSubmission;
+import team.projectpulse.evaluation.repository.EvaluationSubmissionRepository;
+import team.projectpulse.report.domain.InvalidPeerEvaluationReportException;
+import team.projectpulse.report.dto.StudentPeerEvaluationReportResponse;
+import team.projectpulse.rubric.domain.Criterion;
+import team.projectpulse.section.domain.Section;
+import team.projectpulse.team.domain.Team;
+import team.projectpulse.team.repository.TeamRepository;
+import team.projectpulse.user.domain.User;
+import team.projectpulse.user.repository.UserRepository;
+
+import java.math.BigDecimal;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ReportServiceTest {
+
+    @Mock
+    private TeamRepository teamRepository;
+
+    @Mock
+    private ActivityRepository activityRepository;
+
+    @Mock
+    private EvaluationSubmissionRepository evaluationSubmissionRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    private final Clock clock = Clock.fixed(
+        Instant.parse("2026-04-24T12:00:00Z"),
+        ZoneId.of("America/Chicago")
+    );
+
+    @Test
+    void should_LoadDefaultPreviousActiveWeek_When_WeekIsOmitted() {
+        ReportService service = service();
+        Section section = buildSection(List.of("2026-W14", "2026-W15", "2026-W16"));
+        User student = buildStudent(1003L, "Ava", "Johnson", section);
+
+        when(userRepository.findByEmail("ava.johnson@tcu.edu")).thenReturn(Optional.of(student));
+        when(evaluationSubmissionRepository.findEntriesByEvaluateeStudentIdAndWeek(1003L, "2026-W16")).thenReturn(List.of(teammateEntry(student, section)));
+
+        StudentPeerEvaluationReportResponse response = service.generateOwnPeerEvaluationReport("ava.johnson@tcu.edu", null);
+
+        assertEquals("2026-W16", response.selectedWeek());
+        assertTrue(response.reportAvailable());
+    }
+
+    @Test
+    void should_FallBackToMostRecentPastWeek_When_PreviousWeekIsNotSelectable() {
+        ReportService service = service();
+        Section section = buildSection(List.of("2026-W13", "2026-W15"));
+        User student = buildStudent(1003L, "Ava", "Johnson", section);
+
+        when(userRepository.findByEmail("ava.johnson@tcu.edu")).thenReturn(Optional.of(student));
+        when(evaluationSubmissionRepository.findEntriesByEvaluateeStudentIdAndWeek(1003L, "2026-W15")).thenReturn(List.of(teammateEntry(student, section)));
+
+        StudentPeerEvaluationReportResponse response = service.generateOwnPeerEvaluationReport("ava.johnson@tcu.edu", null);
+
+        assertEquals("2026-W15", response.selectedWeek());
+    }
+
+    @Test
+    void should_RejectRequestedWeek_When_NotActive() {
+        ReportService service = service();
+        Section section = buildSection(List.of("2026-W15"));
+        User student = buildStudent(1003L, "Ava", "Johnson", section);
+
+        when(userRepository.findByEmail("ava.johnson@tcu.edu")).thenReturn(Optional.of(student));
+
+        InvalidPeerEvaluationReportException ex = assertThrows(
+            InvalidPeerEvaluationReportException.class,
+            () -> service.generateOwnPeerEvaluationReport("ava.johnson@tcu.edu", "2026-W14")
+        );
+
+        assertEquals("The selected week is not available for your peer evaluation report.", ex.getMessage());
+    }
+
+    @Test
+    void should_RejectRequestedWeek_When_CurrentOrFuture() {
+        ReportService service = service();
+        Section section = buildSection(List.of("2026-W16", "2026-W17", "2026-W18"));
+        User student = buildStudent(1003L, "Ava", "Johnson", section);
+
+        when(userRepository.findByEmail("ava.johnson@tcu.edu")).thenReturn(Optional.of(student));
+
+        InvalidPeerEvaluationReportException ex = assertThrows(
+            InvalidPeerEvaluationReportException.class,
+            () -> service.generateOwnPeerEvaluationReport("ava.johnson@tcu.edu", "2026-W17")
+        );
+
+        assertEquals("The selected week is not available for your peer evaluation report.", ex.getMessage());
+    }
+
+    @Test
+    void should_Reject_When_UserIsNotStudent() {
+        ReportService service = service();
+        User instructor = buildUser(3001L, "Ivy", "Stone", "instructor", null);
+
+        when(userRepository.findByEmail("ivy.stone@tcu.edu")).thenReturn(Optional.of(instructor));
+
+        InvalidPeerEvaluationReportException ex = assertThrows(
+            InvalidPeerEvaluationReportException.class,
+            () -> service.generateOwnPeerEvaluationReport("ivy.stone@tcu.edu", null)
+        );
+
+        assertEquals("Only students can view their peer evaluation report.", ex.getMessage());
+    }
+
+    @Test
+    void should_Reject_When_StudentHasNoSection() {
+        ReportService service = service();
+        User student = buildStudent(1003L, "Ava", "Johnson", null);
+
+        when(userRepository.findByEmail("ava.johnson@tcu.edu")).thenReturn(Optional.of(student));
+
+        InvalidPeerEvaluationReportException ex = assertThrows(
+            InvalidPeerEvaluationReportException.class,
+            () -> service.generateOwnPeerEvaluationReport("ava.johnson@tcu.edu", null)
+        );
+
+        assertEquals("You must belong to a senior design section to view your peer evaluation report.", ex.getMessage());
+    }
+
+    @Test
+    void should_ReturnNoDataResponse_When_NoTeammateEvaluationsExist() {
+        ReportService service = service();
+        Section section = buildSection(List.of("2026-W16"));
+        User student = buildStudent(1003L, "Ava", "Johnson", section);
+
+        when(userRepository.findByEmail("ava.johnson@tcu.edu")).thenReturn(Optional.of(student));
+        when(evaluationSubmissionRepository.findEntriesByEvaluateeStudentIdAndWeek(1003L, "2026-W16")).thenReturn(List.of(selfEntry(student, section)));
+
+        StudentPeerEvaluationReportResponse response = service.generateOwnPeerEvaluationReport("ava.johnson@tcu.edu", null);
+
+        assertFalse(response.reportAvailable());
+        assertEquals("No peer evaluation data is available for the selected week.", response.availabilityMessage());
+        assertTrue(response.publicComments().isEmpty());
+        assertNull(response.overallGrade());
+    }
+
+    @Test
+    void should_ExcludeSelfEvaluationAndPrivateComments_When_ComputingReport() {
+        ReportService service = service();
+        Section section = buildSection(List.of("2026-W16"));
+        User student = buildStudent(1003L, "Ava", "Johnson", section);
+        EvaluationEntry self = selfEntry(student, section);
+        EvaluationEntry teammateOne = teammateEntry(student, section);
+        EvaluationEntry teammateTwo = teammateEntry(student, section);
+        teammateTwo.getScores().get(0).setScore(6);
+        teammateTwo.getScores().get(1).setScore(8);
+        teammateTwo.setPublicComment("Needs more consistency.");
+
+        when(userRepository.findByEmail("ava.johnson@tcu.edu")).thenReturn(Optional.of(student));
+        when(evaluationSubmissionRepository.findEntriesByEvaluateeStudentIdAndWeek(1003L, "2026-W16"))
+            .thenReturn(List.of(self, teammateOne, teammateTwo));
+
+        StudentPeerEvaluationReportResponse response = service.generateOwnPeerEvaluationReport("ava.johnson@tcu.edu", null);
+
+        assertTrue(response.reportAvailable());
+        assertEquals(new BigDecimal("7.50"), response.criterionAverages().get(0).averageScore());
+        assertEquals(new BigDecimal("9.00"), response.criterionAverages().get(1).averageScore());
+        assertEquals(new BigDecimal("16.50"), response.overallGrade());
+        assertEquals(List.of("Great teammate.", "Needs more consistency."), response.publicComments());
+        assertEquals(20, response.maxTotalScore());
+    }
+
+    private ReportService service() {
+        return new ReportService(
+            teamRepository,
+            activityRepository,
+            evaluationSubmissionRepository,
+            userRepository,
+            clock
+        );
+    }
+
+    private Section buildSection(List<String> activeWeeks) {
+        Section section = new Section();
+        section.setSectionId(1L);
+        section.setSectionName("Spring 2026 - Section A");
+        section.setStartDate(LocalDate.of(2026, 1, 12));
+        section.setEndDate(LocalDate.of(2026, 5, 8));
+        section.setActiveWeeks(activeWeeks);
+        return section;
+    }
+
+    private User buildStudent(Long id, String firstName, String lastName, Section section) {
+        return buildUser(id, firstName, lastName, "student", section);
+    }
+
+    private User buildUser(Long id, String firstName, String lastName, String role, Section section) {
+        User user = new User();
+        user.setId(id);
+        user.setFirstName(firstName);
+        user.setLastName(lastName);
+        user.setEmail(firstName.toLowerCase() + "." + lastName.toLowerCase() + "@tcu.edu");
+        user.setRoles(role);
+        user.setEnabled(true);
+        user.setSection(section);
+        return user;
+    }
+
+    private EvaluationEntry selfEntry(User student, Section section) {
+        User selfEvaluator = buildStudent(student.getId(), student.getFirstName(), student.getLastName(), section);
+        return buildEntry(student, selfEvaluator, "Self reflection", "Instructor only", 10, 10);
+    }
+
+    private EvaluationEntry teammateEntry(User student, Section section) {
+        User evaluator = buildStudent(1004L, "Liam", "Parker", section);
+        return buildEntry(student, evaluator, "Great teammate.", "Private note", 9, 10);
+    }
+
+    private EvaluationEntry buildEntry(User evaluatee, User evaluator, String publicComment, String privateComment, int scoreOne, int scoreTwo) {
+        Criterion participation = criterion(1L, "Participation", "Participates", 10);
+        Criterion communication = criterion(2L, "Communication", "Communicates", 10);
+
+        EvaluationEntry entry = new EvaluationEntry();
+        entry.setEntryId(evaluator.getId() + 1000);
+        entry.setEvaluateeStudent(evaluatee);
+        entry.setPublicComment(publicComment);
+        entry.setPrivateComment(privateComment);
+
+        EvaluationSubmission submission = new EvaluationSubmission();
+        submission.setSubmissionId(evaluator.getId() + 5000);
+        submission.setWeek("2026-W16");
+        submission.setEvaluatorStudent(evaluator);
+        Team team = new Team();
+        team.setTeamId(2001L);
+        team.setTeamName("Pulse Analytics");
+        team.setSection(evaluatee.getSection());
+        submission.setTeam(team);
+        entry.setSubmission(submission);
+
+        entry.addScore(score(participation, scoreOne));
+        entry.addScore(score(communication, scoreTwo));
+        return entry;
+    }
+
+    private EvaluationScore score(Criterion criterion, int value) {
+        EvaluationScore score = new EvaluationScore();
+        score.setCriterion(criterion);
+        score.setScore(value);
+        return score;
+    }
+
+    private Criterion criterion(Long id, String name, String description, double maxScore) {
+        Criterion criterion = new Criterion();
+        criterion.setCriterionId(id);
+        criterion.setCriterion(name);
+        criterion.setDescription(description);
+        criterion.setMaxScore(maxScore);
+        return criterion;
+    }
+}

--- a/src/frontend/src/features/report/pages/MyPeerEvaluationReport.vue
+++ b/src/frontend/src/features/report/pages/MyPeerEvaluationReport.vue
@@ -1,0 +1,229 @@
+<template>
+  <v-container>
+    <v-row class="mb-4" align="center">
+      <v-col>
+        <h2 class="text-h5 font-weight-bold">My Peer Evaluation Report</h2>
+        <div class="text-body-2 text-medium-emphasis">
+          Review your averaged peer evaluation scores, public comments, and overall grade for an active week.
+        </div>
+      </v-col>
+    </v-row>
+
+    <v-card variant="outlined" class="mb-4">
+      <v-card-text class="pa-4">
+        <v-row align="center" class="ga-0">
+          <v-col cols="12" md="4">
+            <v-select
+              v-model="selectedWeek"
+              :items="weekOptions"
+              item-title="title"
+              item-value="value"
+              label="Active Week"
+              :disabled="loading || !report?.availableWeeks.length"
+            />
+          </v-col>
+          <v-col cols="12" md="8" class="text-md-right">
+            <v-btn color="primary" :loading="loading" :disabled="!selectedWeek" @click="loadReport(selectedWeek, true)">
+              Generate Report
+            </v-btn>
+          </v-col>
+        </v-row>
+      </v-card-text>
+    </v-card>
+
+    <v-row v-if="loading">
+      <v-col class="text-center">
+        <v-progress-circular indeterminate />
+      </v-col>
+    </v-row>
+
+    <template v-else-if="report">
+      <v-card variant="outlined" class="mb-4">
+        <v-card-text class="pa-4">
+          <v-row>
+            <v-col cols="12" md="8" class="d-flex flex-wrap ga-2">
+              <v-chip v-if="report.sectionName" color="primary" variant="tonal">
+                {{ report.sectionName }}
+              </v-chip>
+              <v-chip v-if="report.teamName" color="secondary" variant="tonal">
+                {{ report.teamName }}
+              </v-chip>
+              <v-chip color="success" variant="tonal">
+                {{ report.selectedWeekLabel }}
+              </v-chip>
+              <v-chip variant="outlined">
+                {{ report.selectedWeekRangeLabel }}
+              </v-chip>
+            </v-col>
+            <v-col cols="12" md="4" class="text-md-right">
+              <div class="text-caption text-medium-emphasis">Student</div>
+              <div class="text-body-1 font-weight-medium">{{ report.studentName }}</div>
+            </v-col>
+          </v-row>
+        </v-card-text>
+      </v-card>
+
+      <v-alert
+        v-if="!report.reportAvailable"
+        type="info"
+        variant="tonal"
+        class="mb-4"
+      >
+        {{ report.availabilityMessage || 'No peer evaluation data is available for the selected week.' }}
+      </v-alert>
+
+      <template v-else>
+        <v-card variant="outlined" class="mb-4">
+          <v-card-text class="pa-4">
+            <div class="text-caption text-medium-emphasis mb-1">Overall Grade</div>
+            <div class="text-h5 font-weight-bold">
+              {{ overallGradeLabel }}
+            </div>
+          </v-card-text>
+        </v-card>
+
+        <v-card variant="outlined" class="mb-4">
+          <v-card-title class="pa-4 pb-2">Criterion Averages</v-card-title>
+          <v-card-text class="pt-0">
+            <v-row>
+              <v-col
+                v-for="criterion in report.criterionAverages"
+                :key="criterion.criterionId"
+                cols="12"
+                md="6"
+              >
+                <v-card variant="tonal" color="surface" class="criterion-card">
+                  <v-card-text class="criterion-card__body">
+                    <div class="criterion-card__title text-subtitle-1 font-weight-medium">{{ criterion.criterion }}</div>
+                    <div v-if="criterion.description" class="criterion-card__description text-body-2 mb-3">
+                      {{ criterion.description }}
+                    </div>
+                    <div class="criterion-card__score text-h6">
+                      {{ formatDecimal(criterion.averageScore) }} / {{ formatMaxScore(criterion.maxScore) }}
+                    </div>
+                  </v-card-text>
+                </v-card>
+              </v-col>
+            </v-row>
+          </v-card-text>
+        </v-card>
+
+        <v-card variant="outlined">
+          <v-card-title class="pa-4 pb-2">Public Comments</v-card-title>
+          <v-card-text class="pt-0">
+            <v-list v-if="report.publicComments.length" lines="two">
+              <v-list-item
+                v-for="(comment, index) in report.publicComments"
+                :key="`${report.selectedWeek}-${index}`"
+              >
+                <template #prepend>
+                  <v-icon icon="mdi-comment-text-outline" />
+                </template>
+                <v-list-item-title class="preserve-lines">{{ comment }}</v-list-item-title>
+              </v-list-item>
+            </v-list>
+            <div v-else class="text-body-2 text-medium-emphasis">
+              No public comments were provided for this week.
+            </div>
+          </v-card-text>
+        </v-card>
+      </template>
+    </template>
+
+    <v-snackbar v-model="snackbar.show" :color="snackbar.color" timeout="3000">
+      {{ snackbar.message }}
+    </v-snackbar>
+  </v-container>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted, ref } from 'vue'
+import { getMyPeerEvaluationReport } from '../services/reportService'
+import type { StudentPeerEvaluationReportResponse } from '../services/reportTypes'
+
+const loading = ref(false)
+const selectedWeek = ref<string>('')
+const report = ref<StudentPeerEvaluationReportResponse | null>(null)
+const snackbar = ref({ show: false, message: '', color: 'success' })
+
+const weekOptions = computed(() =>
+  (report.value?.availableWeeks ?? []).map((week) => ({
+    title: `${week.label} — ${week.rangeLabel}`,
+    value: week.week
+  }))
+)
+
+const overallGradeLabel = computed(() => {
+  if (!report.value || report.value.overallGrade == null || report.value.maxTotalScore == null) {
+    return '—'
+  }
+  return `${formatDecimal(report.value.overallGrade)} / ${report.value.maxTotalScore}`
+})
+
+onMounted(async () => {
+  await loadReport(undefined, false)
+})
+
+async function loadReport(week?: string, userInitiated = false) {
+  loading.value = true
+  try {
+    const response = await getMyPeerEvaluationReport(week)
+    report.value = response.flag ? response.data : null
+    if (report.value) {
+      selectedWeek.value = report.value.selectedWeek
+      if (userInitiated) {
+        snackbar.value = {
+          show: true,
+          message: report.value.reportAvailable
+            ? 'Report refreshed.'
+            : (report.value.availabilityMessage || 'No peer evaluation data is available for the selected week.'),
+          color: report.value.reportAvailable ? 'success' : 'info'
+        }
+      }
+    }
+  } catch (err: any) {
+    snackbar.value = {
+      show: true,
+      message: err?.response?.data?.message || 'An error occurred generating the report.',
+      color: 'error'
+    }
+  } finally {
+    loading.value = false
+  }
+}
+
+function formatDecimal(value: number) {
+  return Number(value).toString()
+}
+
+function formatMaxScore(value: number) {
+  return Number.isInteger(value) ? String(value) : Number(value).toString()
+}
+</script>
+
+<style scoped>
+.preserve-lines {
+  white-space: pre-line;
+}
+
+.criterion-card {
+  background: #f3f6fb !important;
+}
+
+.criterion-card__body {
+  color: #1f2937;
+}
+
+.criterion-card__title {
+  color: #1f2937;
+}
+
+.criterion-card__description {
+  color: #4b5563;
+}
+
+.criterion-card__score {
+  color: #0f172a;
+  font-weight: 700;
+}
+</style>

--- a/src/frontend/src/features/report/services/reportService.ts
+++ b/src/frontend/src/features/report/services/reportService.ts
@@ -1,7 +1,14 @@
 import request from '@/shared/utils/request'
-import type { TeamWarReportResponse } from './reportTypes'
+import type { ApiResponse } from '@/shared/types/api'
+import type { StudentPeerEvaluationReportResponse, TeamWarReportResponse } from './reportTypes'
 
 const BASE = '/teams'
+const REPORT_BASE = '/reports'
 
 export const getTeamWarReport = (teamId: number, week: string) =>
   request.get<any>(`${BASE}/${teamId}/war-report`, { params: { week } })
+
+export const getMyPeerEvaluationReport = (week?: string) =>
+  request.get<ApiResponse<StudentPeerEvaluationReportResponse>>(`${REPORT_BASE}/peer-evaluations/me`, {
+    params: week ? { week } : undefined
+  }) as unknown as Promise<ApiResponse<StudentPeerEvaluationReportResponse>>

--- a/src/frontend/src/features/report/services/reportTypes.ts
+++ b/src/frontend/src/features/report/services/reportTypes.ts
@@ -20,3 +20,36 @@ export interface TeamWarReportResponse {
   week: string
   studentReports: StudentWarReport[]
 }
+
+export interface ReportWeekOption {
+  week: string
+  label: string
+  rangeLabel: string
+}
+
+export interface StudentPeerEvaluationCriterionAverage {
+  criterionId: number
+  criterion: string
+  description: string | null
+  averageScore: number
+  maxScore: number
+}
+
+export interface StudentPeerEvaluationReportResponse {
+  sectionId: number | null
+  sectionName: string | null
+  teamId: number | null
+  teamName: string | null
+  studentId: number
+  studentName: string
+  selectedWeek: string
+  selectedWeekLabel: string
+  selectedWeekRangeLabel: string
+  availableWeeks: ReportWeekOption[]
+  reportAvailable: boolean
+  availabilityMessage: string | null
+  criterionAverages: StudentPeerEvaluationCriterionAverage[]
+  publicComments: string[]
+  overallGrade: number | null
+  maxTotalScore: number | null
+}

--- a/src/frontend/src/router/routes.ts
+++ b/src/frontend/src/router/routes.ts
@@ -71,6 +71,18 @@ export const routes = [
           roles: ['student']
         }
       },
+      {
+        path: '/peer-evaluation-report',
+        component: () => import('@/features/report/pages/MyPeerEvaluationReport.vue'),
+        name: 'peer-evaluation-report',
+        meta: {
+          title: 'My Peer Report',
+          icon: 'mdi-file-chart-outline',
+          isMenuItem: true,
+          requiresAuth: true,
+          roles: ['student']
+        }
+      },
 
       // ── Sections ─────────────────────────────────────────────────────────
       {

--- a/src/frontend/src/shared/components/TopNavigationBar.vue
+++ b/src/frontend/src/shared/components/TopNavigationBar.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-app-bar flat border="b" color="white" height="56">
+  <v-app-bar flat border="b" color="white" height="64" class="top-nav">
     <v-app-bar-nav-icon @click="toggleCollapse" />
 
     <v-breadcrumbs :items="breadcrumbItems" density="compact" class="ml-0 px-0">
@@ -137,6 +137,13 @@ function confirmLogout() {
 </script>
 
 <style lang="scss" scoped>
+.top-nav {
+  :deep(.v-toolbar__content) {
+    min-height: 64px !important;
+    padding-inline: 20px 16px;
+  }
+}
+
 .user-btn {
   text-transform: none;
   letter-spacing: 0;


### PR DESCRIPTION
## Summary
- Implemented UC-29 student peer evaluation report
- Added backend report API, DTOs, validation, and tests
- Added frontend `My Peer Report` page and route
- Fixed report refresh feedback and criterion score visibility
- Fixed migration ordering/startup issues for local dev