### PR TITLE
feat(uc-18): implement invite instructors to register an account

### DIFF
--- a/src/backend/src/main/java/team/projectpulse/invite/controller/InstructorInviteController.java
+++ b/src/backend/src/main/java/team/projectpulse/invite/controller/InstructorInviteController.java
@@ -1,0 +1,44 @@
+package team.projectpulse.invite.controller;
+
+import jakarta.validation.Valid;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import team.projectpulse.invite.dto.InstructorInviteSendRequest;
+import team.projectpulse.invite.dto.InvitePreview;
+import team.projectpulse.invite.dto.InvitePreviewRequest;
+import team.projectpulse.invite.dto.InviteSendResult;
+import team.projectpulse.invite.service.InstructorInviteService;
+import team.projectpulse.system.Result;
+import team.projectpulse.user.domain.User;
+
+@RestController
+@RequestMapping("${api.endpoint.base-url}/instructors/invites")
+public class InstructorInviteController {
+
+    private final InstructorInviteService instructorInviteService;
+
+    public InstructorInviteController(InstructorInviteService instructorInviteService) {
+        this.instructorInviteService = instructorInviteService;
+    }
+
+    @PreAuthorize("hasRole('ADMIN')")
+    @PostMapping("/preview")
+    public Result<InvitePreview> preview(@Valid @RequestBody InvitePreviewRequest request,
+                                          Authentication authentication) {
+        User admin = (User) authentication.getPrincipal();
+        return Result.success(instructorInviteService.preview(request.emailsInput(), admin));
+    }
+
+    @PreAuthorize("hasRole('ADMIN')")
+    @PostMapping("/send")
+    public Result<InviteSendResult> send(@Valid @RequestBody InstructorInviteSendRequest request,
+                                          Authentication authentication) {
+        User admin = (User) authentication.getPrincipal();
+        return Result.success("Invitations sent successfully.",
+                instructorInviteService.send(request.emails(), request.subject(), request.body(), admin));
+    }
+}

--- a/src/backend/src/main/java/team/projectpulse/invite/dto/InstructorInviteSendRequest.java
+++ b/src/backend/src/main/java/team/projectpulse/invite/dto/InstructorInviteSendRequest.java
@@ -1,0 +1,12 @@
+package team.projectpulse.invite.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+
+import java.util.List;
+
+public record InstructorInviteSendRequest(
+        @NotEmpty List<String> emails,
+        @NotBlank String subject,
+        @NotBlank String body
+) {}

--- a/src/backend/src/main/java/team/projectpulse/invite/service/InstructorInviteService.java
+++ b/src/backend/src/main/java/team/projectpulse/invite/service/InstructorInviteService.java
@@ -1,0 +1,90 @@
+package team.projectpulse.invite.service;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import team.projectpulse.invite.domain.InvalidEmailFormatException;
+import team.projectpulse.invite.dto.InvitePreview;
+import team.projectpulse.invite.dto.InviteSendResult;
+import team.projectpulse.user.domain.User;
+
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.List;
+import java.util.regex.Pattern;
+
+@Service
+public class InstructorInviteService {
+
+    public static final String DEFAULT_SUBJECT =
+            "Welcome to The Peer Evaluation Tool - Instructor Account Registration";
+
+    private static final Pattern EMAIL_PATTERN = Pattern.compile(
+            "^[a-zA-Z0-9._%+\\-]+@[a-zA-Z0-9.\\-]+\\.[a-zA-Z]{2,}$"
+    );
+
+    private final EmailService emailService;
+
+    @Value("${front-end.url}")
+    private String frontendUrl;
+
+    public InstructorInviteService(EmailService emailService) {
+        this.emailService = emailService;
+    }
+
+    public InvitePreview preview(String emailsInput, User admin) {
+        List<String> emails = parseEmails(emailsInput);
+        validateEmails(emails);
+
+        String adminName = admin.getFirstName() + " " + admin.getLastName();
+        String body = buildDefaultBody(adminName, admin.getEmail(), "[Registration link]");
+
+        return new InvitePreview(emails, emails.size(), DEFAULT_SUBJECT, body);
+    }
+
+    public InviteSendResult send(List<String> emails, String subject, String body, User admin) {
+        for (String email : emails) {
+            String registrationLink = frontendUrl + "/register?email="
+                    + URLEncoder.encode(email, StandardCharsets.UTF_8);
+            String resolvedBody = body.replace("[Registration link]", registrationLink);
+            emailService.send(email, subject, resolvedBody);
+        }
+        return new InviteSendResult(emails.size());
+    }
+
+    private List<String> parseEmails(String input) {
+        return Arrays.stream(input.split(";"))
+                .map(String::trim)
+                .filter(e -> !e.isBlank())
+                .distinct()
+                .toList();
+    }
+
+    private void validateEmails(List<String> emails) {
+        if (emails.isEmpty()) {
+            throw new InvalidEmailFormatException(List.of());
+        }
+        List<String> invalid = emails.stream()
+                .filter(e -> !EMAIL_PATTERN.matcher(e).matches())
+                .toList();
+        if (!invalid.isEmpty()) {
+            throw new InvalidEmailFormatException(invalid);
+        }
+    }
+
+    public static String buildDefaultBody(String adminName, String adminEmail, String registrationLink) {
+        return """
+                Hello,
+
+                %s has invited you to register as an instructor on The Peer Evaluation Tool. To complete your registration, please use the link below:
+                %s
+
+                If you have any questions or need assistance, feel free to contact %s or our team directly.
+
+                Please note: This email is not monitored, so do not reply directly to this message.
+
+                Best regards,
+                Peer Evaluation Tool Team
+                """.formatted(adminName, registrationLink, adminEmail);
+    }
+}

--- a/src/backend/src/test/java/team/projectpulse/invite/controller/InstructorInviteControllerIntegrationTest.java
+++ b/src/backend/src/test/java/team/projectpulse/invite/controller/InstructorInviteControllerIntegrationTest.java
@@ -1,0 +1,198 @@
+package team.projectpulse.invite.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import team.projectpulse.config.ControllerTestSecurityConfig;
+import team.projectpulse.config.SecurityConfig;
+import team.projectpulse.invite.domain.InvalidEmailFormatException;
+import team.projectpulse.invite.dto.InvitePreview;
+import team.projectpulse.invite.dto.InviteSendResult;
+import team.projectpulse.invite.service.InstructorInviteService;
+import team.projectpulse.user.domain.User;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = InstructorInviteController.class)
+@Import({InviteExceptionHandler.class, SecurityConfig.class, ControllerTestSecurityConfig.class})
+@ActiveProfiles("test")
+class InstructorInviteControllerIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockitoBean
+    private InstructorInviteService instructorInviteService;
+
+    // ── Preview ──────────────────────────────────────────────────────────────
+
+    @Test
+    void should_ReturnPreview_When_AdminSendsValidEmails() throws Exception {
+        InvitePreview preview = new InvitePreview(
+                List.of("ivy@tcu.edu", "noah@tcu.edu"),
+                2,
+                InstructorInviteService.DEFAULT_SUBJECT,
+                "Hello, Admin has invited you..."
+        );
+        when(instructorInviteService.preview(eq("ivy@tcu.edu; noah@tcu.edu"), any(User.class)))
+                .thenReturn(preview);
+
+        mockMvc.perform(post("/api/v1/instructors/invites/preview")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of("emailsInput", "ivy@tcu.edu; noah@tcu.edu")))
+                        .with(authentication(adminAuth())))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.flag").value(true))
+                .andExpect(jsonPath("$.data.emailCount").value(2))
+                .andExpect(jsonPath("$.data.emails[0]").value("ivy@tcu.edu"));
+
+        verify(instructorInviteService).preview(eq("ivy@tcu.edu; noah@tcu.edu"), any(User.class));
+    }
+
+    @Test
+    void should_ReturnBadRequest_When_EmailsInputIsBlank() throws Exception {
+        mockMvc.perform(post("/api/v1/instructors/invites/preview")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of("emailsInput", "")))
+                        .with(authentication(adminAuth())))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void should_ReturnBadRequest_When_EmailFormatIsInvalid() throws Exception {
+        when(instructorInviteService.preview(eq("bad-email"), any(User.class)))
+                .thenThrow(new InvalidEmailFormatException(List.of("bad-email")));
+
+        mockMvc.perform(post("/api/v1/instructors/invites/preview")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of("emailsInput", "bad-email")))
+                        .with(authentication(adminAuth())))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.flag").value(false))
+                .andExpect(jsonPath("$.data[0]").value("bad-email"));
+    }
+
+    @Test
+    @WithMockUser(roles = "INSTRUCTOR")
+    void should_ReturnForbidden_When_InstructorAttemptsPreview() throws Exception {
+        mockMvc.perform(post("/api/v1/instructors/invites/preview")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of("emailsInput", "ivy@tcu.edu"))))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void should_ReturnUnauthorized_When_UnauthenticatedUserAttemptsPreview() throws Exception {
+        mockMvc.perform(post("/api/v1/instructors/invites/preview")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of("emailsInput", "ivy@tcu.edu"))))
+                .andExpect(status().isUnauthorized());
+    }
+
+    // ── Send ─────────────────────────────────────────────────────────────────
+
+    @Test
+    void should_ReturnSentCount_When_AdminSendsInvitations() throws Exception {
+        when(instructorInviteService.send(
+                eq(List.of("ivy@tcu.edu")),
+                eq(InstructorInviteService.DEFAULT_SUBJECT),
+                any(String.class),
+                any(User.class)
+        )).thenReturn(new InviteSendResult(1));
+
+        Map<String, Object> body = Map.of(
+                "emails", List.of("ivy@tcu.edu"),
+                "subject", InstructorInviteService.DEFAULT_SUBJECT,
+                "body", "Hello, please register."
+        );
+
+        mockMvc.perform(post("/api/v1/instructors/invites/send")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(body))
+                        .with(authentication(adminAuth())))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.flag").value(true))
+                .andExpect(jsonPath("$.message").value("Invitations sent successfully."))
+                .andExpect(jsonPath("$.data.sentCount").value(1));
+    }
+
+    @Test
+    void should_ReturnBadRequest_When_SendRequestHasEmptyEmails() throws Exception {
+        Map<String, Object> body = Map.of(
+                "emails", List.of(),
+                "subject", "Subject",
+                "body", "Body"
+        );
+
+        mockMvc.perform(post("/api/v1/instructors/invites/send")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(body))
+                        .with(authentication(adminAuth())))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @WithMockUser(roles = "INSTRUCTOR")
+    void should_ReturnForbidden_When_InstructorAttemptsSend() throws Exception {
+        Map<String, Object> body = Map.of(
+                "emails", List.of("ivy@tcu.edu"),
+                "subject", "Subject",
+                "body", "Body"
+        );
+
+        mockMvc.perform(post("/api/v1/instructors/invites/send")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(body)))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void should_ReturnUnauthorized_When_UnauthenticatedUserAttemptsSend() throws Exception {
+        Map<String, Object> body = Map.of(
+                "emails", List.of("ivy@tcu.edu"),
+                "subject", "Subject",
+                "body", "Body"
+        );
+
+        mockMvc.perform(post("/api/v1/instructors/invites/send")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(body)))
+                .andExpect(status().isUnauthorized());
+    }
+
+    // ── Helper ───────────────────────────────────────────────────────────────
+
+    private Authentication adminAuth() {
+        User admin = new User();
+        admin.setId(1L);
+        admin.setFirstName("Admin");
+        admin.setLastName("User");
+        admin.setEmail("admin@tcu.edu");
+        admin.setPassword("encoded");
+        admin.setRoles("admin");
+        admin.setEnabled(true);
+        return new UsernamePasswordAuthenticationToken(admin, null, admin.getAuthorities());
+    }
+}

--- a/src/backend/src/test/java/team/projectpulse/invite/service/InstructorInviteServiceTest.java
+++ b/src/backend/src/test/java/team/projectpulse/invite/service/InstructorInviteServiceTest.java
@@ -1,0 +1,135 @@
+package team.projectpulse.invite.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+import team.projectpulse.invite.domain.InvalidEmailFormatException;
+import team.projectpulse.invite.dto.InvitePreview;
+import team.projectpulse.invite.dto.InviteSendResult;
+import team.projectpulse.user.domain.User;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class InstructorInviteServiceTest {
+
+    @Mock
+    private EmailService emailService;
+
+    @InjectMocks
+    private InstructorInviteService service;
+
+    @BeforeEach
+    void setUp() {
+        ReflectionTestUtils.setField(service, "frontendUrl", "http://localhost:5173");
+    }
+
+    // ── Preview ──────────────────────────────────────────────────────────────
+
+    @Test
+    void should_ReturnPreviewWithDefaultSubjectAndBody_When_EmailsAreValid() {
+        InvitePreview preview = service.preview("ivy@tcu.edu; noah@tcu.edu", buildAdmin());
+
+        assertEquals(2, preview.emailCount());
+        assertEquals(List.of("ivy@tcu.edu", "noah@tcu.edu"), preview.emails());
+        assertEquals(InstructorInviteService.DEFAULT_SUBJECT, preview.subject());
+        assertTrue(preview.body().contains("Admin User"));
+        assertTrue(preview.body().contains("admin@tcu.edu"));
+        assertTrue(preview.body().contains("[Registration link]"));
+    }
+
+    @Test
+    void should_Deduplicate_When_SameEmailAppearsMoreThanOnce() {
+        InvitePreview preview = service.preview("ivy@tcu.edu; ivy@tcu.edu", buildAdmin());
+
+        assertEquals(1, preview.emailCount());
+        assertEquals(List.of("ivy@tcu.edu"), preview.emails());
+    }
+
+    @Test
+    void should_ThrowInvalidEmailFormat_When_NoEmailsProvided() {
+        assertThrows(InvalidEmailFormatException.class,
+                () -> service.preview("   ;   ; ", buildAdmin()));
+    }
+
+    @Test
+    void should_ThrowInvalidEmailFormatWithBadEmails_When_FormatIsWrong() {
+        InvalidEmailFormatException ex = assertThrows(InvalidEmailFormatException.class,
+                () -> service.preview("not-an-email; ivy@tcu.edu", buildAdmin()));
+
+        assertEquals(List.of("not-an-email"), ex.getInvalidEmails());
+    }
+
+    // ── Send ─────────────────────────────────────────────────────────────────
+
+    @Test
+    void should_SendEmailToEachRecipient_When_Inviting() {
+        InviteSendResult result = service.send(
+                List.of("ivy@tcu.edu", "noah@tcu.edu"),
+                InstructorInviteService.DEFAULT_SUBJECT,
+                InstructorInviteService.buildDefaultBody("Admin User", "admin@tcu.edu", "[Registration link]"),
+                buildAdmin()
+        );
+
+        assertEquals(2, result.sentCount());
+        verify(emailService, times(2)).send(anyString(), eq(InstructorInviteService.DEFAULT_SUBJECT), anyString());
+    }
+
+    @Test
+    void should_ReplacePlaceholderWithActualLink_When_Sending() {
+        ArgumentCaptor<String> bodyCaptor = ArgumentCaptor.forClass(String.class);
+
+        service.send(
+                List.of("ivy@tcu.edu"),
+                InstructorInviteService.DEFAULT_SUBJECT,
+                InstructorInviteService.buildDefaultBody("Admin User", "admin@tcu.edu", "[Registration link]"),
+                buildAdmin()
+        );
+
+        verify(emailService).send(eq("ivy@tcu.edu"), anyString(), bodyCaptor.capture());
+
+        String sentBody = bodyCaptor.getValue();
+        assertTrue(sentBody.contains("http://localhost:5173/register?email="));
+        assertTrue(sentBody.contains("ivy%40tcu.edu"));
+    }
+
+    @Test
+    void should_SendWithCustomBody_When_AdminPersonalizesMessage() {
+        String customBody = "Hello! Please register using this link: [Registration link]";
+        ArgumentCaptor<String> bodyCaptor = ArgumentCaptor.forClass(String.class);
+
+        service.send(List.of("ivy@tcu.edu"), InstructorInviteService.DEFAULT_SUBJECT, customBody, buildAdmin());
+
+        verify(emailService).send(eq("ivy@tcu.edu"), anyString(), bodyCaptor.capture());
+
+        String sentBody = bodyCaptor.getValue();
+        assertTrue(sentBody.startsWith("Hello! Please register using this link: http://localhost:5173"));
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
+    private User buildAdmin() {
+        User admin = new User();
+        admin.setId(1L);
+        admin.setFirstName("Admin");
+        admin.setLastName("User");
+        admin.setEmail("admin@tcu.edu");
+        admin.setPassword("encoded");
+        admin.setRoles("admin");
+        admin.setEnabled(true);
+        return admin;
+    }
+}

--- a/src/frontend/src/features/instructor/pages/InstructorInvite.vue
+++ b/src/frontend/src/features/instructor/pages/InstructorInvite.vue
@@ -1,0 +1,182 @@
+<template>
+  <v-container max-width="720">
+    <v-btn variant="text" prepend-icon="mdi-arrow-left" class="mb-4" @click="router.push({ name: 'home' })">
+      Back to Home
+    </v-btn>
+
+    <h2 class="text-h5 font-weight-bold mb-6">Invite Instructors</h2>
+
+    <!-- Step 1: Enter emails -->
+    <v-card v-if="step === 1" variant="outlined">
+      <v-card-title class="text-subtitle-1 font-weight-bold pa-4 pb-2">
+        Step 1 of 2 — Enter Instructor Emails
+      </v-card-title>
+      <v-card-text>
+        <p class="text-body-2 text-medium-emphasis mb-4">
+          Enter one or more instructor email addresses separated by semicolons.
+          Spaces between emails are ignored. Duplicate emails are removed automatically.
+        </p>
+        <v-textarea
+          v-model="emailsInput"
+          label="Instructor emails"
+          placeholder="ivy@tcu.edu; noah@tcu.edu; emma@tcu.edu"
+          rows="5"
+          variant="outlined"
+          :error-messages="inputError"
+          @input="inputError = ''"
+        />
+      </v-card-text>
+      <v-card-actions class="pa-4 pt-0">
+        <v-spacer />
+        <v-btn color="primary" :loading="loading" @click="handlePreview">
+          Next — Preview Email
+        </v-btn>
+      </v-card-actions>
+    </v-card>
+
+    <!-- Step 2: Preview & confirm -->
+    <template v-else-if="step === 2 && preview">
+      <v-card variant="outlined" class="mb-4">
+        <v-card-title class="text-subtitle-1 font-weight-bold pa-4 pb-2">
+          Step 2 of 2 — Confirm &amp; Send
+        </v-card-title>
+        <v-card-text>
+          <v-alert type="info" variant="tonal" density="compact" class="mb-4">
+            <strong>{{ preview.emailCount }}</strong>
+            {{ preview.emailCount === 1 ? 'invitation' : 'invitations' }} will be sent.
+          </v-alert>
+
+          <div class="text-caption text-medium-emphasis mb-1">Recipients</div>
+          <div class="mb-4">
+            <v-chip
+              v-for="email in preview.emails"
+              :key="email"
+              size="small"
+              color="primary"
+              variant="tonal"
+              class="mr-1 mb-1"
+            >{{ email }}</v-chip>
+          </div>
+
+          <div class="text-caption text-medium-emphasis mb-1">Email Subject</div>
+          <v-text-field
+            v-model="customSubject"
+            variant="outlined"
+            density="compact"
+            class="mb-4"
+          />
+
+          <div class="text-caption text-medium-emphasis mb-1">
+            Email Message
+            <span class="ml-2 text-primary" style="cursor: pointer;" @click="editingBody = !editingBody">
+              {{ editingBody ? 'Preview' : 'Customize' }}
+            </span>
+          </div>
+
+          <v-textarea
+            v-if="editingBody"
+            v-model="customBody"
+            variant="outlined"
+            rows="10"
+            class="mb-2"
+            hint="Use [Registration link] as a placeholder — it will be replaced with the actual link."
+            persistent-hint
+          />
+          <v-sheet
+            v-else
+            rounded="lg"
+            border
+            class="pa-4 text-body-2 mb-2"
+            style="white-space: pre-wrap; font-family: monospace; background: #f8f9fa;"
+          >
+            {{ customBody }}
+          </v-sheet>
+        </v-card-text>
+
+        <v-card-actions class="pa-4 pt-0">
+          <v-btn variant="text" @click="step = 1">Modify Details</v-btn>
+          <v-spacer />
+          <v-btn color="primary" :loading="loading" @click="handleSend">
+            Send Invitations
+          </v-btn>
+        </v-card-actions>
+      </v-card>
+    </template>
+
+    <v-snackbar v-model="snackbar.show" :color="snackbar.color" timeout="3000">
+      {{ snackbar.message }}
+    </v-snackbar>
+  </v-container>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue'
+import { useRouter } from 'vue-router'
+import {
+  previewInstructorInvites,
+  sendInstructorInvites
+} from '../services/instructorInviteService'
+import type { InstructorInvitePreview } from '../services/instructorInviteService'
+
+const router = useRouter()
+
+const step = ref<1 | 2>(1)
+const emailsInput = ref('')
+const preview = ref<InstructorInvitePreview | null>(null)
+const customSubject = ref('')
+const customBody = ref('')
+const editingBody = ref(false)
+const loading = ref(false)
+const inputError = ref('')
+const snackbar = ref({ show: false, message: '', color: 'success' })
+
+async function handlePreview() {
+  if (!emailsInput.value.trim()) {
+    inputError.value = 'Please enter at least one email address.'
+    return
+  }
+  loading.value = true
+  try {
+    const res = await previewInstructorInvites(emailsInput.value) as any
+    if (res.flag) {
+      preview.value = res.data
+      customSubject.value = res.data.subject
+      customBody.value = res.data.body
+      step.value = 2
+    } else {
+      inputError.value = res.message
+    }
+  } catch (err: any) {
+    const msg = err?.response?.data?.message
+    inputError.value = msg || 'Failed to validate emails. Please try again.'
+  } finally {
+    loading.value = false
+  }
+}
+
+async function handleSend() {
+  if (!preview.value) return
+  loading.value = true
+  try {
+    const res = await sendInstructorInvites({
+      emails: preview.value.emails,
+      subject: customSubject.value,
+      body: customBody.value
+    }) as any
+    if (res.flag) {
+      snackbar.value = {
+        show: true,
+        message: `${res.data.sentCount} invitation(s) sent successfully.`,
+        color: 'success'
+      }
+      setTimeout(() => router.push({ name: 'home' }), 1500)
+    } else {
+      snackbar.value = { show: true, message: res.message, color: 'error' }
+    }
+  } catch {
+    snackbar.value = { show: true, message: 'Failed to send invitations. Please try again.', color: 'error' }
+  } finally {
+    loading.value = false
+  }
+}
+</script>

--- a/src/frontend/src/features/instructor/services/instructorInviteService.ts
+++ b/src/frontend/src/features/instructor/services/instructorInviteService.ts
@@ -1,0 +1,25 @@
+import request from '@/shared/utils/request'
+import type { ApiResponse } from '@/shared/types/api'
+
+export interface InstructorInvitePreview {
+  emails: string[]
+  emailCount: number
+  subject: string
+  body: string
+}
+
+export interface InstructorInviteSendResult {
+  sentCount: number
+}
+
+export interface InstructorInviteSendPayload {
+  emails: string[]
+  subject: string
+  body: string
+}
+
+export const previewInstructorInvites = (emailsInput: string) =>
+  request.post<ApiResponse<InstructorInvitePreview>>('/instructors/invites/preview', { emailsInput })
+
+export const sendInstructorInvites = (payload: InstructorInviteSendPayload) =>
+  request.post<ApiResponse<InstructorInviteSendResult>>('/instructors/invites/send', payload)

--- a/src/frontend/src/router/routes.ts
+++ b/src/frontend/src/router/routes.ts
@@ -130,6 +130,14 @@ export const routes = [
         meta: { requiresAuth: true, roles: ['admin', 'instructor', 'student'] }
       },
 
+      // ── Instructors ──────────────────────────────────────────────────────
+      {
+        path: '/instructors/invite',
+        component: () => import('@/features/instructor/pages/InstructorInvite.vue'),
+        name: 'instructor-invite',
+        meta: { title: 'Invite Instructors', icon: 'mdi-account-tie-outline', isMenuItem: true, requiresAuth: true, roles: ['admin'] }
+      },
+
       // ── Students ─────────────────────────────────────────────────────────
       {
         path: '/students',


### PR DESCRIPTION
- POST /api/v1/instructors/invites/preview — validates emails, returns default subject/body
- POST /api/v1/instructors/invites/send — sends registration emails (supports custom body)
- Two-step UI: enter emails → preview with editable message → confirm send (extension 6a)
- Admin-only access enforced on both endpoints
- Full controller integration tests and service unit tests