### PR TITLE
feat(uc-17): implement delete student

### DIFF
--- a/src/backend/src/main/java/team/projectpulse/team/repository/TeamRepository.java
+++ b/src/backend/src/main/java/team/projectpulse/team/repository/TeamRepository.java
@@ -71,4 +71,12 @@ public interface TeamRepository extends JpaRepository<Team, Long> {
         where st.id = :studentId
         """)
     Optional<Team> findByStudentIdWithSection(@Param("studentId") Long studentId);
+
+    @Query("""
+        select t from Team t
+        join t.students st
+        where st.id = :studentId
+        order by t.teamName
+        """)
+    List<Team> findAllByStudentId(@Param("studentId") Long studentId);
 }

--- a/src/backend/src/main/java/team/projectpulse/user/controller/UserController.java
+++ b/src/backend/src/main/java/team/projectpulse/user/controller/UserController.java
@@ -1,10 +1,44 @@
 package team.projectpulse.user.controller;
 
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import team.projectpulse.system.Result;
+import team.projectpulse.user.dto.StudentDetail;
+import team.projectpulse.user.dto.StudentSummary;
+import team.projectpulse.user.service.StudentService;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("${api.endpoint.base-url}/users")
 public class UserController {
-    // User management endpoints (profile, invite, find, delete) go here.
+
+    private final StudentService studentService;
+
+    public UserController(StudentService studentService) {
+        this.studentService = studentService;
+    }
+
+    @GetMapping("/students")
+    @PreAuthorize("hasRole('ADMIN')")
+    public Result<List<StudentSummary>> findAllStudents() {
+        return Result.success(studentService.findAllStudents());
+    }
+
+    @GetMapping("/students/{id}")
+    @PreAuthorize("hasRole('ADMIN')")
+    public Result<StudentDetail> getStudent(@PathVariable Long id) {
+        return Result.success(studentService.findStudentById(id));
+    }
+
+    @DeleteMapping("/students/{id}")
+    @PreAuthorize("hasRole('ADMIN')")
+    public Result<Void> deleteStudent(@PathVariable Long id) {
+        studentService.deleteStudent(id);
+        return Result.success("Student deleted successfully.", null);
+    }
 }

--- a/src/backend/src/main/java/team/projectpulse/user/controller/UserExceptionHandler.java
+++ b/src/backend/src/main/java/team/projectpulse/user/controller/UserExceptionHandler.java
@@ -1,8 +1,18 @@
 package team.projectpulse.user.controller;
 
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import team.projectpulse.system.Result;
+import team.projectpulse.user.domain.StudentNotFoundException;
 
 @RestControllerAdvice
 public class UserExceptionHandler {
-    // User-specific exception handlers go here.
+
+    @ExceptionHandler(StudentNotFoundException.class)
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    public Result<Void> handleStudentNotFound(StudentNotFoundException ex) {
+        return Result.notFound(ex.getMessage());
+    }
 }

--- a/src/backend/src/main/java/team/projectpulse/user/domain/StudentNotFoundException.java
+++ b/src/backend/src/main/java/team/projectpulse/user/domain/StudentNotFoundException.java
@@ -1,0 +1,8 @@
+package team.projectpulse.user.domain;
+
+public class StudentNotFoundException extends RuntimeException {
+
+    public StudentNotFoundException(Long studentId) {
+        super("No student found with id: " + studentId);
+    }
+}

--- a/src/backend/src/main/java/team/projectpulse/user/dto/StudentDetail.java
+++ b/src/backend/src/main/java/team/projectpulse/user/dto/StudentDetail.java
@@ -1,0 +1,14 @@
+package team.projectpulse.user.dto;
+
+import java.util.List;
+
+public record StudentDetail(
+    Long studentId,
+    String firstName,
+    String lastName,
+    String email,
+    boolean enabled,
+    Long sectionId,
+    String sectionName,
+    List<String> teamNames
+) {}

--- a/src/backend/src/main/java/team/projectpulse/user/dto/StudentSummary.java
+++ b/src/backend/src/main/java/team/projectpulse/user/dto/StudentSummary.java
@@ -1,0 +1,11 @@
+package team.projectpulse.user.dto;
+
+public record StudentSummary(
+    Long studentId,
+    String firstName,
+    String lastName,
+    String email,
+    boolean enabled,
+    Long sectionId,
+    String sectionName
+) {}

--- a/src/backend/src/main/java/team/projectpulse/user/repository/UserRepository.java
+++ b/src/backend/src/main/java/team/projectpulse/user/repository/UserRepository.java
@@ -29,4 +29,20 @@ public interface UserRepository extends JpaRepository<User, Long> {
         order by lower(u.lastName), lower(u.firstName), lower(u.email)
         """)
     List<User> findEnabledInstructorsOrdered();
+
+    @Query("""
+        select u from User u
+        left join fetch u.section
+        where lower(concat(' ', coalesce(u.roles, ''), ' ')) like '% student %'
+        order by lower(u.lastName), lower(u.firstName), lower(u.email)
+        """)
+    List<User> findAllStudents();
+
+    @Query("""
+        select u from User u
+        left join fetch u.section
+        where u.id = :id
+          and lower(concat(' ', coalesce(u.roles, ''), ' ')) like '% student %'
+        """)
+    Optional<User> findStudentById(@Param("id") Long id);
 }

--- a/src/backend/src/main/java/team/projectpulse/user/service/StudentService.java
+++ b/src/backend/src/main/java/team/projectpulse/user/service/StudentService.java
@@ -1,0 +1,69 @@
+package team.projectpulse.user.service;
+
+import org.springframework.stereotype.Service;
+import team.projectpulse.team.repository.TeamRepository;
+import team.projectpulse.user.domain.StudentNotFoundException;
+import team.projectpulse.user.domain.User;
+import team.projectpulse.user.dto.StudentDetail;
+import team.projectpulse.user.dto.StudentSummary;
+import team.projectpulse.user.repository.UserRepository;
+
+import java.util.List;
+
+@Service
+public class StudentService {
+
+    private final UserRepository userRepository;
+    private final TeamRepository teamRepository;
+
+    public StudentService(UserRepository userRepository, TeamRepository teamRepository) {
+        this.userRepository = userRepository;
+        this.teamRepository = teamRepository;
+    }
+
+    public List<StudentSummary> findAllStudents() {
+        return userRepository.findAllStudents().stream()
+                .map(this::toStudentSummary)
+                .toList();
+    }
+
+    public StudentDetail findStudentById(Long id) {
+        User user = userRepository.findStudentById(id)
+                .orElseThrow(() -> new StudentNotFoundException(id));
+        List<String> teamNames = teamRepository.findAllByStudentId(id).stream()
+                .map(t -> t.getTeamName())
+                .toList();
+        return toStudentDetail(user, teamNames);
+    }
+
+    public void deleteStudent(Long id) {
+        User user = userRepository.findStudentById(id)
+                .orElseThrow(() -> new StudentNotFoundException(id));
+        userRepository.delete(user);
+    }
+
+    private StudentSummary toStudentSummary(User user) {
+        return new StudentSummary(
+                user.getId(),
+                user.getFirstName(),
+                user.getLastName(),
+                user.getEmail(),
+                user.isEnabled(),
+                user.getSection() != null ? user.getSection().getSectionId() : null,
+                user.getSection() != null ? user.getSection().getSectionName() : null
+        );
+    }
+
+    private StudentDetail toStudentDetail(User user, List<String> teamNames) {
+        return new StudentDetail(
+                user.getId(),
+                user.getFirstName(),
+                user.getLastName(),
+                user.getEmail(),
+                user.isEnabled(),
+                user.getSection() != null ? user.getSection().getSectionId() : null,
+                user.getSection() != null ? user.getSection().getSectionName() : null,
+                teamNames
+        );
+    }
+}

--- a/src/backend/src/test/java/team/projectpulse/user/controller/UserControllerIntegrationTest.java
+++ b/src/backend/src/test/java/team/projectpulse/user/controller/UserControllerIntegrationTest.java
@@ -1,0 +1,147 @@
+package team.projectpulse.user.controller;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import team.projectpulse.config.ControllerTestSecurityConfig;
+import team.projectpulse.config.SecurityConfig;
+import team.projectpulse.user.domain.StudentNotFoundException;
+import team.projectpulse.user.dto.StudentDetail;
+import team.projectpulse.user.dto.StudentSummary;
+import team.projectpulse.user.service.StudentService;
+
+import java.util.List;
+
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = UserController.class)
+@Import({UserExceptionHandler.class, SecurityConfig.class, ControllerTestSecurityConfig.class})
+@ActiveProfiles("test")
+class UserControllerIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private StudentService studentService;
+
+    // ── GET /users/students ───────────────────────────────────────────────────
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void should_ReturnStudentList_When_AdminRequestsStudents() throws Exception {
+        when(studentService.findAllStudents()).thenReturn(List.of(
+            new StudentSummary(1003L, "Ava", "Johnson", "ava.johnson@tcu.edu", true, 1L, "Spring 2026 - Section A"),
+            new StudentSummary(1004L, "Liam", "Parker", "liam.parker@tcu.edu", true, 1L, "Spring 2026 - Section A")
+        ));
+
+        mockMvc.perform(get("/api/v1/users/students"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.flag").value(true))
+            .andExpect(jsonPath("$.data[0].email").value("ava.johnson@tcu.edu"))
+            .andExpect(jsonPath("$.data[1].email").value("liam.parker@tcu.edu"));
+
+        verify(studentService).findAllStudents();
+    }
+
+    @Test
+    @WithMockUser(roles = "INSTRUCTOR")
+    void should_ReturnForbidden_When_InstructorRequestsStudentList() throws Exception {
+        mockMvc.perform(get("/api/v1/users/students"))
+            .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void should_ReturnUnauthorized_When_UnauthenticatedRequestsStudentList() throws Exception {
+        mockMvc.perform(get("/api/v1/users/students"))
+            .andExpect(status().isUnauthorized());
+    }
+
+    // ── GET /users/students/{id} ──────────────────────────────────────────────
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void should_ReturnStudentDetail_When_AdminRequestsStudent() throws Exception {
+        when(studentService.findStudentById(1003L)).thenReturn(
+            new StudentDetail(1003L, "Ava", "Johnson", "ava.johnson@tcu.edu", true, 1L, "Spring 2026 - Section A", List.of("Pulse Analytics"))
+        );
+
+        mockMvc.perform(get("/api/v1/users/students/1003"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.flag").value(true))
+            .andExpect(jsonPath("$.data.email").value("ava.johnson@tcu.edu"))
+            .andExpect(jsonPath("$.data.teamNames[0]").value("Pulse Analytics"));
+
+        verify(studentService).findStudentById(1003L);
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void should_ReturnNotFound_When_StudentDoesNotExist() throws Exception {
+        when(studentService.findStudentById(9999L)).thenThrow(new StudentNotFoundException(9999L));
+
+        mockMvc.perform(get("/api/v1/users/students/9999"))
+            .andExpect(status().isNotFound())
+            .andExpect(jsonPath("$.flag").value(false))
+            .andExpect(jsonPath("$.code").value(404))
+            .andExpect(jsonPath("$.message").value("No student found with id: 9999"));
+    }
+
+    // ── DELETE /users/students/{id} ───────────────────────────────────────────
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void should_DeleteStudent_When_AdminRequestsDeletion() throws Exception {
+        mockMvc.perform(delete("/api/v1/users/students/1003"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.flag").value(true))
+            .andExpect(jsonPath("$.message").value("Student deleted successfully."))
+            .andExpect(jsonPath("$.data").isEmpty());
+
+        verify(studentService).deleteStudent(1003L);
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void should_ReturnNotFound_When_DeletedStudentDoesNotExist() throws Exception {
+        doThrow(new StudentNotFoundException(9999L))
+            .when(studentService).deleteStudent(9999L);
+
+        mockMvc.perform(delete("/api/v1/users/students/9999"))
+            .andExpect(status().isNotFound())
+            .andExpect(jsonPath("$.flag").value(false))
+            .andExpect(jsonPath("$.code").value(404))
+            .andExpect(jsonPath("$.message").value("No student found with id: 9999"));
+    }
+
+    @Test
+    @WithMockUser(roles = "INSTRUCTOR")
+    void should_ReturnForbidden_When_InstructorRequestsStudentDeletion() throws Exception {
+        mockMvc.perform(delete("/api/v1/users/students/1003"))
+            .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @WithMockUser(roles = "STUDENT")
+    void should_ReturnForbidden_When_StudentRequestsStudentDeletion() throws Exception {
+        mockMvc.perform(delete("/api/v1/users/students/1003"))
+            .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void should_ReturnUnauthorized_When_UnauthenticatedRequestDeletesStudent() throws Exception {
+        mockMvc.perform(delete("/api/v1/users/students/1003"))
+            .andExpect(status().isUnauthorized());
+    }
+}

--- a/src/frontend/src/features/student/pages/StudentDetail.vue
+++ b/src/frontend/src/features/student/pages/StudentDetail.vue
@@ -1,0 +1,270 @@
+<template>
+  <v-container>
+    <v-btn variant="text" prepend-icon="mdi-arrow-left" class="mb-4"
+           @click="router.push({ name: 'students' })">
+      Back to Students
+    </v-btn>
+
+    <v-row v-if="loading">
+      <v-col class="text-center"><v-progress-circular indeterminate /></v-col>
+    </v-row>
+
+    <template v-else-if="student">
+      <!-- Header -->
+      <v-row class="mb-2" align="center">
+        <v-col>
+          <h2 class="text-h5 font-weight-bold">{{ student.firstName }} {{ student.lastName }}</h2>
+        </v-col>
+        <v-col cols="auto" class="d-flex align-center ga-2">
+          <v-chip :color="student.enabled ? 'success' : 'default'" variant="tonal">
+            {{ student.enabled ? 'Active' : 'Inactive' }}
+          </v-chip>
+          <v-btn color="error" prepend-icon="mdi-delete-outline" variant="outlined" size="small"
+                 @click="openDeleteDialog">
+            Delete Student
+          </v-btn>
+        </v-col>
+      </v-row>
+
+      <!-- Student Info -->
+      <v-card variant="outlined" class="mb-4">
+        <v-card-title class="text-subtitle-1 font-weight-bold pa-4 pb-2">Student Info</v-card-title>
+        <v-card-text>
+          <v-row>
+            <v-col cols="12" sm="4">
+              <div class="text-caption text-medium-emphasis">First Name</div>
+              <div>{{ student.firstName }}</div>
+            </v-col>
+            <v-col cols="12" sm="4">
+              <div class="text-caption text-medium-emphasis">Last Name</div>
+              <div>{{ student.lastName }}</div>
+            </v-col>
+            <v-col cols="12" sm="4">
+              <div class="text-caption text-medium-emphasis">Email</div>
+              <div>{{ student.email }}</div>
+            </v-col>
+            <v-col cols="12" sm="4">
+              <div class="text-caption text-medium-emphasis">Section</div>
+              <div>{{ student.sectionName ?? '—' }}</div>
+            </v-col>
+            <v-col cols="12" sm="4">
+              <div class="text-caption text-medium-emphasis">Status</div>
+              <div>
+                <v-chip :color="student.enabled ? 'success' : 'default'" size="x-small" variant="tonal">
+                  {{ student.enabled ? 'Active' : 'Inactive' }}
+                </v-chip>
+              </div>
+            </v-col>
+          </v-row>
+        </v-card-text>
+      </v-card>
+
+      <!-- Teams -->
+      <v-card variant="outlined">
+        <v-card-title class="text-subtitle-1 font-weight-bold pa-4 pb-2">Teams</v-card-title>
+        <v-card-text>
+          <v-alert v-if="student.teamNames.length === 0" type="info" variant="tonal" density="compact">
+            This student is not assigned to any team.
+          </v-alert>
+          <div v-else>
+            <v-chip
+              v-for="team in student.teamNames"
+              :key="team"
+              size="small"
+              color="primary"
+              variant="tonal"
+              class="mr-1 mb-1"
+            >{{ team }}</v-chip>
+          </div>
+        </v-card-text>
+      </v-card>
+    </template>
+
+    <!-- Delete Confirmation Dialog -->
+    <v-dialog v-model="deleteDialog" max-width="640" persistent>
+      <v-card>
+        <v-card-title class="pa-4">
+          {{ deleteStep === 1 ? 'Delete Student' : 'Confirm Student Deletion' }}
+        </v-card-title>
+        <v-divider />
+
+        <!-- Step 1: Consequences warning -->
+        <v-card-text v-if="deleteStep === 1" class="pa-4">
+          <v-alert type="warning" variant="tonal" class="mb-4">
+            Deleting this student is permanent and cannot be undone.
+          </v-alert>
+
+          <div class="text-body-2 mb-4">
+            If you continue, the system will permanently delete this student and all associated data.
+            Specifically, deleting this student will automatically delete:
+          </div>
+
+          <v-list density="compact" class="mb-4">
+            <v-list-item prepend-icon="mdi-clipboard-text-clock-outline" title="All WAR (Weekly Activity Report) submissions by this student" />
+            <v-list-item prepend-icon="mdi-account-star-outline" title="All peer evaluation submissions by this student" />
+            <v-list-item prepend-icon="mdi-account-star-outline" title="All peer evaluation entries received by this student" />
+            <v-list-item prepend-icon="mdi-account-group" title="All team memberships for this student" />
+          </v-list>
+
+          <v-table density="compact" class="mb-4">
+            <tbody>
+              <tr>
+                <th class="text-left" style="width: 160px">Student</th>
+                <td>{{ student?.firstName }} {{ student?.lastName }}</td>
+              </tr>
+              <tr>
+                <th class="text-left">Email</th>
+                <td>{{ student?.email }}</td>
+              </tr>
+              <tr>
+                <th class="text-left">Section</th>
+                <td>{{ student?.sectionName ?? '—' }}</td>
+              </tr>
+              <tr>
+                <th class="text-left">Deletion Strategy</th>
+                <td>Physical delete (permanent)</td>
+              </tr>
+            </tbody>
+          </v-table>
+        </v-card-text>
+
+        <!-- Step 2: Confirm -->
+        <v-card-text v-else class="pa-4">
+          <v-alert type="warning" variant="tonal" class="mb-4">
+            Please review the details before confirming the deletion.
+          </v-alert>
+
+          <v-table density="compact" class="mb-4">
+            <tbody>
+              <tr>
+                <th class="text-left" style="width: 160px">Student</th>
+                <td>{{ student?.firstName }} {{ student?.lastName }}</td>
+              </tr>
+              <tr>
+                <th class="text-left">Email</th>
+                <td>{{ student?.email }}</td>
+              </tr>
+              <tr>
+                <th class="text-left">Section</th>
+                <td>{{ student?.sectionName ?? '—' }}</td>
+              </tr>
+            </tbody>
+          </v-table>
+
+          <div class="text-subtitle-2 font-weight-bold mb-2">Teams to be removed from</div>
+          <v-alert
+            v-if="!student?.teamNames.length"
+            type="info"
+            variant="tonal"
+            density="compact"
+            class="mb-4"
+          >
+            This student is not assigned to any team.
+          </v-alert>
+          <div v-else class="mb-4">
+            <v-chip
+              v-for="team in student.teamNames"
+              :key="team"
+              size="small"
+              class="mr-1 mb-1"
+            >{{ team }}</v-chip>
+          </div>
+
+          <v-alert type="error" variant="tonal">
+            This action cannot be undone. All WARs and peer evaluations for this student will also be permanently deleted.
+          </v-alert>
+        </v-card-text>
+
+        <v-divider />
+        <v-card-actions class="pa-4">
+          <v-btn variant="text" @click="cancelDelete">Cancel</v-btn>
+          <v-spacer />
+          <v-btn v-if="deleteStep === 2" variant="outlined" @click="deleteStep = 1">Modify</v-btn>
+          <v-btn
+            color="error"
+            :loading="deleteSaving"
+            @click="deleteStep === 1 ? deleteStep = 2 : confirmDelete()"
+          >
+            {{ deleteStep === 1 ? 'Preview' : 'Confirm Delete' }}
+          </v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
+
+    <v-snackbar v-model="snackbar.show" :color="snackbar.color" timeout="3000">
+      {{ snackbar.message }}
+    </v-snackbar>
+  </v-container>
+</template>
+
+<script setup lang="ts">
+import { ref, onMounted } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import { getStudent, deleteStudent } from '../services/studentService'
+import { useStudentNotificationsStore } from '../stores/studentNotifications'
+import type { StudentDetail } from '../services/studentTypes'
+
+const route = useRoute()
+const router = useRouter()
+const studentNotificationsStore = useStudentNotificationsStore()
+
+const student = ref<StudentDetail | null>(null)
+const loading = ref(false)
+
+const deleteDialog = ref(false)
+const deleteStep = ref(1)
+const deleteSaving = ref(false)
+
+const snackbar = ref({ show: false, message: '', color: 'success' })
+
+onMounted(async () => {
+  loading.value = true
+  try {
+    const res = await getStudent(Number(route.params.id)) as any
+    if (res.flag) student.value = res.data
+    else router.replace({ name: 'not-found' })
+  } catch {
+    router.replace({ name: 'not-found' })
+  } finally {
+    loading.value = false
+  }
+})
+
+function openDeleteDialog() {
+  deleteStep.value = 1
+  deleteDialog.value = true
+}
+
+function cancelDelete() {
+  deleteDialog.value = false
+  deleteStep.value = 1
+}
+
+async function confirmDelete() {
+  if (!student.value) return
+  deleteSaving.value = true
+  try {
+    const res = await deleteStudent(student.value.studentId) as any
+    if (res.flag) {
+      studentNotificationsStore.setDeletedStudentNotification({
+        studentId: student.value.studentId,
+        fullName: `${student.value.firstName} ${student.value.lastName}`,
+        email: student.value.email,
+        sectionName: student.value.sectionName,
+        teamNames: student.value.teamNames
+      })
+      await router.push({ name: 'students' })
+    } else {
+      snackbar.value = { show: true, message: res.message || 'Failed to delete student.', color: 'error' }
+    }
+  } catch (err: any) {
+    snackbar.value = {
+      show: true,
+      message: err?.response?.data?.message || 'Failed to delete student.',
+      color: 'error'
+    }
+  } finally {
+    deleteSaving.value = false
+  }
+}
+</script>

--- a/src/frontend/src/features/student/pages/Students.vue
+++ b/src/frontend/src/features/student/pages/Students.vue
@@ -1,0 +1,129 @@
+<template>
+  <v-container>
+    <v-row class="mb-4" align="center">
+      <v-col>
+        <h2 class="text-h5 font-weight-bold">Students</h2>
+      </v-col>
+    </v-row>
+
+    <!-- Deletion notification banner -->
+    <v-row v-if="deletedStudentNotification" class="mb-4">
+      <v-col cols="12">
+        <v-card variant="outlined">
+          <v-card-title class="pa-4 pb-2 d-flex align-center">
+            <span>Student Deleted</span>
+            <v-spacer />
+            <v-btn variant="text" size="small" @click="studentNotificationsStore.clearDeletedStudentNotification()">
+              Dismiss
+            </v-btn>
+          </v-card-title>
+          <v-card-text class="pt-0">
+            <div class="text-body-2 mb-3">
+              The following student has been permanently deleted from the system.
+            </div>
+            <v-table density="compact" class="mb-2">
+              <tbody>
+                <tr>
+                  <th class="text-left" style="width: 140px">Name</th>
+                  <td>{{ deletedStudentNotification.fullName }}</td>
+                </tr>
+                <tr>
+                  <th class="text-left">Email</th>
+                  <td>{{ deletedStudentNotification.email }}</td>
+                </tr>
+                <tr>
+                  <th class="text-left">Section</th>
+                  <td>{{ deletedStudentNotification.sectionName ?? '—' }}</td>
+                </tr>
+                <tr>
+                  <th class="text-left">Teams</th>
+                  <td>{{ deletedStudentNotification.teamNames.length ? deletedStudentNotification.teamNames.join(', ') : '—' }}</td>
+                </tr>
+              </tbody>
+            </v-table>
+          </v-card-text>
+        </v-card>
+      </v-col>
+    </v-row>
+
+    <!-- Loading -->
+    <v-row v-if="loading">
+      <v-col class="text-center"><v-progress-circular indeterminate /></v-col>
+    </v-row>
+
+    <!-- Student table -->
+    <template v-else>
+      <v-card variant="outlined">
+        <v-card-text class="pa-0">
+          <v-table>
+            <thead>
+              <tr>
+                <th class="text-left">Name</th>
+                <th class="text-left">Email</th>
+                <th class="text-left">Section</th>
+                <th class="text-left">Status</th>
+                <th class="text-left"></th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr v-if="students.length === 0">
+                <td colspan="5" class="text-center text-medium-emphasis py-6">
+                  No students found in the system.
+                </td>
+              </tr>
+              <tr v-for="student in students" :key="student.studentId">
+                <td class="font-weight-medium">{{ student.firstName }} {{ student.lastName }}</td>
+                <td>{{ student.email }}</td>
+                <td>{{ student.sectionName ?? '—' }}</td>
+                <td>
+                  <v-chip
+                    :color="student.enabled ? 'success' : 'default'"
+                    size="x-small"
+                    variant="tonal"
+                  >
+                    {{ student.enabled ? 'Active' : 'Inactive' }}
+                  </v-chip>
+                </td>
+                <td>
+                  <v-btn
+                    size="small"
+                    variant="text"
+                    @click="router.push({ name: 'student-detail', params: { id: student.studentId } })"
+                  >
+                    View
+                  </v-btn>
+                </td>
+              </tr>
+            </tbody>
+          </v-table>
+        </v-card-text>
+      </v-card>
+    </template>
+  </v-container>
+</template>
+
+<script setup lang="ts">
+import { ref, onMounted, computed } from 'vue'
+import { useRouter } from 'vue-router'
+import { findAllStudents } from '../services/studentService'
+import { useStudentNotificationsStore } from '../stores/studentNotifications'
+import type { StudentSummary } from '../services/studentTypes'
+
+const router = useRouter()
+const studentNotificationsStore = useStudentNotificationsStore()
+
+const students = ref<StudentSummary[]>([])
+const loading = ref(false)
+
+const deletedStudentNotification = computed(() => studentNotificationsStore.deletedStudentNotification)
+
+onMounted(async () => {
+  loading.value = true
+  try {
+    const res = await findAllStudents() as any
+    if (res.flag) students.value = res.data ?? []
+  } catch { /* handled by request interceptor */ } finally {
+    loading.value = false
+  }
+})
+</script>

--- a/src/frontend/src/features/student/services/studentService.ts
+++ b/src/frontend/src/features/student/services/studentService.ts
@@ -1,0 +1,14 @@
+import request from '@/shared/utils/request'
+import type { ApiResponse } from '@/shared/types/api'
+import type { StudentDetail, StudentSummary } from './studentTypes'
+
+const BASE = '/users/students'
+
+export const findAllStudents = () =>
+  request.get<ApiResponse<StudentSummary[]>>(BASE)
+
+export const getStudent = (id: number) =>
+  request.get<ApiResponse<StudentDetail>>(`${BASE}/${id}`)
+
+export const deleteStudent = (id: number) =>
+  request.delete<ApiResponse<null>>(`${BASE}/${id}`)

--- a/src/frontend/src/features/student/services/studentTypes.ts
+++ b/src/frontend/src/features/student/services/studentTypes.ts
@@ -1,0 +1,28 @@
+export interface StudentSummary {
+  studentId: number
+  firstName: string
+  lastName: string
+  email: string
+  enabled: boolean
+  sectionId: number | null
+  sectionName: string | null
+}
+
+export interface StudentDetail {
+  studentId: number
+  firstName: string
+  lastName: string
+  email: string
+  enabled: boolean
+  sectionId: number | null
+  sectionName: string | null
+  teamNames: string[]
+}
+
+export interface StudentDeletionNotification {
+  studentId: number
+  fullName: string
+  email: string
+  sectionName: string | null
+  teamNames: string[]
+}

--- a/src/frontend/src/features/student/stores/studentNotifications.ts
+++ b/src/frontend/src/features/student/stores/studentNotifications.ts
@@ -1,0 +1,21 @@
+import { defineStore } from 'pinia'
+import { ref } from 'vue'
+import type { StudentDeletionNotification } from '../services/studentTypes'
+
+export const useStudentNotificationsStore = defineStore('studentNotifications', () => {
+  const deletedStudentNotification = ref<StudentDeletionNotification | null>(null)
+
+  function setDeletedStudentNotification(notification: StudentDeletionNotification) {
+    deletedStudentNotification.value = notification
+  }
+
+  function clearDeletedStudentNotification() {
+    deletedStudentNotification.value = null
+  }
+
+  return {
+    deletedStudentNotification,
+    setDeletedStudentNotification,
+    clearDeletedStudentNotification
+  }
+})

--- a/src/frontend/src/router/routes.ts
+++ b/src/frontend/src/router/routes.ts
@@ -130,6 +130,20 @@ export const routes = [
         meta: { requiresAuth: true, roles: ['admin', 'instructor', 'student'] }
       },
 
+      // ── Students ─────────────────────────────────────────────────────────
+      {
+        path: '/students',
+        component: () => import('@/features/student/pages/Students.vue'),
+        name: 'students',
+        meta: { title: 'Students', icon: 'mdi-account-school', isMenuItem: true, requiresAuth: true, roles: ['admin'] }
+      },
+      {
+        path: '/students/:id',
+        component: () => import('@/features/student/pages/StudentDetail.vue'),
+        name: 'student-detail',
+        meta: { requiresAuth: true, roles: ['admin'] }
+      },
+
       // ── Rubrics ──────────────────────────────────────────────────────────
       {
         path: '/rubrics',


### PR DESCRIPTION
Backend:
- StudentService with findAllStudents, findStudentById, deleteStudent
- UserController with GET/DELETE /users/students endpoints (admin-only)
- StudentNotFoundException, StudentSummary, StudentDetail DTOs
- UserRepository: findAllStudents and findStudentById queries
- TeamRepository: findAllByStudentId query
- UserExceptionHandler: handle StudentNotFoundException with 404
- UserControllerIntegrationTest covering all endpoints and auth cases

Physical delete cascades to WARs, peer evaluations, and team memberships via ON DELETE CASCADE constraints already in the DB schema.

Frontend:
- Students list page with deletion notification banner
- StudentDetail page with two-step delete confirmation dialog
- studentService, studentTypes, studentNotifications store
- Routes: /students and /students/:id (admin-only)