### PR TITLE
feat(uc-31): implement peer evaluation report for entire section

### DIFF
--- a/docs/development-plan.md
+++ b/docs/development-plan.md
@@ -35,7 +35,7 @@ Modules: `auth`, `section`, `rubric`
 | UC-5 | Edit a senior design section | Done |
 | UC-6 | Set up active weeks for a section | Done |
 | UC-25 | Student sets up a student account | Done |
-| UC-31 | Generate peer eval report for entire section | Not started |
+| UC-31 | Generate peer eval report for entire section | Done |
 | UC-32 | Generate WAR report for a team | Done |
 | UC-33 | Generate peer eval report for a student | Not started |
 | UC-34 | Generate WAR report for a student | Done |

--- a/src/backend/src/main/java/team/projectpulse/evaluation/repository/EvaluationSubmissionRepository.java
+++ b/src/backend/src/main/java/team/projectpulse/evaluation/repository/EvaluationSubmissionRepository.java
@@ -56,4 +56,30 @@ public interface EvaluationSubmissionRepository extends JpaRepository<Evaluation
         where entry.submission.submissionId = :submissionId
         """)
     java.util.List<team.projectpulse.evaluation.domain.EvaluationEntry> loadScores(@Param("submissionId") Long submissionId);
+
+    @Query("""
+        select distinct e from EvaluationEntry e
+        join fetch e.submission s
+        join fetch s.evaluatorStudent evaluator
+        join fetch e.evaluateeStudent evaluatee
+        left join fetch e.scores score
+        left join fetch score.criterion criterion
+        where s.team.section.sectionId = :sectionId
+          and s.week = :week
+        """)
+    java.util.List<team.projectpulse.evaluation.domain.EvaluationEntry> findEntriesWithScoresBySectionIdAndWeek(
+            @Param("sectionId") Long sectionId,
+            @Param("week") String week
+    );
+
+    @Query("""
+        select distinct s.evaluatorStudent.id
+        from EvaluationSubmission s
+        where s.team.section.sectionId = :sectionId
+          and s.week = :week
+        """)
+    java.util.List<Long> findSubmitterIdsBySectionIdAndWeek(
+            @Param("sectionId") Long sectionId,
+            @Param("week") String week
+    );
 }

--- a/src/backend/src/main/java/team/projectpulse/report/controller/SectionReportController.java
+++ b/src/backend/src/main/java/team/projectpulse/report/controller/SectionReportController.java
@@ -1,0 +1,27 @@
+package team.projectpulse.report.controller;
+
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+import team.projectpulse.report.dto.SectionPeerEvalReportResponse;
+import team.projectpulse.report.service.ReportService;
+import team.projectpulse.system.Result;
+
+@RestController
+@RequestMapping("${api.endpoint.base-url}/sections/{sectionId}")
+public class SectionReportController {
+
+    private final ReportService reportService;
+
+    public SectionReportController(ReportService reportService) {
+        this.reportService = reportService;
+    }
+
+    @GetMapping("/peer-eval-report")
+    @PreAuthorize("hasAnyRole('ADMIN', 'INSTRUCTOR')")
+    public Result<SectionPeerEvalReportResponse> getSectionPeerEvalReport(
+            @PathVariable Long sectionId,
+            @RequestParam String week
+    ) {
+        return Result.success(reportService.generateSectionPeerEvalReport(sectionId, week));
+    }
+}

--- a/src/backend/src/main/java/team/projectpulse/report/dto/EvalReportEntry.java
+++ b/src/backend/src/main/java/team/projectpulse/report/dto/EvalReportEntry.java
@@ -1,0 +1,9 @@
+package team.projectpulse.report.dto;
+
+public record EvalReportEntry(
+        String evaluatorName,
+        double totalScore,
+        double maxScore,
+        String publicComment,
+        String privateComment
+) {}

--- a/src/backend/src/main/java/team/projectpulse/report/dto/SectionPeerEvalReportResponse.java
+++ b/src/backend/src/main/java/team/projectpulse/report/dto/SectionPeerEvalReportResponse.java
@@ -1,0 +1,10 @@
+package team.projectpulse.report.dto;
+
+import java.util.List;
+
+public record SectionPeerEvalReportResponse(
+        Long sectionId,
+        String sectionName,
+        String week,
+        List<StudentPeerEvalReport> studentReports
+) {}

--- a/src/backend/src/main/java/team/projectpulse/report/dto/StudentPeerEvalReport.java
+++ b/src/backend/src/main/java/team/projectpulse/report/dto/StudentPeerEvalReport.java
@@ -1,0 +1,13 @@
+package team.projectpulse.report.dto;
+
+import java.util.List;
+
+public record StudentPeerEvalReport(
+        Long studentId,
+        String studentName,
+        String teamName,
+        boolean submitted,
+        Double grade,
+        Double maxGrade,
+        List<EvalReportEntry> evaluations
+) {}

--- a/src/backend/src/main/java/team/projectpulse/report/service/ReportService.java
+++ b/src/backend/src/main/java/team/projectpulse/report/service/ReportService.java
@@ -3,11 +3,19 @@ package team.projectpulse.report.service;
 import org.springframework.stereotype.Service;
 import team.projectpulse.activity.domain.Activity;
 import team.projectpulse.activity.repository.ActivityRepository;
+import team.projectpulse.evaluation.domain.EvaluationEntry;
+import team.projectpulse.evaluation.domain.EvaluationScore;
+import team.projectpulse.evaluation.repository.EvaluationSubmissionRepository;
+import team.projectpulse.report.dto.EvalReportEntry;
+import team.projectpulse.report.dto.SectionPeerEvalReportResponse;
+import team.projectpulse.report.dto.StudentPeerEvalReport;
 import team.projectpulse.report.dto.StudentWarReport;
 import team.projectpulse.report.dto.StudentWarReportResponse;
 import team.projectpulse.report.dto.StudentWeekWarReport;
 import team.projectpulse.report.dto.TeamWarReportResponse;
 import team.projectpulse.report.dto.WarReportRow;
+import team.projectpulse.section.domain.Section;
+import team.projectpulse.section.repository.SectionRepository;
 import team.projectpulse.team.domain.InvalidTeamException;
 import team.projectpulse.team.domain.Team;
 import team.projectpulse.team.repository.TeamRepository;
@@ -18,6 +26,7 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 @Service
@@ -26,11 +35,17 @@ public class ReportService {
     private final TeamRepository teamRepository;
     private final ActivityRepository activityRepository;
     private final UserRepository userRepository;
+    private final SectionRepository sectionRepository;
+    private final EvaluationSubmissionRepository evaluationSubmissionRepository;
 
-    public ReportService(TeamRepository teamRepository, ActivityRepository activityRepository, UserRepository userRepository) {
+    public ReportService(TeamRepository teamRepository, ActivityRepository activityRepository,
+                         UserRepository userRepository, SectionRepository sectionRepository,
+                         EvaluationSubmissionRepository evaluationSubmissionRepository) {
         this.teamRepository = teamRepository;
         this.activityRepository = activityRepository;
         this.userRepository = userRepository;
+        this.sectionRepository = sectionRepository;
+        this.evaluationSubmissionRepository = evaluationSubmissionRepository;
     }
 
     public TeamWarReportResponse generateTeamWarReport(Long teamId, String week) {
@@ -110,5 +125,75 @@ public class ReportService {
                 endWeek,
                 weekReports
         );
+    }
+
+    public SectionPeerEvalReportResponse generateSectionPeerEvalReport(Long sectionId, String week) {
+        Section section = sectionRepository.findById(sectionId)
+                .orElseThrow(() -> new InvalidTeamException("Section not found with id " + sectionId));
+
+        List<Team> teams = teamRepository.findAllBySectionIdWithStudentsOrdered(sectionId);
+
+        List<User> allStudents = teams.stream()
+                .flatMap(t -> t.getStudents().stream())
+                .distinct()
+                .sorted((a, b) -> {
+                    int cmp = a.getLastName().compareToIgnoreCase(b.getLastName());
+                    return cmp != 0 ? cmp : a.getFirstName().compareToIgnoreCase(b.getFirstName());
+                })
+                .toList();
+
+        Map<Long, String> studentTeamNames = new java.util.HashMap<>();
+        for (Team team : teams) {
+            for (User student : team.getStudents()) {
+                studentTeamNames.put(student.getId(), team.getTeamName());
+            }
+        }
+
+        List<EvaluationEntry> entries = evaluationSubmissionRepository
+                .findEntriesWithScoresBySectionIdAndWeek(sectionId, week);
+
+        Set<Long> submitterIds = new java.util.HashSet<>(
+                evaluationSubmissionRepository.findSubmitterIdsBySectionIdAndWeek(sectionId, week)
+        );
+
+        Map<Long, List<EvaluationEntry>> entriesByEvaluatee = entries.stream()
+                .collect(Collectors.groupingBy(e -> e.getEvaluateeStudent().getId()));
+
+        List<StudentPeerEvalReport> studentReports = allStudents.stream()
+                .map(student -> {
+                    List<EvaluationEntry> received = entriesByEvaluatee.getOrDefault(student.getId(), List.of());
+                    boolean submitted = submitterIds.contains(student.getId());
+                    String teamName = studentTeamNames.getOrDefault(student.getId(), "—");
+
+                    List<EvalReportEntry> evalRows = received.stream()
+                            .map(entry -> {
+                                double totalScore = entry.getScores().stream()
+                                        .mapToInt(EvaluationScore::getScore).sum();
+                                double maxScore = entry.getScores().stream()
+                                        .mapToDouble(s -> s.getCriterion().getMaxScore()).sum();
+                                String evaluatorName = entry.getSubmission().getEvaluatorStudent().getFirstName()
+                                        + " " + entry.getSubmission().getEvaluatorStudent().getLastName();
+                                return new EvalReportEntry(evaluatorName, totalScore, maxScore,
+                                        entry.getPublicComment(), entry.getPrivateComment());
+                            })
+                            .toList();
+
+                    Double grade = received.isEmpty() ? null
+                            : evalRows.stream().mapToDouble(EvalReportEntry::totalScore).average().orElse(0.0);
+                    Double maxGrade = received.isEmpty() ? null : evalRows.get(0).maxScore();
+
+                    return new StudentPeerEvalReport(
+                            student.getId(),
+                            student.getFirstName() + " " + student.getLastName(),
+                            teamName,
+                            submitted,
+                            grade,
+                            maxGrade,
+                            evalRows
+                    );
+                })
+                .toList();
+
+        return new SectionPeerEvalReportResponse(sectionId, section.getSectionName(), week, studentReports);
     }
 }

--- a/src/frontend/src/features/report/services/reportService.ts
+++ b/src/frontend/src/features/report/services/reportService.ts
@@ -7,3 +7,6 @@ export const getTeamWarReport = (teamId: number, week: string) =>
 
 export const getStudentWarReport = (teamId: number, studentId: number, startWeek: string, endWeek: string) =>
   request.get<any>(`${BASE}/${teamId}/students/${studentId}/war-report`, { params: { startWeek, endWeek } })
+
+export const getSectionPeerEvalReport = (sectionId: number, week: string) =>
+  request.get<any>(`/sections/${sectionId}/peer-eval-report`, { params: { week } })

--- a/src/frontend/src/features/report/services/reportTypes.ts
+++ b/src/frontend/src/features/report/services/reportTypes.ts
@@ -33,3 +33,28 @@ export interface StudentWarReportResponse {
   endWeek: string
   weekReports: StudentWeekWarReport[]
 }
+
+export interface EvalReportEntry {
+  evaluatorName: string
+  totalScore: number
+  maxScore: number
+  publicComment: string | null
+  privateComment: string | null
+}
+
+export interface StudentPeerEvalReport {
+  studentId: number
+  studentName: string
+  teamName: string
+  submitted: boolean
+  grade: number | null
+  maxGrade: number | null
+  evaluations: EvalReportEntry[]
+}
+
+export interface SectionPeerEvalReportResponse {
+  sectionId: number
+  sectionName: string
+  week: string
+  studentReports: StudentPeerEvalReport[]
+}

--- a/src/frontend/src/features/section/pages/SectionDetail.vue
+++ b/src/frontend/src/features/section/pages/SectionDetail.vue
@@ -18,6 +18,16 @@
           <v-chip :color="section.active ? 'success' : 'default'" variant="tonal" class="mr-2">
             {{ section.active ? 'Active' : 'Inactive' }}
           </v-chip>
+          <v-btn
+            v-if="isAdmin || isInstructor"
+            color="secondary"
+            prepend-icon="mdi-clipboard-text"
+            variant="outlined"
+            class="mr-2"
+            @click="openPeerEvalReportDialog"
+          >
+            Peer Eval Report
+          </v-btn>
           <v-btn color="primary" prepend-icon="mdi-pencil" variant="outlined" @click="openEditDialog">
             Edit
           </v-btn>
@@ -273,6 +283,99 @@
       </v-card>
     </v-dialog>
 
+    <!-- Peer Eval Report Dialog (UC-31) -->
+    <v-dialog v-model="peerEvalReportDialog" max-width="1000" persistent>
+      <v-card>
+        <v-card-title class="pa-6 pb-2">
+          <span class="text-h6">Peer Evaluation Report — {{ section?.sectionName }}</span>
+        </v-card-title>
+
+        <v-card-text class="pa-6">
+          <template v-if="peerEvalStep === 1">
+            <p class="mb-4 text-body-2">Select the active week to generate the peer evaluation report for this section.</p>
+            <v-select
+              v-model="peerEvalSelectedWeek"
+              :items="sortedActiveWeeks"
+              label="Active Week"
+              density="compact"
+              variant="outlined"
+              :disabled="!sortedActiveWeeks.length"
+              style="max-width: 320px"
+            />
+          </template>
+
+          <template v-else-if="peerEvalReport">
+            <div class="text-subtitle-1 font-weight-bold mb-4">Week {{ peerEvalReport.week }}</div>
+            <template v-if="peerEvalReport.studentReports.length > 0">
+              <v-table density="compact">
+                <thead>
+                  <tr>
+                    <th>Student</th>
+                    <th>Team</th>
+                    <th>Grade</th>
+                    <th>Commented by</th>
+                    <th>Public Comments</th>
+                    <th>Private Comments</th>
+                    <th>Submitted</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <template v-for="sr in peerEvalReport.studentReports" :key="sr.studentId">
+                    <tr v-if="sr.evaluations.length === 0">
+                      <td>{{ sr.studentName }}</td>
+                      <td>{{ sr.teamName }}</td>
+                      <td>—</td>
+                      <td>—</td>
+                      <td>—</td>
+                      <td>—</td>
+                      <td>
+                        <v-chip size="x-small" :color="sr.submitted ? 'success' : 'error'" variant="tonal">
+                          {{ sr.submitted ? 'Yes' : 'No' }}
+                        </v-chip>
+                      </td>
+                    </tr>
+                    <template v-else>
+                      <tr v-for="(ev, idx) in sr.evaluations" :key="idx">
+                        <td>{{ idx === 0 ? sr.studentName : '' }}</td>
+                        <td>{{ idx === 0 ? sr.teamName : '' }}</td>
+                        <td>{{ idx === 0 ? `${Math.round(sr.grade!)}/${Math.round(sr.maxGrade!)}` : '' }}</td>
+                        <td>{{ ev.evaluatorName }}</td>
+                        <td>{{ ev.publicComment ?? '—' }}</td>
+                        <td>{{ ev.privateComment ?? '—' }}</td>
+                        <td>
+                          <v-chip v-if="idx === 0" size="x-small" :color="sr.submitted ? 'success' : 'error'" variant="tonal">
+                            {{ sr.submitted ? 'Yes' : 'No' }}
+                          </v-chip>
+                        </td>
+                      </tr>
+                    </template>
+                  </template>
+                </tbody>
+              </v-table>
+            </template>
+            <v-alert v-else type="info" variant="tonal">
+              No peer evaluation data found for week {{ peerEvalReport.week }}.
+            </v-alert>
+          </template>
+        </v-card-text>
+
+        <v-card-actions class="px-6 pb-4">
+          <v-spacer />
+          <v-btn variant="outlined" @click="closePeerEvalReportDialog">Close</v-btn>
+          <v-btn
+            v-if="peerEvalStep === 1"
+            color="primary"
+            :disabled="!peerEvalSelectedWeek"
+            :loading="peerEvalLoading"
+            @click="generatePeerEvalReport"
+          >
+            Generate
+          </v-btn>
+          <v-btn v-else variant="outlined" @click="peerEvalStep = 1">Back</v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
+
     <v-snackbar v-model="snackbar.show" :color="snackbar.color" timeout="3000">
       {{ snackbar.message }}
     </v-snackbar>
@@ -282,13 +385,17 @@
 <script setup lang="ts">
 import { ref, computed, onMounted } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
+import { useUserInfoStore } from '@/stores/userInfo'
 import { getSection, updateSection, setupActiveWeeks } from '../services/sectionService'
 import { getAllRubrics } from '@/features/rubric/services/rubricService'
+import { getSectionPeerEvalReport } from '@/features/report/services/reportService'
 import type { SectionDetail } from '../services/sectionTypes'
 import type { Rubric } from '@/features/rubric/services/rubricTypes'
+import type { SectionPeerEvalReportResponse } from '@/features/report/services/reportTypes'
 
 const route = useRoute()
 const router = useRouter()
+const userInfoStore = useUserInfoStore()
 
 const section = ref<SectionDetail | null>(null)
 const loading = ref(false)
@@ -309,6 +416,15 @@ const allWeeks = ref<{ value: string; label: string }[]>([])
 const selectedWeeks = ref<string[]>([])
 
 const snackbar = ref({ show: false, message: '', color: 'success' })
+
+const peerEvalReportDialog = ref(false)
+const peerEvalStep = ref(1)
+const peerEvalLoading = ref(false)
+const peerEvalSelectedWeek = ref<string>('')
+const peerEvalReport = ref<SectionPeerEvalReportResponse | null>(null)
+
+const isAdmin = computed(() => userInfoStore.isAdmin)
+const isInstructor = computed(() => userInfoStore.isInstructor)
 
 const selectedRubricName = computed(() =>
   rubrics.value.find(r => r.rubricId === editForm.value.rubricId)?.rubricName ?? null
@@ -467,5 +583,53 @@ async function confirmWeeks() {
   } finally {
     savingWeeks.value = false
   }
+}
+
+// ── Peer Eval Report (UC-31) ──────────────────────────────────────────────────
+
+function openPeerEvalReportDialog() {
+  peerEvalStep.value = 1
+  peerEvalReport.value = null
+  peerEvalSelectedWeek.value = ''
+  if (sortedActiveWeeks.value.length) {
+    const prev = getPreviousIsoWeek()
+    peerEvalSelectedWeek.value = sortedActiveWeeks.value.includes(prev)
+      ? prev
+      : sortedActiveWeeks.value[sortedActiveWeeks.value.length - 1] as string
+  }
+  peerEvalReportDialog.value = true
+}
+
+function getPreviousIsoWeek(): string {
+  const d = new Date()
+  d.setDate(d.getDate() - 7)
+  const jan4 = new Date(d.getFullYear(), 0, 4)
+  const dayOfYear = Math.floor((d.getTime() - new Date(d.getFullYear(), 0, 0).getTime()) / 86400000)
+  const weekNum = Math.ceil((dayOfYear + jan4.getDay()) / 7)
+  return `${d.getFullYear()}-W${String(weekNum).padStart(2, '0')}`
+}
+
+async function generatePeerEvalReport() {
+  if (!section.value || !peerEvalSelectedWeek.value) return
+  peerEvalLoading.value = true
+  try {
+    const res = await getSectionPeerEvalReport(section.value.sectionId, peerEvalSelectedWeek.value) as any
+    if (res.flag) {
+      peerEvalReport.value = res.data
+      peerEvalStep.value = 2
+    } else {
+      snackbar.value = { show: true, message: res.message || 'Failed to generate report.', color: 'error' }
+    }
+  } catch {
+    snackbar.value = { show: true, message: 'An error occurred generating the report.', color: 'error' }
+  } finally {
+    peerEvalLoading.value = false
+  }
+}
+
+function closePeerEvalReportDialog() {
+  peerEvalReportDialog.value = false
+  peerEvalStep.value = 1
+  peerEvalReport.value = null
 }
 </script>


### PR DESCRIPTION
- Add GET /sections/{sectionId}/peer-eval-report?week= endpoint (ADMIN/INSTRUCTOR)
- Add SectionPeerEvalReportResponse, StudentPeerEvalReport, EvalReportEntry DTOs
- Add generateSectionPeerEvalReport service method: grades computed as average of per-evaluator total scores per UC-31 algorithm, sorted by last name
- Add findEntriesWithScoresBySectionIdAndWeek and findSubmitterIdsBySectionIdAndWeek JPQL queries to EvaluationSubmissionRepository
- Add getSectionPeerEvalReport frontend service call and types
- Add Peer Eval Report button and 2-step dialog to SectionDetail.vue