### PR TITLE
feat(uc-21): implement find instructors

### DIFF
--- a/src/backend/src/main/java/team/projectpulse/team/repository/TeamRepository.java
+++ b/src/backend/src/main/java/team/projectpulse/team/repository/TeamRepository.java
@@ -79,4 +79,13 @@ public interface TeamRepository extends JpaRepository<Team, Long> {
         order by t.teamName
         """)
     List<Team> findAllByStudentId(@Param("studentId") Long studentId);
+
+    @Query("""
+        select t from Team t
+        join fetch t.section s
+        join t.instructors i
+        where i.id = :instructorId
+        order by s.startDate desc, lower(t.teamName)
+        """)
+    List<Team> findAllByInstructorId(@Param("instructorId") Long instructorId);
 }

--- a/src/backend/src/main/java/team/projectpulse/user/controller/UserController.java
+++ b/src/backend/src/main/java/team/projectpulse/user/controller/UserController.java
@@ -5,10 +5,13 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import team.projectpulse.system.Result;
+import team.projectpulse.user.dto.InstructorSummary;
 import team.projectpulse.user.dto.StudentDetail;
 import team.projectpulse.user.dto.StudentSummary;
+import team.projectpulse.user.service.InstructorService;
 import team.projectpulse.user.service.StudentService;
 
 import java.util.List;
@@ -18,10 +21,14 @@ import java.util.List;
 public class UserController {
 
     private final StudentService studentService;
+    private final InstructorService instructorService;
 
-    public UserController(StudentService studentService) {
+    public UserController(StudentService studentService, InstructorService instructorService) {
         this.studentService = studentService;
+        this.instructorService = instructorService;
     }
+
+    // ── Students ─────────────────────────────────────────────────────────────
 
     @GetMapping("/students")
     @PreAuthorize("hasRole('ADMIN')")
@@ -40,5 +47,17 @@ public class UserController {
     public Result<Void> deleteStudent(@PathVariable Long id) {
         studentService.deleteStudent(id);
         return Result.success("Student deleted successfully.", null);
+    }
+
+    // ── Instructors ───────────────────────────────────────────────────────────
+
+    @GetMapping("/instructors")
+    @PreAuthorize("hasRole('ADMIN')")
+    public Result<List<InstructorSummary>> findInstructors(
+            @RequestParam(required = false) String firstName,
+            @RequestParam(required = false) String lastName,
+            @RequestParam(required = false) Boolean enabled,
+            @RequestParam(required = false) String teamName) {
+        return Result.success(instructorService.searchInstructors(firstName, lastName, enabled, teamName));
     }
 }

--- a/src/backend/src/main/java/team/projectpulse/user/dto/InstructorSummary.java
+++ b/src/backend/src/main/java/team/projectpulse/user/dto/InstructorSummary.java
@@ -1,0 +1,13 @@
+package team.projectpulse.user.dto;
+
+import java.util.List;
+
+public record InstructorSummary(
+        Long instructorId,
+        String firstName,
+        String lastName,
+        String email,
+        boolean enabled,
+        List<String> teamNames,
+        Integer academicYear
+) {}

--- a/src/backend/src/main/java/team/projectpulse/user/repository/UserRepository.java
+++ b/src/backend/src/main/java/team/projectpulse/user/repository/UserRepository.java
@@ -45,4 +45,27 @@ public interface UserRepository extends JpaRepository<User, Long> {
           and lower(concat(' ', coalesce(u.roles, ''), ' ')) like '% student %'
         """)
     Optional<User> findStudentById(@Param("id") Long id);
+
+    @Query("""
+        select distinct u from User u
+        where lower(concat(' ', coalesce(u.roles, ''), ' ')) like '% instructor %'
+          and (:firstName is null or lower(u.firstName) like lower(concat('%', :firstName, '%')))
+          and (:lastName is null or lower(u.lastName) like lower(concat('%', :lastName, '%')))
+          and (:enabled is null or u.enabled = :enabled)
+          and (
+              :teamName is null
+              or exists (
+                  select t from Team t join t.instructors i
+                  where i.id = u.id
+                    and lower(t.teamName) like lower(concat('%', :teamName, '%'))
+              )
+          )
+        order by lower(u.lastName), lower(u.firstName), lower(u.email)
+        """)
+    List<User> searchInstructors(
+        @Param("firstName") String firstName,
+        @Param("lastName") String lastName,
+        @Param("enabled") Boolean enabled,
+        @Param("teamName") String teamName
+    );
 }

--- a/src/backend/src/main/java/team/projectpulse/user/service/InstructorService.java
+++ b/src/backend/src/main/java/team/projectpulse/user/service/InstructorService.java
@@ -1,0 +1,67 @@
+package team.projectpulse.user.service;
+
+import org.springframework.stereotype.Service;
+import team.projectpulse.team.domain.Team;
+import team.projectpulse.team.repository.TeamRepository;
+import team.projectpulse.user.domain.User;
+import team.projectpulse.user.dto.InstructorSummary;
+import team.projectpulse.user.repository.UserRepository;
+
+import java.util.Comparator;
+import java.util.List;
+
+@Service
+public class InstructorService {
+
+    private final UserRepository userRepository;
+    private final TeamRepository teamRepository;
+
+    public InstructorService(UserRepository userRepository, TeamRepository teamRepository) {
+        this.userRepository = userRepository;
+        this.teamRepository = teamRepository;
+    }
+
+    public List<InstructorSummary> searchInstructors(
+            String firstName, String lastName, Boolean enabled, String teamName) {
+
+        List<User> instructors = userRepository.searchInstructors(
+                normalize(firstName),
+                normalize(lastName),
+                enabled,
+                normalize(teamName)
+        );
+
+        return instructors.stream()
+                .map(this::toSummary)
+                .sorted(Comparator
+                        .comparingInt((InstructorSummary s) ->
+                                s.academicYear() != null ? s.academicYear() : Integer.MIN_VALUE)
+                        .reversed()
+                        .thenComparing(s -> s.lastName().toLowerCase()))
+                .toList();
+    }
+
+    private InstructorSummary toSummary(User instructor) {
+        List<Team> teams = teamRepository.findAllByInstructorId(instructor.getId());
+        List<String> teamNames = teams.stream().map(Team::getTeamName).toList();
+        Integer academicYear = teams.isEmpty()
+                ? null
+                : teams.get(0).getSection().getStartDate().getYear();
+
+        return new InstructorSummary(
+                instructor.getId(),
+                instructor.getFirstName(),
+                instructor.getLastName(),
+                instructor.getEmail(),
+                instructor.isEnabled(),
+                teamNames,
+                academicYear
+        );
+    }
+
+    private String normalize(String value) {
+        if (value == null) return null;
+        String trimmed = value.trim();
+        return trimmed.isEmpty() ? null : trimmed;
+    }
+}

--- a/src/backend/src/test/java/team/projectpulse/user/controller/UserControllerIntegrationTest.java
+++ b/src/backend/src/test/java/team/projectpulse/user/controller/UserControllerIntegrationTest.java
@@ -11,12 +11,15 @@ import org.springframework.test.web.servlet.MockMvc;
 import team.projectpulse.config.ControllerTestSecurityConfig;
 import team.projectpulse.config.SecurityConfig;
 import team.projectpulse.user.domain.StudentNotFoundException;
+import team.projectpulse.user.dto.InstructorSummary;
 import team.projectpulse.user.dto.StudentDetail;
 import team.projectpulse.user.dto.StudentSummary;
+import team.projectpulse.user.service.InstructorService;
 import team.projectpulse.user.service.StudentService;
 
 import java.util.List;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -35,6 +38,9 @@ class UserControllerIntegrationTest {
 
     @MockitoBean
     private StudentService studentService;
+
+    @MockitoBean
+    private InstructorService instructorService;
 
     // ── GET /users/students ───────────────────────────────────────────────────
 
@@ -142,6 +148,70 @@ class UserControllerIntegrationTest {
     @Test
     void should_ReturnUnauthorized_When_UnauthenticatedRequestDeletesStudent() throws Exception {
         mockMvc.perform(delete("/api/v1/users/students/1003"))
+            .andExpect(status().isUnauthorized());
+    }
+
+    // ── GET /users/instructors ────────────────────────────────────────────────
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void should_ReturnInstructorList_When_AdminSearchesWithNoFilters() throws Exception {
+        when(instructorService.searchInstructors(null, null, null, null)).thenReturn(List.of(
+            new InstructorSummary(200L, "Ivy", "Stone", "ivy@tcu.edu", true, List.of("Pulse Analytics"), 2026),
+            new InstructorSummary(201L, "Noah", "Bennett", "noah@tcu.edu", true, List.of(), null)
+        ));
+
+        mockMvc.perform(get("/api/v1/users/instructors"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.flag").value(true))
+            .andExpect(jsonPath("$.data[0].lastName").value("Stone"))
+            .andExpect(jsonPath("$.data[0].teamNames[0]").value("Pulse Analytics"))
+            .andExpect(jsonPath("$.data[0].academicYear").value(2026))
+            .andExpect(jsonPath("$.data[1].academicYear").isEmpty());
+
+        verify(instructorService).searchInstructors(null, null, null, null);
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void should_PassFiltersToService_When_AdminSearchesWithParams() throws Exception {
+        when(instructorService.searchInstructors("Ivy", "Stone", true, "Pulse")).thenReturn(List.of(
+            new InstructorSummary(200L, "Ivy", "Stone", "ivy@tcu.edu", true, List.of("Pulse Analytics"), 2026)
+        ));
+
+        mockMvc.perform(get("/api/v1/users/instructors")
+                .param("firstName", "Ivy")
+                .param("lastName", "Stone")
+                .param("enabled", "true")
+                .param("teamName", "Pulse"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.data[0].email").value("ivy@tcu.edu"));
+
+        verify(instructorService).searchInstructors("Ivy", "Stone", true, "Pulse");
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void should_ReturnEmptyList_When_NoInstructorsMatch() throws Exception {
+        when(instructorService.searchInstructors(any(), any(), any(), any())).thenReturn(List.of());
+
+        mockMvc.perform(get("/api/v1/users/instructors").param("lastName", "Unknown"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.flag").value(true))
+            .andExpect(jsonPath("$.data").isArray())
+            .andExpect(jsonPath("$.data").isEmpty());
+    }
+
+    @Test
+    @WithMockUser(roles = "INSTRUCTOR")
+    void should_ReturnForbidden_When_InstructorSearchesInstructors() throws Exception {
+        mockMvc.perform(get("/api/v1/users/instructors"))
+            .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void should_ReturnUnauthorized_When_UnauthenticatedSearchesInstructors() throws Exception {
+        mockMvc.perform(get("/api/v1/users/instructors"))
             .andExpect(status().isUnauthorized());
     }
 }

--- a/src/backend/src/test/java/team/projectpulse/user/service/InstructorServiceTest.java
+++ b/src/backend/src/test/java/team/projectpulse/user/service/InstructorServiceTest.java
@@ -1,0 +1,160 @@
+package team.projectpulse.user.service;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import team.projectpulse.section.domain.Section;
+import team.projectpulse.team.domain.Team;
+import team.projectpulse.team.repository.TeamRepository;
+import team.projectpulse.user.domain.User;
+import team.projectpulse.user.dto.InstructorSummary;
+import team.projectpulse.user.repository.UserRepository;
+
+import java.time.LocalDate;
+import java.util.LinkedHashSet;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class InstructorServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private TeamRepository teamRepository;
+
+    @InjectMocks
+    private InstructorService instructorService;
+
+    // ── Search ────────────────────────────────────────────────────────────────
+
+    @Test
+    void should_ReturnSortedSummaries_When_SearchingWithNoFilters() {
+        User ivy = buildInstructor(200L, "Ivy", "Stone", true);
+        User noah = buildInstructor(201L, "Noah", "Bennett", true);
+
+        when(userRepository.searchInstructors(null, null, null, null)).thenReturn(List.of(ivy, noah));
+
+        Team pulseTeam = buildTeam("Pulse Analytics", 2026);
+        when(teamRepository.findAllByInstructorId(200L)).thenReturn(List.of(pulseTeam));
+        when(teamRepository.findAllByInstructorId(201L)).thenReturn(List.of());
+
+        List<InstructorSummary> results = instructorService.searchInstructors(null, null, null, null);
+
+        // Sorted: 2026 (Ivy Stone) first, then null year (Noah Bennett)
+        assertEquals(2, results.size());
+        assertEquals("Stone", results.get(0).lastName());
+        assertEquals(2026, results.get(0).academicYear());
+        assertEquals(List.of("Pulse Analytics"), results.get(0).teamNames());
+        assertEquals("Bennett", results.get(1).lastName());
+        assertNull(results.get(1).academicYear());
+    }
+
+    @Test
+    void should_SortByAcademicYearDescThenLastNameAsc_When_MultipleInstructors() {
+        User charlie = buildInstructor(1L, "Charlie", "Adams", true);
+        User alice = buildInstructor(2L, "Alice", "Zane", true);
+        User bob = buildInstructor(3L, "Bob", "Adams", true);
+
+        when(userRepository.searchInstructors(null, null, null, null)).thenReturn(List.of(charlie, alice, bob));
+
+        when(teamRepository.findAllByInstructorId(1L)).thenReturn(List.of(buildTeam("TeamA", 2025)));
+        when(teamRepository.findAllByInstructorId(2L)).thenReturn(List.of(buildTeam("TeamB", 2026)));
+        when(teamRepository.findAllByInstructorId(3L)).thenReturn(List.of(buildTeam("TeamC", 2026)));
+
+        List<InstructorSummary> results = instructorService.searchInstructors(null, null, null, null);
+
+        assertEquals(3, results.size());
+        // 2026 first: Adams (Bob) before Zane (Alice) alphabetically
+        assertEquals("Adams", results.get(0).lastName());
+        assertEquals(2026, results.get(0).academicYear());
+        assertEquals("Zane", results.get(1).lastName());
+        assertEquals(2026, results.get(1).academicYear());
+        // 2025 last
+        assertEquals("Adams", results.get(2).lastName());
+        assertEquals(2025, results.get(2).academicYear());
+    }
+
+    @Test
+    void should_NormalizeBlankFilters_When_CallingRepository() {
+        when(userRepository.searchInstructors(null, "Stone", null, null)).thenReturn(List.of());
+
+        instructorService.searchInstructors("  ", "Stone", null, "");
+
+        verify(userRepository).searchInstructors(null, "Stone", null, null);
+    }
+
+    @Test
+    void should_ReturnEmptyList_When_NoInstructorsMatch() {
+        when(userRepository.searchInstructors(any(), any(), any(), any())).thenReturn(List.of());
+
+        List<InstructorSummary> results = instructorService.searchInstructors("Unknown", null, null, null);
+
+        assertEquals(List.of(), results);
+    }
+
+    @Test
+    void should_SetAcademicYearFromMostRecentTeamSection_When_InstructorHasMultipleTeams() {
+        User instructor = buildInstructor(1L, "Ivy", "Stone", true);
+        when(userRepository.searchInstructors(null, null, null, null)).thenReturn(List.of(instructor));
+
+        // findAllByInstructorId returns most recent first (per query order: startDate DESC)
+        when(teamRepository.findAllByInstructorId(1L)).thenReturn(List.of(
+                buildTeam("Spring Team", 2026),
+                buildTeam("Fall Team", 2025)
+        ));
+
+        List<InstructorSummary> results = instructorService.searchInstructors(null, null, null, null);
+
+        assertEquals(2026, results.get(0).academicYear());
+        assertEquals(List.of("Spring Team", "Fall Team"), results.get(0).teamNames());
+    }
+
+    @Test
+    void should_SetNullAcademicYear_When_InstructorHasNoTeam() {
+        User instructor = buildInstructor(1L, "Ivy", "Stone", true);
+        when(userRepository.searchInstructors(null, null, null, null)).thenReturn(List.of(instructor));
+        when(teamRepository.findAllByInstructorId(1L)).thenReturn(List.of());
+
+        List<InstructorSummary> results = instructorService.searchInstructors(null, null, null, null);
+
+        assertNull(results.get(0).academicYear());
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    private User buildInstructor(Long id, String firstName, String lastName, boolean enabled) {
+        User user = new User();
+        user.setId(id);
+        user.setFirstName(firstName);
+        user.setLastName(lastName);
+        user.setEmail(firstName.toLowerCase() + "." + lastName.toLowerCase() + "@tcu.edu");
+        user.setPassword("encoded");
+        user.setRoles("instructor");
+        user.setEnabled(enabled);
+        return user;
+    }
+
+    private Team buildTeam(String teamName, int startYear) {
+        Section section = new Section();
+        section.setSectionName("Section " + startYear);
+        section.setStartDate(LocalDate.of(startYear, 1, 15));
+        section.setEndDate(LocalDate.of(startYear, 5, 10));
+
+        Team team = new Team();
+        team.setTeamName(teamName);
+        team.setSection(section);
+        team.setStudents(new LinkedHashSet<>());
+        team.setInstructors(new LinkedHashSet<>());
+        return team;
+    }
+}

--- a/src/frontend/src/features/instructor/pages/Instructors.vue
+++ b/src/frontend/src/features/instructor/pages/Instructors.vue
@@ -1,0 +1,190 @@
+<template>
+  <v-container>
+    <v-row class="mb-4" align="center">
+      <v-col><h2 class="text-h5 font-weight-bold">Instructors</h2></v-col>
+      <v-col cols="auto">
+        <v-btn
+          color="primary"
+          prepend-icon="mdi-email-plus-outline"
+          @click="router.push({ name: 'instructor-invite' })"
+        >
+          Invite Instructors
+        </v-btn>
+      </v-col>
+    </v-row>
+
+    <!-- Search form -->
+    <v-row class="mb-4">
+      <v-col cols="12" md="3">
+        <v-text-field
+          v-model="filters.firstName"
+          label="Search by first name"
+          prepend-inner-icon="mdi-account"
+          clearable
+          hide-details
+          @keyup.enter="search"
+        />
+      </v-col>
+      <v-col cols="12" md="3">
+        <v-text-field
+          v-model="filters.lastName"
+          label="Search by last name"
+          prepend-inner-icon="mdi-account"
+          clearable
+          hide-details
+          @keyup.enter="search"
+        />
+      </v-col>
+      <v-col cols="12" md="3">
+        <v-text-field
+          v-model="filters.teamName"
+          label="Search by team name"
+          prepend-inner-icon="mdi-account-group"
+          clearable
+          hide-details
+          @keyup.enter="search"
+        />
+      </v-col>
+      <v-col cols="12" md="2">
+        <v-select
+          v-model="filters.enabledStr"
+          :items="statusOptions"
+          label="Status"
+          clearable
+          hide-details
+        />
+      </v-col>
+      <v-col cols="auto" class="d-flex align-center gap-2">
+        <v-btn color="primary" @click="search">Search</v-btn>
+        <v-btn variant="text" @click="clearFilters">Clear</v-btn>
+      </v-col>
+    </v-row>
+
+    <!-- Loading -->
+    <v-row v-if="loading">
+      <v-col class="text-center"><v-progress-circular indeterminate /></v-col>
+    </v-row>
+
+    <!-- Empty state (ext 4a) -->
+    <v-row v-else-if="searched && instructors.length === 0">
+      <v-col>
+        <v-alert type="info" variant="tonal" class="mb-4">
+          No matching instructors found.
+        </v-alert>
+        <v-btn
+          color="primary"
+          prepend-icon="mdi-email-plus-outline"
+          class="mr-2"
+          @click="router.push({ name: 'instructor-invite' })"
+        >
+          Invite Instructors
+        </v-btn>
+        <v-btn variant="text" @click="clearFilters">Modify Search</v-btn>
+      </v-col>
+    </v-row>
+
+    <!-- Results table -->
+    <v-row v-else-if="instructors.length > 0">
+      <v-col cols="12">
+        <v-table>
+          <thead>
+            <tr>
+              <th>First Name</th>
+              <th>Last Name</th>
+              <th>Team Name(s)</th>
+              <th>Status</th>
+              <th>Academic Year</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr v-for="instructor in instructors" :key="instructor.instructorId">
+              <td>{{ instructor.firstName }}</td>
+              <td>{{ instructor.lastName }}</td>
+              <td>
+                <div v-if="instructor.teamNames.length" class="chip-group">
+                  <v-chip
+                    v-for="name in instructor.teamNames"
+                    :key="name"
+                    size="small"
+                    variant="tonal"
+                    class="mr-1 mb-1"
+                  >{{ name }}</v-chip>
+                </div>
+                <span v-else class="text-medium-emphasis">—</span>
+              </td>
+              <td>
+                <v-chip
+                  :color="instructor.enabled ? 'success' : 'default'"
+                  size="x-small"
+                  variant="tonal"
+                >
+                  {{ instructor.enabled ? 'Active' : 'Inactive' }}
+                </v-chip>
+              </td>
+              <td>{{ instructor.academicYear ?? '—' }}</td>
+            </tr>
+          </tbody>
+        </v-table>
+      </v-col>
+    </v-row>
+  </v-container>
+</template>
+
+<script setup lang="ts">
+import { ref, onMounted } from 'vue'
+import { useRouter } from 'vue-router'
+import { findInstructors } from '../services/instructorService'
+import type { InstructorSummary } from '../services/instructorService'
+
+const router = useRouter()
+
+const instructors = ref<InstructorSummary[]>([])
+const loading = ref(false)
+const searched = ref(false)
+
+const statusOptions = [
+  { title: 'Active', value: 'true' },
+  { title: 'Inactive', value: 'false' }
+]
+
+const filters = ref({
+  firstName: '',
+  lastName: '',
+  teamName: '',
+  enabledStr: null as string | null
+})
+
+onMounted(() => search())
+
+async function search() {
+  loading.value = true
+  searched.value = true
+  try {
+    const params: Record<string, string | boolean | undefined> = {}
+    if (filters.value.firstName?.trim()) params.firstName = filters.value.firstName.trim()
+    if (filters.value.lastName?.trim()) params.lastName = filters.value.lastName.trim()
+    if (filters.value.teamName?.trim()) params.teamName = filters.value.teamName.trim()
+    if (filters.value.enabledStr !== null && filters.value.enabledStr !== undefined) {
+      params.enabled = filters.value.enabledStr === 'true'
+    }
+
+    const res = await findInstructors(params) as any
+    instructors.value = res.flag ? (res.data ?? []) : []
+  } catch {
+    instructors.value = []
+  } finally {
+    loading.value = false
+  }
+}
+
+function clearFilters() {
+  filters.value = { firstName: '', lastName: '', teamName: '', enabledStr: null }
+  search()
+}
+</script>
+
+<style scoped lang="scss">
+.chip-group {
+  min-width: 160px;
+}
+</style>

--- a/src/frontend/src/features/instructor/services/instructorService.ts
+++ b/src/frontend/src/features/instructor/services/instructorService.ts
@@ -1,0 +1,22 @@
+import request from '@/shared/utils/request'
+import type { ApiResponse } from '@/shared/types/api'
+
+export interface InstructorSummary {
+  instructorId: number
+  firstName: string
+  lastName: string
+  email: string
+  enabled: boolean
+  teamNames: string[]
+  academicYear: number | null
+}
+
+export interface FindInstructorsParams {
+  firstName?: string
+  lastName?: string
+  enabled?: boolean
+  teamName?: string
+}
+
+export const findInstructors = (params?: FindInstructorsParams) =>
+  request.get<ApiResponse<InstructorSummary[]>>('/users/instructors', { params })

--- a/src/frontend/src/router/routes.ts
+++ b/src/frontend/src/router/routes.ts
@@ -132,10 +132,16 @@ export const routes = [
 
       // ── Instructors ──────────────────────────────────────────────────────
       {
+        path: '/instructors',
+        component: () => import('@/features/instructor/pages/Instructors.vue'),
+        name: 'instructors',
+        meta: { title: 'Instructors', icon: 'mdi-account-tie', isMenuItem: true, requiresAuth: true, roles: ['admin'] }
+      },
+      {
         path: '/instructors/invite',
         component: () => import('@/features/instructor/pages/InstructorInvite.vue'),
         name: 'instructor-invite',
-        meta: { title: 'Invite Instructors', icon: 'mdi-account-tie-outline', isMenuItem: true, requiresAuth: true, roles: ['admin'] }
+        meta: { requiresAuth: true, roles: ['admin'] }
       },
 
       // ── Students ─────────────────────────────────────────────────────────


### PR DESCRIPTION
- GET /api/v1/users/instructors with optional filters: firstName, lastName, enabled, teamName
- Results sorted by academic year DESC then last name ASC
- Academic year derived from most recent team section's start date
- Empty-state alert with link to UC-18 invite flow (ext 4a)
- InstructorSummary DTO, InstructorService, Instructors.vue search page
- Full controller and service unit tests